### PR TITLE
fix: support user ID targets for message send (DM via conversations.open)

### DIFF
--- a/src/cli/draft-actions.ts
+++ b/src/cli/draft-actions.ts
@@ -12,6 +12,11 @@ export async function draftMessage(input: {
   options: { workspace?: string; threadTs?: string };
 }): Promise<Record<string, unknown>> {
   const target = parseMsgTarget(String(input.targetInput));
+  if (target.kind === "user") {
+    throw new Error(
+      "message draft does not support user ID targets. Use a channel name, channel ID, or message URL.",
+    );
+  }
 
   // URL target: resolve thread context and send
   if (target.kind === "url") {

--- a/src/cli/targets.ts
+++ b/src/cli/targets.ts
@@ -1,9 +1,10 @@
 import { parseSlackMessageUrl, type SlackMessageRef } from "../slack/url.ts";
-import { isChannelId } from "../slack/channels.ts";
+import { isChannelId, isUserId } from "../slack/channels.ts";
 
 export type MsgTarget =
   | { kind: "url"; ref: SlackMessageRef }
-  | { kind: "channel"; channel: string };
+  | { kind: "channel"; channel: string }
+  | { kind: "user"; userId: string };
 
 export function parseMsgTarget(input: string): MsgTarget {
   const trimmed = input.trim();
@@ -18,6 +19,9 @@ export function parseMsgTarget(input: string): MsgTarget {
     // not a slack message URL
   }
 
+  if (isUserId(trimmed)) {
+    return { kind: "user", userId: trimmed };
+  }
   if (trimmed.startsWith("#")) {
     return { kind: "channel", channel: trimmed };
   }

--- a/src/slack/channels.ts
+++ b/src/slack/channels.ts
@@ -5,6 +5,24 @@ export function isChannelId(input: string): boolean {
   return /^[CDG][A-Z0-9]{8,}$/.test(input);
 }
 
+export function isUserId(input: string): boolean {
+  return /^U[A-Z0-9]{8,}$/.test(input);
+}
+
+/**
+ * Open (or reuse) a DM channel with a user via conversations.open.
+ * Returns the DM channel ID.
+ */
+export async function openDmChannel(client: SlackApiClient, userId: string): Promise<string> {
+  const resp = await client.api("conversations.open", { users: userId });
+  const channel = isRecord(resp) ? resp.channel : null;
+  const channelId = isRecord(channel) ? getString(channel.id) : undefined;
+  if (!channelId) {
+    throw new Error(`Could not open DM channel for user: ${userId}`);
+  }
+  return channelId;
+}
+
 export function normalizeChannelInput(input: string): {
   kind: "id" | "name";
   value: string;

--- a/test/targets.test.ts
+++ b/test/targets.test.ts
@@ -40,4 +40,27 @@ describe("parseMsgTarget", () => {
     }
     expect(t.channel).toBe("C060RS20UMV");
   });
+
+  test("accepts user IDs as DM targets", () => {
+    const t = parseMsgTarget("U12345ABCDE");
+    expect(t.kind).toBe("user");
+    if (t.kind !== "user") {
+      throw new Error("expected user");
+    }
+    expect(t.userId).toBe("U12345ABCDE");
+  });
+
+  test("accepts user IDs with leading/trailing whitespace", () => {
+    const t = parseMsgTarget("  U09GDJJKCCW  ");
+    expect(t.kind).toBe("user");
+    if (t.kind !== "user") {
+      throw new Error("expected user");
+    }
+    expect(t.userId).toBe("U09GDJJKCCW");
+  });
+
+  test("does not treat short U-prefixed strings as user IDs", () => {
+    const t = parseMsgTarget("U1234");
+    expect(t.kind).toBe("channel");
+  });
 });


### PR DESCRIPTION
## Summary

- `message send` now accepts Slack user IDs (`U[A-Z0-9]{8,}`) as targets, opening a DM channel via `conversations.open` before posting
- Previously, user IDs fell through to `resolveChannelId` which tried `search.messages` with `in:#U12345...` — this returned no results and fell back to paginating `conversations.list` across the entire workspace, hanging indefinitely on large workspaces
- Other subcommands (`get`, `list`, `edit`, `delete`, `react`, `draft`) now throw a clear error for user ID targets instead of silently hanging

## What changed

| File | Change |
|------|--------|
| `src/slack/channels.ts` | Added `isUserId()` helper and `openDmChannel()` using `conversations.open` |
| `src/cli/targets.ts` | Added `"user"` kind to `MsgTarget` union; `parseMsgTarget` detects user IDs before the bare-name fallback |
| `src/cli/message-actions.ts` | `sendMessage` handles `kind: "user"` via `openDmChannel`; other functions throw early for user targets |
| `src/cli/draft-actions.ts` | Early error for user ID targets |
| `test/targets.test.ts` | 3 new tests for user ID parsing |

## Usage

```bash
# Send a DM to a user by their Slack user ID
agent-slack message send "U12345ABCDE" "Hello!" --workspace "myworkspace"

# Clear error for unsupported subcommands
agent-slack message get "U12345ABCDE"
# → Error: message get does not support user ID targets. Use a channel name, channel ID, or message URL.
```

## Test plan

- [x] `bun test` — 82 tests pass (3 new), 0 failures
- [x] `tsc --noEmit` — clean
- [x] `oxlint` — 0 errors (4 pre-existing max-lines warnings unchanged)

Fixes #35