### PR TITLE
Add auto-update feature

### DIFF
--- a/src/cli/update-command.ts
+++ b/src/cli/update-command.ts
@@ -1,0 +1,59 @@
+import type { Command } from "commander";
+import { checkForUpdate, performUpdate } from "../lib/update.ts";
+import { pruneEmpty } from "../lib/compact-json.ts";
+
+export function registerUpdateCommand(input: { program: Command }): void {
+  input.program
+    .command("update")
+    .description("Update agent-slack to the latest version")
+    .option("--check", "Only check for updates (don't install)")
+    .action(async (...args) => {
+      const [options] = args as [{ check?: boolean }];
+      try {
+        const result = await checkForUpdate(true);
+
+        if (!result) {
+          console.error("Could not check for updates. Check your network connection.");
+          process.exitCode = 1;
+          return;
+        }
+
+        if (!result.update_available) {
+          console.log(JSON.stringify(pruneEmpty({ ...result, status: "up_to_date" }), null, 2));
+          return;
+        }
+
+        if (options.check) {
+          console.log(
+            JSON.stringify(pruneEmpty({ ...result, status: "update_available" }), null, 2),
+          );
+          return;
+        }
+
+        process.stderr.write(`Updating agent-slack ${result.current} → ${result.latest}...\n`);
+        const outcome = await performUpdate(result.latest);
+
+        if (!outcome.success) {
+          console.error(outcome.message);
+          process.exitCode = 1;
+          return;
+        }
+
+        console.log(
+          JSON.stringify(
+            pruneEmpty({
+              status: "updated",
+              previous_version: result.current,
+              new_version: result.latest,
+              message: outcome.message,
+            }),
+            null,
+            2,
+          ),
+        );
+      } catch (err: unknown) {
+        console.error(err instanceof Error ? err.message : String(err));
+        process.exitCode = 1;
+      }
+    });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,9 @@ import { registerAuthCommand } from "./cli/auth-command.ts";
 import { registerCanvasCommand } from "./cli/canvas-command.ts";
 import { registerMessageCommand } from "./cli/message-command.ts";
 import { registerSearchCommand } from "./cli/search-command.ts";
+import { registerUpdateCommand } from "./cli/update-command.ts";
 import { registerUserCommand } from "./cli/user-command.ts";
+import { backgroundUpdateCheck } from "./lib/update.ts";
 
 const program = new Command();
 program
@@ -19,9 +21,17 @@ registerAuthCommand({ program, ctx });
 registerMessageCommand({ program, ctx });
 registerCanvasCommand({ program, ctx });
 registerSearchCommand({ program, ctx });
+registerUpdateCommand({ program });
 registerUserCommand({ program, ctx });
 
 program.parse(process.argv);
 if (!process.argv.slice(2).length) {
   program.outputHelp();
+}
+
+// Fire-and-forget background update check (throttled to once/24h, stderr only).
+// Skip for the update command itself to avoid duplicate output.
+const [subcommand] = process.argv.slice(2);
+if (subcommand && subcommand !== "update") {
+  backgroundUpdateCheck();
 }

--- a/src/lib/update.ts
+++ b/src/lib/update.ts
@@ -1,0 +1,217 @@
+import { createHash } from "node:crypto";
+import { chmod, copyFile, mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { getAppDir } from "./app-dir.ts";
+import { readJsonFile, writeJsonFile } from "./fs.ts";
+import { getPackageVersion } from "./version.ts";
+
+const REPO = "stablyai/agent-slack";
+const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+type UpdateCheckCache = {
+  latest_version: string;
+  checked_at: number; // epoch ms
+};
+
+type GitHubRelease = {
+  tag_name: string;
+  assets: { name: string; browser_download_url: string }[];
+};
+
+function getCachePath(): string {
+  return join(getAppDir(), "update-check.json");
+}
+
+/**
+ * Compare two semver strings. Returns:
+ *   negative if a < b, 0 if equal, positive if a > b
+ */
+export function compareSemver(a: string, b: string): number {
+  const pa = a.replace(/^v/, "").split(".").map(Number);
+  const pb = b.replace(/^v/, "").split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    const diff = (pa[i] ?? 0) - (pb[i] ?? 0);
+    if (diff !== 0) {
+      return diff;
+    }
+  }
+  return 0;
+}
+
+/**
+ * Fetch the latest release version from GitHub.
+ * Returns null on any network/API error (never throws).
+ */
+export async function fetchLatestVersion(): Promise<string | null> {
+  try {
+    const resp = await fetch(`https://api.github.com/repos/${REPO}/releases/latest`, {
+      headers: { Accept: "application/vnd.github+json", "User-Agent": "agent-slack-updater" },
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!resp.ok) {
+      return null;
+    }
+    const data = (await resp.json()) as GitHubRelease;
+    return data.tag_name?.replace(/^v/, "") ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Check if a newer version is available. Uses a local cache to avoid
+ * hitting GitHub more than once per CHECK_INTERVAL_MS.
+ *
+ * @param force  Skip the cache and always fetch from GitHub.
+ * @returns `{ current, latest, updateAvailable }` or null on error.
+ */
+export async function checkForUpdate(force = false): Promise<{
+  current: string;
+  latest: string;
+  update_available: boolean;
+} | null> {
+  const current = getPackageVersion();
+
+  if (!force) {
+    const cached = await readJsonFile<UpdateCheckCache>(getCachePath());
+    if (cached && Date.now() - cached.checked_at < CHECK_INTERVAL_MS) {
+      return {
+        current,
+        latest: cached.latest_version,
+        update_available: compareSemver(cached.latest_version, current) > 0,
+      };
+    }
+  }
+
+  const latest = await fetchLatestVersion();
+  if (!latest) {
+    return null;
+  }
+
+  // Persist cache (best-effort, never throw)
+  try {
+    await writeJsonFile(getCachePath(), {
+      latest_version: latest,
+      checked_at: Date.now(),
+    } satisfies UpdateCheckCache);
+  } catch {
+    // ignore
+  }
+
+  return {
+    current,
+    latest,
+    update_available: compareSemver(latest, current) > 0,
+  };
+}
+
+function detectPlatformAsset(): string {
+  const platform = process.platform === "win32" ? "windows" : process.platform;
+  const archMap: Record<string, string> = { x64: "x64", arm64: "arm64" };
+  const arch = archMap[process.arch] ?? process.arch;
+  const ext = platform === "windows" ? ".exe" : "";
+  return `agent-slack-${platform}-${arch}${ext}`;
+}
+
+async function sha256(filePath: string): Promise<string> {
+  const data = await readFile(filePath);
+  return createHash("sha256").update(data).digest("hex");
+}
+
+/**
+ * Download, verify, and replace the current binary with the latest release.
+ * Returns `true` on success.
+ */
+export async function performUpdate(
+  latest: string,
+): Promise<{ success: boolean; message: string }> {
+  const asset = detectPlatformAsset();
+  const tag = `v${latest}`;
+  const baseUrl = `https://github.com/${REPO}/releases/download/${tag}`;
+
+  const tmp = join(tmpdir(), `agent-slack-update-${Date.now()}`);
+  await mkdir(tmp, { recursive: true });
+
+  const binTmp = join(tmp, asset);
+  const sumsTmp = join(tmp, "checksums-sha256.txt");
+
+  try {
+    // Download binary + checksums in parallel
+    const [binResp, sumsResp] = await Promise.all([
+      fetch(`${baseUrl}/${asset}`, { signal: AbortSignal.timeout(120_000) }),
+      fetch(`${baseUrl}/checksums-sha256.txt`, { signal: AbortSignal.timeout(30_000) }),
+    ]);
+
+    if (!binResp.ok) {
+      return { success: false, message: `Failed to download ${asset}: HTTP ${binResp.status}` };
+    }
+    if (!sumsResp.ok) {
+      return { success: false, message: `Failed to download checksums: HTTP ${sumsResp.status}` };
+    }
+
+    await writeFile(binTmp, Buffer.from(await binResp.arrayBuffer()));
+    const sumsText = await sumsResp.text();
+    await writeFile(sumsTmp, sumsText);
+
+    // Verify checksum
+    const expected = sumsText
+      .split("\n")
+      .map((line) => line.trim().split(/\s+/))
+      .find((parts) => parts[1] === asset)?.[0];
+
+    if (!expected) {
+      return { success: false, message: `Checksum not found for ${asset} in release checksums` };
+    }
+
+    const actual = await sha256(binTmp);
+    if (actual !== expected) {
+      return { success: false, message: `Checksum mismatch: expected ${expected}, got ${actual}` };
+    }
+
+    // Replace current binary
+    const currentBin = process.execPath;
+    const backupPath = `${currentBin}.bak`;
+
+    // Rename current -> backup, copy new -> current, remove backup
+    await rename(currentBin, backupPath);
+    try {
+      await copyFile(binTmp, currentBin);
+      await chmod(currentBin, 0o755);
+      await rm(backupPath, { force: true });
+    } catch (err) {
+      // Restore backup on failure
+      try {
+        await rename(backupPath, currentBin);
+      } catch {
+        // ignore restore failure
+      }
+      throw err;
+    }
+
+    return { success: true, message: `Updated agent-slack to ${latest}` };
+  } finally {
+    await rm(tmp, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+/**
+ * Background update check. Writes a notice to stderr if an update is available.
+ * Swallows all errors silently. Respects the 24-hour throttle.
+ * Disable with AGENT_SLACK_NO_UPDATE_CHECK=1.
+ */
+export async function backgroundUpdateCheck(): Promise<void> {
+  if (process.env.AGENT_SLACK_NO_UPDATE_CHECK === "1") {
+    return;
+  }
+  try {
+    const result = await checkForUpdate();
+    if (result?.update_available) {
+      process.stderr.write(
+        `\nUpdate available: ${result.current} → ${result.latest}. Run "agent-slack update" to upgrade.\n`,
+      );
+    }
+  } catch {
+    // never interfere with normal operation
+  }
+}

--- a/test/update.test.ts
+++ b/test/update.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { compareSemver } from "../src/lib/update.ts";
+
+describe("compareSemver", () => {
+  test("equal versions return 0", () => {
+    expect(compareSemver("1.2.3", "1.2.3")).toBe(0);
+  });
+
+  test("strips v prefix", () => {
+    expect(compareSemver("v1.2.3", "1.2.3")).toBe(0);
+  });
+
+  test("newer major", () => {
+    expect(compareSemver("2.0.0", "1.9.9")).toBeGreaterThan(0);
+  });
+
+  test("newer minor", () => {
+    expect(compareSemver("1.3.0", "1.2.9")).toBeGreaterThan(0);
+  });
+
+  test("newer patch", () => {
+    expect(compareSemver("1.2.4", "1.2.3")).toBeGreaterThan(0);
+  });
+
+  test("older version returns negative", () => {
+    expect(compareSemver("0.1.0", "0.2.0")).toBeLessThan(0);
+  });
+
+  test("handles 0.x versions", () => {
+    expect(compareSemver("0.2.10", "0.2.9")).toBeGreaterThan(0);
+    expect(compareSemver("0.2.10", "0.2.10")).toBe(0);
+    expect(compareSemver("0.2.10", "0.3.0")).toBeLessThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `agent-slack update` command that checks GitHub Releases for the latest version and self-replaces the running binary with SHA-256 checksum verification
- Adds `agent-slack update --check` to check for updates without installing
- Adds a background update check (throttled to once per 24 hours) that prints a stderr notice when a newer version is available on every CLI invocation
- Disable background checks with `AGENT_SLACK_NO_UPDATE_CHECK=1`

## Details

### New files
- **`src/lib/update.ts`** — Core update logic: fetches latest release from GitHub API, semver comparison, binary download + checksum verification, atomic self-replacement (rename current → backup, copy new → current, remove backup with rollback on failure)
- **`src/cli/update-command.ts`** — Registers the `update` command with `--check` option
- **`test/update.test.ts`** — Tests for semver comparison

### Modified files
- **`src/index.ts`** — Registers the update command and fires a background update check (skipped for the `update` command itself)

### Design decisions
- Background check uses a JSON cache file (`~/.agent-slack/update-check.json`) to throttle GitHub API calls to once per 24 hours
- Update notices go to stderr only, so they never pollute JSON stdout consumed by agents
- Binary replacement uses an atomic rename-copy-cleanup pattern with backup rollback on failure
- Network timeouts: 5s for version check, 120s for binary download, 30s for checksum download

## Test plan
- [x] `bun test` — all 37 tests pass (including new semver comparison tests)
- [x] `bun run lint` — 0 warnings, 0 errors
- [x] `bun run typecheck` — clean
- [x] `bun run build` — bundles successfully
- [ ] Manual: `bun run dev -- update --check` returns current/latest version info
- [ ] Manual: `bun run dev -- update` performs self-update on a compiled binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)