### PR TITLE
fix(lint): add curly braces in users.ts to fix CI

### DIFF
--- a/src/slack/users.ts
+++ b/src/slack/users.ts
@@ -36,14 +36,14 @@ export async function listUsers(
         const members = asArray(resp.members).filter(isRecord);
         for (const m of members) {
           const id = getString(m.id);
-          if (!id) continue;
-          if (!includeBots && m.is_bot) continue;
+          if (!id) { continue; }
+          if (!includeBots && m.is_bot) { continue; }
           users.push(toCompactUser(m));
-          if (users.length >= limit) break;
+          if (users.length >= limit) { break; }
         }
         const meta = isRecord(resp.response_metadata) ? resp.response_metadata : null;
         const next = meta ? getString(meta.next_cursor) : undefined;
-        if (!next) break;
+        if (!next) { break; }
         cursor = next;
         next_cursor = next;
       }
@@ -54,7 +54,7 @@ export async function listUsers(
 
   for (const u of out) {
     const dmId = dmMap.get(u.id);
-    if (dmId) u.dm_id = dmId;
+    if (dmId) { u.dm_id = dmId; }
   }
 
   return { users: out, next_cursor };
@@ -148,11 +148,11 @@ async function fetchDmMap(client: SlackApiClient): Promise<Map<string, string>> 
     for (const ch of channels) {
       const id = getString(ch.id);
       const user = getString(ch.user);
-      if (id && user) map.set(user, id);
+      if (id && user) { map.set(user, id); }
     }
     const meta = isRecord(resp.response_metadata) ? resp.response_metadata : null;
     const next = meta ? getString(meta.next_cursor) : undefined;
-    if (!next) break;
+    if (!next) { break; }
     cursor = next;
   }
   return map;


### PR DESCRIPTION
## Summary

- Adds curly braces to 7 single-line `if` statements in `src/slack/users.ts` to satisfy the `eslint(curly)` rule
- These 7 errors currently cause CI to fail on every PR against `main`

## Context

Noticed while CI was failing on #45 — all 7 lint errors are pre-existing on `main`, not introduced by that PR.

No functional changes — purely style/lint compliance.
