### PR TITLE
feat(message): auto-detect bullet lists and send as rich_text blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ npm i -g agent-slack
 - **Read**: fetch a message, browse channel history, list full threads
 - **Search**: messages + files (with filters)
 - **Artifacts**: auto-download snippets/images/files to local paths for agents
-- **Write**: reply, edit/delete messages, add reactions
+- **Write**: reply, edit/delete messages, add reactions (bullet lists auto-render as native Slack rich text)
 - **Channels**: list conversations, create channels, and invite users by id/handle/email
 - **Canvas**: fetch Slack canvases as Markdown
 

--- a/skills/agent-slack/SKILL.md
+++ b/skills/agent-slack/SKILL.md
@@ -113,6 +113,12 @@ agent-slack message draft "https://workspace.slack.com/archives/C123/p1700000000
 agent-slack message send "https://workspace.slack.com/archives/C123/p1700000000000000" "I can take this."
 agent-slack message edit "https://workspace.slack.com/archives/C123/p1700000000000000" "I can take this today."
 agent-slack message delete "https://workspace.slack.com/archives/C123/p1700000000000000"
+
+# Bullet lists are auto-detected and rendered as native Slack rich text:
+agent-slack message send "#general" "Here's the plan:
+- Step 1: do the thing
+- Step 2: verify it worked
+  - Sub-step: check logs"
 agent-slack message react add "https://workspace.slack.com/archives/C123/p1700000000000000" "eyes"
 agent-slack message react remove "https://workspace.slack.com/archives/C123/p1700000000000000" "eyes"
 ```

--- a/skills/agent-slack/references/commands.md
+++ b/skills/agent-slack/references/commands.md
@@ -58,6 +58,7 @@ Run `agent-slack --help` (or `agent-slack <command> --help`) for the full option
 - `agent-slack message send <target> <text>`
   - If `<target>` is a Slack message URL, replies in that message’s thread.
   - Otherwise posts to the channel/DM.
+  - Bullet lists (`- `, `* `, `• `, `1. `, etc.) are automatically converted to Slack’s native rich text format, so recipients see real editable bullets instead of plain-text dashes.
   - Options:
     - `--workspace <url-or-unique-substring>` (needed for channel _names_ across multiple workspaces)
     - `--thread-ts <seconds>.<micros>` (optional, channel mode only)

--- a/src/cli/message-actions.ts
+++ b/src/cli/message-actions.ts
@@ -11,6 +11,7 @@ import { resolveChannelId, openDmChannel } from "../slack/channels.ts";
 import { normalizeSlackReactionName } from "../slack/emoji.ts";
 import { downloadMessageFiles } from "./message-file-downloads.ts";
 import { warnOnTruncatedSlackUrl } from "./message-url-warning.ts";
+import { textToRichTextBlocks } from "../slack/rich-text.ts";
 import { getThreadSummary, toThreadListMessage } from "./message-thread-info.ts";
 
 export type MessageCommandOptions = {
@@ -267,6 +268,8 @@ export async function sendMessage(input: {
   options: { workspace?: string; threadTs?: string };
 }): Promise<Record<string, unknown>> {
   const target = parseMsgTarget(String(input.targetInput));
+  const blocks = textToRichTextBlocks(input.text);
+
   if (target.kind === "url") {
     const { ref } = target;
     warnOnTruncatedSlackUrl(ref);
@@ -280,6 +283,7 @@ export async function sendMessage(input: {
           channel: ref.channel_id,
           text: input.text,
           thread_ts: threadTs,
+          ...(blocks ? { blocks } : {}),
         });
       },
     });
@@ -296,6 +300,7 @@ export async function sendMessage(input: {
         await client.api("chat.postMessage", {
           channel: dmChannelId,
           text: input.text,
+          ...(blocks ? { blocks } : {}),
         });
       },
     });
@@ -316,6 +321,7 @@ export async function sendMessage(input: {
         channel: channelId,
         text: input.text,
         thread_ts: input.options.threadTs ? String(input.options.threadTs) : undefined,
+        ...(blocks ? { blocks } : {}),
       });
     },
   });

--- a/src/slack/client.ts
+++ b/src/slack/client.ts
@@ -57,7 +57,7 @@ export class SlackApiClient {
     const url = `${input.workspaceUrl.replace(/\/$/, "")}/api/${input.method}`;
     const cleanedEntries = Object.entries(input.params)
       .filter(([, v]) => v !== undefined)
-      .map(([k, v]) => [k, String(v)]);
+      .map(([k, v]) => [k, typeof v === "object" ? JSON.stringify(v) : String(v)]);
     const formBody = new URLSearchParams({
       token: input.auth.xoxc_token,
       ...Object.fromEntries(cleanedEntries),

--- a/src/slack/rich-text.ts
+++ b/src/slack/rich-text.ts
@@ -1,0 +1,225 @@
+type InlineStyle = { bold?: true; italic?: true; strike?: true; code?: true };
+
+type InlineElement =
+  | { type: "text"; text: string; style?: InlineStyle }
+  | { type: "link"; url: string; text?: string; style?: InlineStyle };
+
+type RichTextElement =
+  | { type: "rich_text_section"; elements: InlineElement[] }
+  | {
+      type: "rich_text_list";
+      style: "bullet" | "ordered";
+      indent?: number;
+      elements: RichTextListItem[];
+    }
+  | { type: "rich_text_preformatted"; elements: InlineElement[] }
+  | { type: "rich_text_quote"; elements: InlineElement[] };
+
+type RichTextListItem = {
+  type: "rich_text_section";
+  elements: InlineElement[];
+};
+
+type RichTextBlock = {
+  type: "rich_text";
+  elements: RichTextElement[];
+};
+
+const BULLET_RE = /^(\s*)[•◦▪▫▸‣●○◆◇\-*]\s+(.*)$/;
+const ORDERED_RE = /^(\s*)\d+[.)]\s+(.*)$/;
+const CODE_BLOCK_START = /^```/;
+const BLOCKQUOTE_RE = /^> (.*)$/;
+
+/**
+ * Parse mrkdwn inline formatting into Slack rich_text inline elements.
+ *
+ * Handles: *bold*, _italic_, ~strike~, `code`, <url|label>, <url>
+ */
+export function parseInlineElements(text: string): InlineElement[] {
+  const elements: InlineElement[] = [];
+  const re = /`([^`]+)`|\*([^*]+)\*|_([^_]+)_|~([^~]+)~|<([^>|]+)\|([^>]+)>|<([^>|]+)>/g;
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = re.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      elements.push({ type: "text", text: text.slice(lastIndex, match.index) });
+    }
+
+    const [, code, bold, italic, strike, linkUrl, linkText, bareUrl] = match;
+    if (code != null) {
+      elements.push({ type: "text", text: code, style: { code: true } });
+    } else if (bold != null) {
+      elements.push({ type: "text", text: bold, style: { bold: true } });
+    } else if (italic != null) {
+      elements.push({ type: "text", text: italic, style: { italic: true } });
+    } else if (strike != null) {
+      elements.push({ type: "text", text: strike, style: { strike: true } });
+    } else if (linkUrl != null && linkText != null) {
+      elements.push({ type: "link", url: linkUrl, text: linkText });
+    } else if (bareUrl != null) {
+      elements.push({ type: "link", url: bareUrl });
+    }
+
+    lastIndex = match.index + match[0].length;
+  }
+
+  if (lastIndex < text.length) {
+    elements.push({ type: "text", text: text.slice(lastIndex) });
+  }
+
+  return elements.length > 0 ? elements : [{ type: "text", text }];
+}
+
+/**
+ * Convert mrkdwn text to Slack rich_text blocks when bullet or numbered
+ * lists are detected. Returns `null` when the text contains no lists,
+ * so the caller can fall back to plain `text`.
+ */
+export function textToRichTextBlocks(text: string): RichTextBlock[] | null {
+  const lines = text.split("\n");
+  const elements: RichTextElement[] = [];
+  let hasLists = false;
+  let idx = 0;
+
+  while (idx < lines.length) {
+    const line = lines[idx]!;
+
+    // Code block
+    if (CODE_BLOCK_START.test(line)) {
+      idx++; // skip opening ```
+      const codeLines: string[] = [];
+      while (idx < lines.length && !CODE_BLOCK_START.test(lines[idx]!)) {
+        codeLines.push(lines[idx]!);
+        idx++;
+      }
+      if (idx < lines.length) {
+        idx++;
+      } // skip closing ```
+      elements.push({
+        type: "rich_text_preformatted",
+        elements: [{ type: "text", text: codeLines.join("\n") }],
+      });
+      continue;
+    }
+
+    // Blockquote
+    const quoteMatch = line.match(BLOCKQUOTE_RE);
+    if (quoteMatch) {
+      const quoteLines: string[] = [];
+      while (idx < lines.length) {
+        const qm = lines[idx]!.match(BLOCKQUOTE_RE);
+        if (!qm) {
+          break;
+        }
+        quoteLines.push(qm[1]!);
+        idx++;
+      }
+      elements.push({
+        type: "rich_text_quote",
+        elements: parseInlineElements(quoteLines.join("\n")),
+      });
+      continue;
+    }
+
+    // Bullet list
+    if (BULLET_RE.test(line)) {
+      hasLists = true;
+      idx = collectList({ lines, startIdx: idx, style: "bullet", pattern: BULLET_RE, elements });
+      continue;
+    }
+
+    // Ordered list
+    if (ORDERED_RE.test(line)) {
+      hasLists = true;
+      idx = collectList({ lines, startIdx: idx, style: "ordered", pattern: ORDERED_RE, elements });
+      continue;
+    }
+
+    // Plain text — collect consecutive non-special lines
+    const textLines: string[] = [];
+    while (idx < lines.length) {
+      const l = lines[idx]!;
+      if (
+        BULLET_RE.test(l) ||
+        ORDERED_RE.test(l) ||
+        CODE_BLOCK_START.test(l) ||
+        BLOCKQUOTE_RE.test(l)
+      ) {
+        break;
+      }
+      textLines.push(l);
+      idx++;
+    }
+    const content = textLines.join("\n");
+    if (content.trim()) {
+      elements.push({
+        type: "rich_text_section",
+        elements: parseInlineElements(content.endsWith("\n") ? content : `${content}\n`),
+      });
+    }
+  }
+
+  if (!hasLists) {
+    return null;
+  }
+
+  return [{ type: "rich_text", elements }];
+}
+
+function collectList(input: {
+  lines: string[];
+  startIdx: number;
+  style: "bullet" | "ordered";
+  pattern: RegExp;
+  elements: RichTextElement[];
+}): number {
+  const { lines, startIdx, style, pattern, elements } = input;
+  let idx = startIdx;
+
+  // Determine base indent from the first bullet in this group
+  const firstMatch = lines[startIdx]!.match(pattern)!;
+  const baseIndent = firstMatch[1]!.length;
+
+  let currentIndent = -1;
+  let currentItems: RichTextListItem[] = [];
+
+  while (idx < lines.length) {
+    const match = lines[idx]!.match(pattern);
+    if (!match) {
+      break;
+    }
+
+    // Anything significantly deeper (>= baseIndent + 2) is a sub-bullet
+    const indent = match[1]!.length >= baseIndent + 2 ? 1 : 0;
+    const content = match[2]!;
+
+    if (currentIndent !== -1 && indent !== currentIndent) {
+      elements.push({
+        type: "rich_text_list",
+        style,
+        ...(currentIndent > 0 ? { indent: currentIndent } : {}),
+        elements: currentItems,
+      });
+      currentItems = [];
+    }
+
+    currentIndent = indent;
+    currentItems.push({
+      type: "rich_text_section",
+      elements: parseInlineElements(content),
+    });
+    idx++;
+  }
+
+  if (currentItems.length > 0) {
+    elements.push({
+      type: "rich_text_list",
+      style,
+      ...(currentIndent > 0 ? { indent: currentIndent } : {}),
+      elements: currentItems,
+    });
+  }
+
+  return idx;
+}

--- a/test/rich-text.test.ts
+++ b/test/rich-text.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test } from "bun:test";
+import { parseInlineElements, textToRichTextBlocks } from "../src/slack/rich-text.ts";
+
+describe("parseInlineElements", () => {
+  test("plain text returns single text element", () => {
+    expect(parseInlineElements("Hello world")).toEqual([{ type: "text", text: "Hello world" }]);
+  });
+
+  test("*bold* is parsed with bold style", () => {
+    expect(parseInlineElements("Hello *world*!")).toEqual([
+      { type: "text", text: "Hello " },
+      { type: "text", text: "world", style: { bold: true } },
+      { type: "text", text: "!" },
+    ]);
+  });
+
+  test("_italic_ is parsed with italic style", () => {
+    expect(parseInlineElements("This is _important_")).toEqual([
+      { type: "text", text: "This is " },
+      { type: "text", text: "important", style: { italic: true } },
+    ]);
+  });
+
+  test("~strike~ is parsed with strike style", () => {
+    expect(parseInlineElements("~done~")).toEqual([
+      { type: "text", text: "done", style: { strike: true } },
+    ]);
+  });
+
+  test("`code` is parsed with code style", () => {
+    expect(parseInlineElements("Run `npm install`")).toEqual([
+      { type: "text", text: "Run " },
+      { type: "text", text: "npm install", style: { code: true } },
+    ]);
+  });
+
+  test("<url|label> is parsed as link with text", () => {
+    expect(parseInlineElements("Visit <https://example.com|Example>")).toEqual([
+      { type: "text", text: "Visit " },
+      { type: "link", url: "https://example.com", text: "Example" },
+    ]);
+  });
+
+  test("<url> is parsed as link without text", () => {
+    expect(parseInlineElements("See <https://example.com>")).toEqual([
+      { type: "text", text: "See " },
+      { type: "link", url: "https://example.com" },
+    ]);
+  });
+});
+
+describe("textToRichTextBlocks", () => {
+  test("plain text returns null", () => {
+    expect(textToRichTextBlocks("Hello world")).toBeNull();
+  });
+
+  test("bullet list with - prefix", () => {
+    const result = textToRichTextBlocks("- Item 1\n- Item 2\n- Item 3")!;
+    expect(result).not.toBeNull();
+    const lists = result[0]!.elements.filter((e) => e.type === "rich_text_list");
+    expect(lists).toHaveLength(1);
+    const list = lists[0]!;
+    expect(list.type === "rich_text_list" && list.elements).toHaveLength(3);
+  });
+
+  test("bullet list with bullet character", () => {
+    expect(textToRichTextBlocks("• Item 1\n• Item 2")).not.toBeNull();
+  });
+
+  test("sub-bullets with indentation", () => {
+    const result = textToRichTextBlocks("- Main 1\n- Main 2\n  - Sub 2a\n  - Sub 2b\n- Main 3")!;
+    expect(result).not.toBeNull();
+    const lists = result[0]!.elements.filter((e) => e.type === "rich_text_list");
+    expect(lists).toHaveLength(3); // main, sub, main
+    expect((lists[1] as { indent?: number }).indent).toBe(1);
+  });
+
+  test("white bullet sub-bullets under bullet", () => {
+    const result = textToRichTextBlocks("• Top level\n  ◦ Sub-bullet\n  ◦ Another sub")!;
+    expect(result).not.toBeNull();
+    const lists = result[0]!.elements.filter((e) => e.type === "rich_text_list");
+    expect(lists).toHaveLength(2);
+    expect((lists[1] as { indent?: number }).indent).toBe(1);
+  });
+
+  test("mixed text and bullets", () => {
+    const result = textToRichTextBlocks("Here is a list:\n- Item 1\n- Item 2")!;
+    expect(result).not.toBeNull();
+    expect(result[0]!.elements[0]!.type).toBe("rich_text_section");
+    expect(result[0]!.elements[1]!.type).toBe("rich_text_list");
+  });
+
+  test("numbered list", () => {
+    const result = textToRichTextBlocks("1. First\n2. Second\n3. Third")!;
+    expect(result).not.toBeNull();
+    const list = result[0]!.elements.find((e) => e.type === "rich_text_list")!;
+    expect((list as { style: string }).style).toBe("ordered");
+  });
+
+  test("bold text in list items is parsed", () => {
+    const result = textToRichTextBlocks("- *Bold item*\n- Normal item")!;
+    expect(result).not.toBeNull();
+    const list = result[0]!.elements.find((e) => e.type === "rich_text_list") as {
+      elements: { elements: unknown[] }[];
+    };
+    expect(list.elements[0]!.elements).toEqual([
+      { type: "text", text: "Bold item", style: { bold: true } },
+    ]);
+  });
+
+  test("code block is preserved", () => {
+    const result = textToRichTextBlocks("- Item\n```\ncode here\n```")!;
+    expect(result).not.toBeNull();
+    expect(result[0]!.elements.find((e) => e.type === "rich_text_preformatted")).toBeDefined();
+  });
+
+  test("blockquote is preserved", () => {
+    const result = textToRichTextBlocks("- Item\n> quoted text")!;
+    expect(result).not.toBeNull();
+    expect(result[0]!.elements.find((e) => e.type === "rich_text_quote")).toBeDefined();
+  });
+});


### PR DESCRIPTION
Closes #44

## Summary

- Adds `src/slack/rich-text.ts` with `textToRichTextBlocks()` — detects bullet/numbered list patterns (`- `, `* `, `• `, `◦ `, `1. `, etc.) and converts to Slack `rich_text` blocks with proper `rich_text_list` elements and indent support
- Handles inline formatting within list items (`*bold*`, `_italic_`, `` `code` ``, `~strike~`, `<url|label>`)
- Also handles code blocks and blockquotes when mixed with lists
- Fixes `browserApi()` serialization in `client.ts` where `String(v)` on objects/arrays produced `"[object Object]"` — now uses `JSON.stringify` so `blocks` serialize correctly via form encoding
- Wires up `sendMessage()` to pass `blocks` alongside `text` when lists are detected (all three target paths: URL, user DM, channel). When no lists are found, behavior is unchanged
- 17 new tests in `test/rich-text.test.ts`
- Updated README, SKILL.md, and commands.md reference docs

## Design decisions

- **Autodetect over explicit flags** — per maintainer feedback, eats fewer tokens since blocks are verbose for LLMs to output
- **Indentation is relative** — first bullet's whitespace is the baseline; anything 2+ chars deeper becomes `indent: 1` (handles AI models' inconsistent spacing)
- **Both `blocks` and `text` sent** — `blocks` for rich rendering, `text` as fallback for notifications and search
- **No behavior change for non-list text** — `textToRichTextBlocks()` returns `null` when no lists detected

## Test plan

- [x] All 117 tests pass (`bun test`) — 17 new + 100 existing
- [x] `bun run typecheck` clean
- [x] `bun run format:check` clean
- [x] `bun run lint` — no new warnings/errors (pre-existing upstream warnings only)
- [x] Manual test: sent messages with bullets and numbered lists via `message send`, verified native rich text rendering in Slack