### PR TITLE
docs(skill): keep hybrid skill format and enforce docs sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,6 @@ jobs:
 
       - name: Test
         run: bun run test
+
+      - name: Docs drift check
+        run: bun run docs:check

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Test
         run: bun run test
 
+      - name: Docs drift check
+        run: bun run docs:check
+
       - name: Build release binaries
         run: bun run build:release
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ agent-slack
 │   ├── test
 │   ├── import-desktop
 │   ├── import-chrome
+│   ├── import-brave
 │   └── parse-curl
 ├── message
 │   ├── get   <target>             # fetch 1 message (+ thread meta )
@@ -76,8 +77,9 @@ agent-slack
 │   ├── all      <query>           # messages + files
 │   ├── messages <query>
 │   └── files    <query>
-└── canvas
-    └── get <canvas-url-or-id>     # canvas → markdown
+├── canvas
+│   └── get <canvas-url-or-id>     # canvas → markdown
+└── update [options]               # self-update utility (--check to only check)
 ```
 
 Notes:
@@ -98,6 +100,7 @@ You can also run manual imports:
 agent-slack auth whoami
 agent-slack auth import-desktop
 agent-slack auth import-chrome
+agent-slack auth import-brave
 agent-slack auth test
 ```
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "release": "sh ./scripts/release.sh",
     "typecheck": "tsc --noEmit",
     "test": "bun test",
+    "docs:check": "bash ./scripts/check-docs-sync.sh",
     "lint": "oxlint .",
     "lintf": "oxlint --fix .",
     "lint:fix": "oxlint --fix .",

--- a/scripts/check-docs-sync.sh
+++ b/scripts/check-docs-sync.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+README_FILE="$ROOT_DIR/README.md"
+SKILL_FILE="$ROOT_DIR/skills/agent-slack/SKILL.md"
+COMMANDS_FILE="$ROOT_DIR/skills/agent-slack/references/commands.md"
+
+failures=0
+
+require_in_file() {
+  local needle="$1"
+  local file="$2"
+  if ! rg -F -q "$needle" "$file"; then
+    echo "Missing in $(basename "$file"): $needle" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+require_path() {
+  local path="$1"
+  if [[ ! -f "$path" ]]; then
+    echo "Missing file: $path" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+require_path "$README_FILE"
+require_path "$SKILL_FILE"
+require_path "$COMMANDS_FILE"
+
+skill_lines="$(wc -l < "$SKILL_FILE" | tr -d ' ')"
+if (( skill_lines > 500 )); then
+  echo "SKILL.md is too long ($skill_lines lines). Keep it under 500 lines." >&2
+  failures=$((failures + 1))
+fi
+
+# Keep setup guidance in SKILL.md so first-run execution works.
+require_in_file "curl -fsSL https://raw.githubusercontent.com/stablyai/agent-slack/master/install.sh | sh" "$SKILL_FILE"
+require_in_file "npm i -g agent-slack" "$SKILL_FILE"
+
+# Keep references linked from SKILL.md (one-level deep).
+require_in_file "[references/commands.md](references/commands.md)" "$SKILL_FILE"
+require_in_file "[references/targets.md](references/targets.md)" "$SKILL_FILE"
+require_in_file "[references/output.md](references/output.md)" "$SKILL_FILE"
+
+# Core command coverage in the exhaustive command reference.
+reference_commands=(
+  "agent-slack auth whoami"
+  "agent-slack auth test"
+  "agent-slack auth import-desktop"
+  "agent-slack auth import-chrome"
+  "agent-slack auth import-brave"
+  "agent-slack auth parse-curl"
+  "agent-slack auth add"
+  "agent-slack auth set-default"
+  "agent-slack auth remove"
+  "agent-slack message get"
+  "agent-slack message list"
+  "agent-slack message send"
+  "agent-slack message edit"
+  "agent-slack message delete"
+  "agent-slack message react add"
+  "agent-slack message react remove"
+  "agent-slack channel new"
+  "agent-slack channel invite"
+  "agent-slack search all"
+  "agent-slack search messages"
+  "agent-slack search files"
+  "agent-slack canvas get"
+  "agent-slack user list"
+  "agent-slack user get"
+  "agent-slack update --check"
+)
+
+for command in "${reference_commands[@]}"; do
+  require_in_file "$command" "$COMMANDS_FILE"
+done
+
+# Keep frequent day-to-day operations directly in SKILL.md.
+skill_common_commands=(
+  "agent-slack message get"
+  "agent-slack message list"
+  "agent-slack message send"
+  "agent-slack message edit"
+  "agent-slack message delete"
+  "agent-slack message react add"
+  "agent-slack search all"
+  "agent-slack channel invite"
+  "agent-slack canvas get"
+  "agent-slack user get"
+)
+
+for command in "${skill_common_commands[@]}"; do
+  require_in_file "$command" "$SKILL_FILE"
+done
+
+# README should include top-level command map entries for discoverability.
+readme_commands=(
+  "├── auth"
+  "├── message"
+  "├── channel"
+  "├── search"
+  "├── canvas"
+  "├── user"
+  "└── update [options]"
+)
+
+for command in "${readme_commands[@]}"; do
+  require_in_file "$command" "$README_FILE"
+done
+
+if (( failures > 0 )); then
+  echo "Docs drift check failed with $failures issue(s)." >&2
+  exit 1
+fi
+
+echo "Docs drift check passed."

--- a/skills/agent-slack/SKILL.md
+++ b/skills/agent-slack/SKILL.md
@@ -17,7 +17,23 @@ description: |
 
 `agent-slack` is a CLI binary installed on `$PATH`. Invoke it directly (e.g. `agent-slack user list`)
 
-## Quick start (auth)
+## Quick start (install + auth)
+
+If `agent-slack` is not installed on `$PATH`, install it first:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/stablyai/agent-slack/master/install.sh | sh
+# or
+npm i -g agent-slack
+```
+
+Optional update command:
+
+```bash
+agent-slack update --check
+```
+
+### Authentication on macOS (automatic)
 
 Authentication is automatic on macOS (Slack Desktop first, then Chrome fallback).
 
@@ -34,6 +50,22 @@ agent-slack auth test
 
 ```bash
 agent-slack auth import-chrome
+agent-slack auth test
+```
+
+- Brave fallback:
+
+```bash
+agent-slack auth import-brave
+agent-slack auth test
+```
+
+### Authentication on Linux/Windows (manual)
+
+- Parse cURL auth import:
+
+```bash
+agent-slack auth parse-curl
 agent-slack auth test
 ```
 
@@ -56,6 +88,21 @@ Check configured workspaces:
 
 ```bash
 agent-slack auth whoami
+```
+
+## Common commands (quick reference)
+
+```bash
+agent-slack message get "<message-url>"
+agent-slack message list "<message-url>"
+agent-slack message send "<message-url>" "I can take this."
+agent-slack message edit "<message-url>" "Updated text"
+agent-slack message delete "<message-url>"
+agent-slack message react add "<message-url>" "eyes"
+agent-slack search all "query" --channel "#alerts"
+agent-slack channel invite --channel "incident-war-room" --users "@alice,bob@example.com"
+agent-slack canvas get "https://workspace.slack.com/docs/T123/F456"
+agent-slack user get "@alice" --workspace "https://workspace.slack.com"
 ```
 
 ## Canonical workflow (given a Slack message URL)

--- a/skills/agent-slack/references/commands.md
+++ b/skills/agent-slack/references/commands.md
@@ -2,12 +2,23 @@
 
 Run `agent-slack --help` (or `agent-slack <command> --help`) for the full option list.
 
+## Table of contents
+
+- [Auth](#auth)
+- [Messages / threads](#messages--threads)
+- [Channels](#channels)
+- [Search](#search)
+- [Canvas](#canvas)
+- [Users](#users)
+- [Update](#update)
+
 ## Auth
 
 - `agent-slack auth whoami` — show configured workspaces + token sources (secrets redacted)
 - `agent-slack auth test [--workspace <url-or-unique-substring>]` — verify credentials (`auth.test`)
 - `agent-slack auth import-desktop` — import browser-style creds from Slack Desktop (macOS)
 - `agent-slack auth import-chrome` — import creds from Chrome (macOS)
+- `agent-slack auth import-brave` — import creds from Brave (macOS)
 - `agent-slack auth parse-curl` — read a copied Slack cURL command from stdin and save creds
 - `agent-slack auth add --workspace-url <url> [--token <xoxb/xoxp> | --xoxc <xoxc> --xoxd <xoxd>]`
 - `agent-slack auth set-default <workspace-url>`
@@ -107,3 +118,8 @@ Common options:
 
 - `agent-slack user list [--workspace <url-or-unique-substring>] [--limit <n>] [--cursor <cursor>] [--include-bots]`
 - `agent-slack user get <U...|@handle|handle> [--workspace <url-or-unique-substring>]`
+
+## Update
+
+- `agent-slack update` — update to latest version
+- `agent-slack update --check` — only check whether an update is available


### PR DESCRIPTION
## Summary

Apply the skill-format follow-up as a standalone PR from `master`:

- Keep hybrid skill structure: `SKILL.md` + `references/*`
- Add concise install/update guidance in `skills/agent-slack/SKILL.md`
- Add quick common-command block in `skills/agent-slack/SKILL.md`
- Add TOC and missing command entries (`auth import-brave`, `update`) in `skills/agent-slack/references/commands.md`
- Sync `README.md` command map/auth examples with current CLI surface
- Add docs drift checker script and CI wiring

## Details

### Skill docs
- `skills/agent-slack/SKILL.md`
  - install commands (`curl ... install.sh` / `npm i -g agent-slack`)
  - `agent-slack update --check`
  - explicit Linux/Windows manual auth fallback section
  - quick reference command block

- `skills/agent-slack/references/commands.md`
  - table of contents
  - `auth import-brave`
  - `update` / `update --check`

### Docs sync enforcement
- `scripts/check-docs-sync.sh` (new)
- `package.json` script: `docs:check`
- `.github/workflows/ci.yml`: run `bun run docs:check`
- `.github/workflows/publish.yml`: run `bun run docs:check`

## Validation

- `bun run docs:check`
- `bun run test`

Both pass.
