### PR TITLE
feat[users]: add dm-channel command - discover DM and group DM channels

### DIFF
--- a/src/cli/user-command.ts
+++ b/src/cli/user-command.ts
@@ -1,7 +1,7 @@
 import type { Command } from "commander";
 import type { CliContext } from "./context.ts";
 import { pruneEmpty } from "../lib/compact-json.ts";
-import { getUser, listUsers } from "../slack/users.ts";
+import { getDmChannelForUsers, getUser, listUsers } from "../slack/users.ts";
 
 export function registerUserCommand(input: { program: Command; ctx: CliContext }): void {
   const userCmd = input.program.command("user").description("Workspace user directory");
@@ -52,6 +52,29 @@ export function registerUserCommand(input: { program: Command; ctx: CliContext }
           work: async () => {
             const { client } = await input.ctx.getClientForWorkspace(workspaceUrl);
             return await getUser(client, user);
+          },
+        });
+        console.log(JSON.stringify(pruneEmpty(payload), null, 2));
+      } catch (err: unknown) {
+        console.error(input.ctx.errorMessage(err));
+        process.exitCode = 1;
+      }
+    });
+
+  userCmd
+    .command("dm-channel")
+    .description("Get DM/group DM channel ID for user(s) by id (U...) or handle (@name)")
+    .argument("<users...>", "One or more user ids or @handles (space-separated)")
+    .option("--workspace <url>", "Workspace URL (required if you have multiple workspaces)")
+    .action(async (...args) => {
+      const [users, options] = args as [string[], { workspace?: string }];
+      try {
+        const workspaceUrl = input.ctx.effectiveWorkspaceUrl(options.workspace);
+        const payload = await input.ctx.withAutoRefresh({
+          workspaceUrl,
+          work: async () => {
+            const { client } = await input.ctx.getClientForWorkspace(workspaceUrl);
+            return await getDmChannelForUsers(client, users);
           },
         });
         console.log(JSON.stringify(pruneEmpty(payload), null, 2));


### PR DESCRIPTION
It is really hard to go from user handle / user ID to the DM channel right now.

This adds a command that makes it easy to get that channel ID and then everything else works like normal channel messaging