### PR TITLE
Add fuzzy workspace selector matching for --workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,10 +127,12 @@ agent-slack message get "#general" --ts "1770165109.628379"
 agent-slack message list "#general" --thread-ts "1770165109.000001"
 ```
 
-If you have multiple workspaces configured and you use a channel **name** (`#channel` / `channel`), you must pass `--workspace` (or set `SLACK_WORKSPACE_URL`):
+If you have multiple workspaces configured and you use a channel **name** (`#channel` / `channel`), you must pass `--workspace` (or set `SLACK_WORKSPACE_URL`).
+`--workspace` accepts a full URL or a unique substring selector:
 
 ```bash
 agent-slack message get "#general" --workspace "https://stablygroup.slack.com" --ts "1770165109.628379"
+agent-slack message get "#general" --workspace "stablygroup" --ts "1770165109.628379"
 ```
 
 ## Examples
@@ -210,7 +212,7 @@ agent-slack search files "testing" --content-type snippet --limit 10
 Tips:
 
 - For reliable results, include `--channel ...` (channel-scoped search scans history/files and filters locally).
-- Use `--workspace https://...slack.com` when using `#channel` names across multiple workspaces.
+- Use `--workspace <url-or-unique-substring>` when using `#channel` names across multiple workspaces.
 
 <!-- AI search (assistant.search.*) is described in design.doc but not currently implemented. -->
 

--- a/skills/agent-slack/SKILL.md
+++ b/skills/agent-slack/SKILL.md
@@ -110,6 +110,7 @@ If you have multiple workspaces configured and you use a channel **name** (`#gen
 
 ```bash
 agent-slack message get "#general" --workspace "https://myteam.slack.com" --ts "1770165109.628379"
+agent-slack message get "#general" --workspace "myteam" --ts "1770165109.628379"
 ```
 
 ## Canvas + Users

--- a/skills/agent-slack/references/commands.md
+++ b/skills/agent-slack/references/commands.md
@@ -5,7 +5,7 @@ Run `agent-slack --help` (or `agent-slack <command> --help`) for the full option
 ## Auth
 
 - `agent-slack auth whoami` — show configured workspaces + token sources (secrets redacted)
-- `agent-slack auth test [--workspace <url>]` — verify credentials (`auth.test`)
+- `agent-slack auth test [--workspace <url-or-unique-substring>]` — verify credentials (`auth.test`)
 - `agent-slack auth import-desktop` — import browser-style creds from Slack Desktop (macOS)
 - `agent-slack auth import-chrome` — import creds from Chrome (macOS)
 - `agent-slack auth parse-curl` — read a copied Slack cURL command from stdin and save creds
@@ -18,7 +18,7 @@ Run `agent-slack --help` (or `agent-slack <command> --help`) for the full option
 - `agent-slack message get <target>`
   - `<target>`: Slack message URL OR `#channel`/`channel`/channel id (`C...`) (see `targets.md`)
   - Options:
-    - `--workspace <url>` (required when using a channel _name_ across multiple workspaces)
+    - `--workspace <url-or-unique-substring>` (required when using a channel _name_ across multiple workspaces)
     - `--ts <seconds>.<micros>` (required when targeting a channel)
     - `--thread-ts <seconds>.<micros>` (optional hint for thread permalinks)
     - `--max-body-chars <n>` (default `8000`, `-1` unlimited)
@@ -33,7 +33,7 @@ Run `agent-slack --help` (or `agent-slack <command> --help`) for the full option
     - `agent-slack message list "<url>"` — all replies in that thread
     - `agent-slack message list "#general" --thread-ts "1770165109.000001"` — thread replies
   - Options:
-    - `--workspace <url>` (same rules as above)
+    - `--workspace <url-or-unique-substring>` (same rules as above)
     - `--thread-ts <seconds>.<micros>` (switches to thread mode; fetches replies)
     - `--ts <seconds>.<micros>` (resolve a message to its thread)
     - `--limit <n>` (default `25`, max `200`; channel history mode only)
@@ -46,13 +46,13 @@ Run `agent-slack --help` (or `agent-slack <command> --help`) for the full option
   - If `<target>` is a Slack message URL, replies in that message’s thread.
   - Otherwise posts to the channel/DM.
   - Options:
-    - `--workspace <url>` (needed for channel _names_ across multiple workspaces)
+    - `--workspace <url-or-unique-substring>` (needed for channel _names_ across multiple workspaces)
     - `--thread-ts <seconds>.<micros>` (optional, channel mode only)
 
 - `agent-slack message react add <target> <emoji>`
 - `agent-slack message react remove <target> <emoji>`
   - Options (channel mode):
-    - `--workspace <url>` (needed for channel _names_ across multiple workspaces)
+    - `--workspace <url-or-unique-substring>` (needed for channel _names_ across multiple workspaces)
     - `--ts <seconds>.<micros>` (required for channel targets)
 
 ## Search
@@ -63,7 +63,7 @@ Run `agent-slack --help` (or `agent-slack <command> --help`) for the full option
 
 Common options:
 
-- `--workspace <url>` (recommended when using channel names across multiple workspaces)
+- `--workspace <url-or-unique-substring>` (recommended when using channel names across multiple workspaces)
 - `--channel <channel...>` repeatable (`#name`, `name`, or id)
 - `--user <@name|name|U...>`
 - `--after YYYY-MM-DD`
@@ -76,10 +76,10 @@ Common options:
 
 - `agent-slack canvas get <canvas-url-or-id>`
   - Options:
-    - `--workspace <url>` (required when passing an id and multiple workspaces)
+    - `--workspace <url-or-unique-substring>` (required when passing an id and multiple workspaces)
     - `--max-chars <n>` (default `20000`, `-1` unlimited)
 
 ## Users
 
-- `agent-slack user list [--workspace <url>] [--limit <n>] [--cursor <cursor>] [--include-bots]`
-- `agent-slack user get <U...|@handle|handle> [--workspace <url>]`
+- `agent-slack user list [--workspace <url-or-unique-substring>] [--limit <n>] [--cursor <cursor>] [--include-bots]`
+- `agent-slack user get <U...|@handle|handle> [--workspace <url-or-unique-substring>]`

--- a/skills/agent-slack/references/targets.md
+++ b/skills/agent-slack/references/targets.md
@@ -47,7 +47,7 @@ agent-slack message react add "#general" "eyes" --ts "1770165109.628379"
 
 If you have multiple workspaces configured and your target is a channel **name** (`#general` / `general`), you must disambiguate:
 
-- pass `--workspace "https://myteam.slack.com"`, or
-- set `SLACK_WORKSPACE_URL="https://myteam.slack.com"`
+- pass `--workspace "https://myteam.slack.com"` (or a unique substring like `--workspace "myteam"`), or
+- set `SLACK_WORKSPACE_URL` to the same selector format
 
 Channel IDs (`C...`/`G...`/`D...`) do not require `--workspace`.

--- a/src/cli/auth-command.ts
+++ b/src/cli/auth-command.ts
@@ -55,7 +55,10 @@ export function registerAuthCommand(input: { program: Command; ctx: CliContext }
   auth
     .command("test")
     .description("Verify credentials (calls Slack auth.test)")
-    .option("--workspace <url>", "Workspace URL (needed when you have multiple workspaces)")
+    .option(
+      "--workspace <url>",
+      "Workspace selector (full URL or unique substring; needed when you have multiple workspaces)",
+    )
     .action(async (...args) => {
       const [options] = args as [{ workspace?: string }];
       try {

--- a/src/cli/canvas-command.ts
+++ b/src/cli/canvas-command.ts
@@ -12,7 +12,7 @@ export function registerCanvasCommand(input: { program: Command; ctx: CliContext
     .argument("<canvas>", "Slack canvas URL (…/docs/…/F…) or canvas id (F…)")
     .option(
       "--workspace <url>",
-      "Workspace URL (required if passing a canvas id and you have multiple workspaces)",
+      "Workspace selector (full URL or unique substring; required if passing a canvas id across multiple workspaces)",
     )
     .option(
       "--max-chars <n>",

--- a/src/cli/message-command.ts
+++ b/src/cli/message-command.ts
@@ -19,7 +19,7 @@ export function registerMessageCommand(input: { program: Command; ctx: CliContex
     .argument("<target>", "Slack message URL, #channel, or channel ID")
     .option(
       "--workspace <url>",
-      "Workspace URL (needed when using #channel/channel id and you have multiple workspaces)",
+      "Workspace selector (full URL or unique substring; needed when using #channel/channel id across multiple workspaces)",
     )
     .option("--ts <ts>", "Message ts (required when using #channel/channel id)")
     .option("--thread-ts <ts>", "Thread root ts hint (useful for thread permalinks)")
@@ -46,7 +46,7 @@ export function registerMessageCommand(input: { program: Command; ctx: CliContex
     .argument("<target>", "Slack message URL, #channel, or channel ID")
     .option(
       "--workspace <url>",
-      "Workspace URL (needed when using #channel/channel id and you have multiple workspaces)",
+      "Workspace selector (full URL or unique substring; needed when using #channel/channel id across multiple workspaces)",
     )
     .option("--thread-ts <ts>", "Thread root ts (lists thread replies instead of channel history)")
     .option("--ts <ts>", "Message ts (resolve message to its thread)")
@@ -77,7 +77,7 @@ export function registerMessageCommand(input: { program: Command; ctx: CliContex
     .argument("<text>", "Message text to post")
     .option(
       "--workspace <url>",
-      "Workspace URL (needed when using #channel/channel id and you have multiple workspaces)",
+      "Workspace selector (full URL or unique substring; needed when using #channel/channel id across multiple workspaces)",
     )
     .option("--thread-ts <ts>", "Thread root ts to post into (optional)")
     .action(async (...args) => {
@@ -109,7 +109,7 @@ export function registerMessageCommand(input: { program: Command; ctx: CliContex
     .argument("<emoji>", "Emoji to react with (:rocket:, rocket, or 🚀)")
     .option(
       "--workspace <url>",
-      "Workspace URL (needed when using #channel/channel id and you have multiple workspaces)",
+      "Workspace selector (full URL or unique substring; needed when using #channel/channel id across multiple workspaces)",
     )
     .option("--ts <ts>", "Message ts (required when using #channel/channel id)")
     .action(async (...args) => {
@@ -140,7 +140,7 @@ export function registerMessageCommand(input: { program: Command; ctx: CliContex
     .argument("<emoji>", "Emoji to remove (:rocket:, rocket, or 🚀)")
     .option(
       "--workspace <url>",
-      "Workspace URL (needed when using #channel/channel id and you have multiple workspaces)",
+      "Workspace selector (full URL or unique substring; needed when using #channel/channel id across multiple workspaces)",
     )
     .option("--ts <ts>", "Message ts (required when using #channel/channel id)")
     .action(async (...args) => {

--- a/src/cli/search-command.ts
+++ b/src/cli/search-command.ts
@@ -16,7 +16,10 @@ type SearchCommandOptions = {
 
 function addSearchOptions(cmd: Command): Command {
   return cmd
-    .option("--workspace <url>", "Workspace URL (needed when searching across multiple workspaces)")
+    .option(
+      "--workspace <url>",
+      "Workspace selector (full URL or unique substring; needed when searching across multiple workspaces)",
+    )
     .option("--channel <channel...>", "Channel filter (#name, name, or id). Repeatable.")
     .option("--user <user>", "User filter (@name, name, or user id U...)")
     .option("--after <date>", "Only results after YYYY-MM-DD")

--- a/src/cli/user-command.ts
+++ b/src/cli/user-command.ts
@@ -9,7 +9,10 @@ export function registerUserCommand(input: { program: Command; ctx: CliContext }
   userCmd
     .command("list")
     .description("List users in the workspace")
-    .option("--workspace <url>", "Workspace URL (required if you have multiple workspaces)")
+    .option(
+      "--workspace <url>",
+      "Workspace selector (full URL or unique substring; required if you have multiple workspaces)",
+    )
     .option("--limit <n>", "Max users (default 200)", "200")
     .option("--cursor <cursor>", "Pagination cursor")
     .option("--include-bots", "Include bot users")
@@ -42,7 +45,10 @@ export function registerUserCommand(input: { program: Command; ctx: CliContext }
     .command("get")
     .description("Get a single user by id (U...) or handle (@name)")
     .argument("<user>", "User id (U...) or @handle/handle")
-    .option("--workspace <url>", "Workspace URL (required if you have multiple workspaces)")
+    .option(
+      "--workspace <url>",
+      "Workspace selector (full URL or unique substring; required if you have multiple workspaces)",
+    )
     .action(async (...args) => {
       const [user, options] = args as [string, { workspace?: string }];
       try {

--- a/src/cli/workspace-selector.ts
+++ b/src/cli/workspace-selector.ts
@@ -1,0 +1,60 @@
+import type { Workspace } from "../auth/schema.ts";
+
+export type WorkspaceSelectorResult = {
+  match: Workspace | null;
+  ambiguous: Workspace[];
+};
+
+function normalizeUrl(u: string): string {
+  const url = new URL(u);
+  return `${url.protocol}//${url.host}`;
+}
+
+function normalizedWorkspaceCandidates(workspace: Workspace): string[] {
+  let host = "";
+  try {
+    host = new URL(workspace.workspace_url).host.toLowerCase();
+  } catch {
+    host = "";
+  }
+  const hostWithoutSlackSuffix = host.replace(/\.slack\.com$/i, "");
+  return [
+    workspace.workspace_url.toLowerCase(),
+    host,
+    hostWithoutSlackSuffix,
+    workspace.workspace_name?.toLowerCase() ?? "",
+    workspace.team_domain?.toLowerCase() ?? "",
+  ].filter(Boolean);
+}
+
+export function resolveWorkspaceSelector(
+  workspaces: Workspace[],
+  selector: string,
+): WorkspaceSelectorResult {
+  const raw = selector.trim();
+  if (!raw) {
+    return { match: null, ambiguous: [] };
+  }
+
+  try {
+    const normalized = normalizeUrl(raw).toLowerCase();
+    const exact = workspaces.find((w) => w.workspace_url.toLowerCase() === normalized);
+    if (exact) {
+      return { match: exact, ambiguous: [] };
+    }
+  } catch {
+    // Not a URL selector; continue with fuzzy matching.
+  }
+
+  const needle = raw.toLowerCase();
+  const matches = workspaces.filter((workspace) =>
+    normalizedWorkspaceCandidates(workspace).some((candidate) => candidate.includes(needle)),
+  );
+  if (matches.length === 1) {
+    return { match: matches[0]!, ambiguous: [] };
+  }
+  if (matches.length > 1) {
+    return { match: null, ambiguous: matches };
+  }
+  return { match: null, ambiguous: [] };
+}

--- a/test/workspace-selector.test.ts
+++ b/test/workspace-selector.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+import type { Workspace } from "../src/auth/schema.ts";
+import { resolveWorkspaceSelector } from "../src/cli/workspace-selector.ts";
+
+function browserWorkspace(input: {
+  url: string;
+  workspace_name?: string;
+  team_domain?: string;
+}): Workspace {
+  return {
+    workspace_url: input.url,
+    workspace_name: input.workspace_name,
+    team_domain: input.team_domain,
+    auth: {
+      auth_type: "browser",
+      xoxc_token: "xoxc-test",
+      xoxd_cookie: "xoxd-test",
+    },
+  };
+}
+
+describe("resolveWorkspaceSelector", () => {
+  const workspaces: Workspace[] = [
+    browserWorkspace({
+      url: "https://stablygroup.slack.com",
+      workspace_name: "Stably Group",
+      team_domain: "stablygroup",
+    }),
+    browserWorkspace({
+      url: "https://stablylabs.slack.com",
+      workspace_name: "Stably Labs",
+      team_domain: "stablylabs",
+    }),
+    browserWorkspace({ url: "https://acme.slack.com", workspace_name: "Acme" }),
+  ];
+
+  test("matches exact URL", () => {
+    const result = resolveWorkspaceSelector(workspaces, "https://stablygroup.slack.com");
+    expect(result.match?.workspace_url).toBe("https://stablygroup.slack.com");
+    expect(result.ambiguous).toHaveLength(0);
+  });
+
+  test("matches unique substring by host/team", () => {
+    const result = resolveWorkspaceSelector(workspaces, "acme");
+    expect(result.match?.workspace_url).toBe("https://acme.slack.com");
+    expect(result.ambiguous).toHaveLength(0);
+  });
+
+  test("matches unique substring by workspace name", () => {
+    const result = resolveWorkspaceSelector(workspaces, "group");
+    expect(result.match?.workspace_url).toBe("https://stablygroup.slack.com");
+    expect(result.ambiguous).toHaveLength(0);
+  });
+
+  test("returns ambiguity when selector matches multiple workspaces", () => {
+    const result = resolveWorkspaceSelector(workspaces, "stably");
+    expect(result.match).toBeNull();
+    expect(result.ambiguous.map((w) => w.workspace_url).sort()).toEqual([
+      "https://stablygroup.slack.com",
+      "https://stablylabs.slack.com",
+    ]);
+  });
+
+  test("returns no match when selector does not match", () => {
+    const result = resolveWorkspaceSelector(workspaces, "does-not-exist");
+    expect(result.match).toBeNull();
+    expect(result.ambiguous).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Problem

Using channel targets across multiple Slack workspaces requires `--workspace`, but the CLI currently expects a full workspace URL. This is unnecessarily strict and slows usage when users already know a short, unique workspace identifier.

## Solution

Add smart workspace selector resolution so `--workspace` accepts either a full URL or a unique substring (matching URL/host/workspace metadata), with explicit errors for ambiguous and no-match selectors; update help/docs and add tests.

## Validation

- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun test`

All passed.
