### PR TITLE
feat(nix): add flake package and automated source hash updates

### DIFF
--- a/.github/workflows/update-nix-sources.yml
+++ b/.github/workflows/update-nix-sources.yml
@@ -1,0 +1,34 @@
+name: Update Nix Sources
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 9 * * 1"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+
+      - name: Update nix sources
+        run: ./scripts/update-nix-sources.sh
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: "chore(nix): update release hashes"
+          title: "chore(nix): update release hashes"
+          body: |
+            Automated update of `nix/sources.json` from the latest GitHub release checksums.
+          branch: chore/update-nix-sources
+          delete-branch: true

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ OR npm global install (requires Node >= 22.5):
 npm i -g agent-slack
 ```
 
+OR run via Nix flake:
+
+```bash
+nix run github:stablyai/agent-slack
+```
+
 ## At a glance
 
 - **Read**: fetch a message, browse channel history, list full threads

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1772624091,
+        "narHash": "sha256-QKyJ0QGWBn6r0invrMAK8dmJoBYWoOWy7lN+UHzW1jc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "80bdc1e5ce51f56b19791b52b2901187931f5353",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,30 @@
+{
+  description = "agent-slack: Slack automation CLI for AI agents";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+  }:
+    flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = import nixpkgs {inherit system;};
+      agent-slack = pkgs.callPackage ./nix/package.nix {};
+    in {
+      packages = {
+        inherit agent-slack;
+        default = agent-slack;
+      };
+
+      apps = {
+        default = flake-utils.lib.mkApp {
+          drv = agent-slack;
+          name = "agent-slack";
+        };
+      };
+    });
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,47 @@
+{lib, fetchurl, stdenvNoCC}:
+let
+  sources = builtins.fromJSON (builtins.readFile ./sources.json);
+
+  assetBySystem = {
+    aarch64-darwin = "agent-slack-darwin-arm64";
+    x86_64-darwin = "agent-slack-darwin-x64";
+    aarch64-linux = "agent-slack-linux-arm64";
+    x86_64-linux = "agent-slack-linux-x64";
+  };
+
+  system = stdenvNoCC.hostPlatform.system;
+
+  asset =
+    assetBySystem.${system}
+    or (throw "agent-slack: unsupported system '${system}'");
+
+  hash =
+    sources.hashes.${system}
+    or (throw "agent-slack: missing hash for system '${system}' in nix/sources.json");
+in
+  stdenvNoCC.mkDerivation {
+    pname = "agent-slack";
+    inherit (sources) version;
+
+    src = fetchurl {
+      url = "https://github.com/stablyai/agent-slack/releases/download/v${sources.version}/${asset}";
+      inherit hash;
+    };
+
+    dontUnpack = true;
+
+    installPhase = ''
+      runHook preInstall
+      install -Dm755 "$src" "$out/bin/agent-slack"
+      runHook postInstall
+    '';
+
+    meta = {
+      description = "Slack automation CLI for AI agents";
+      homepage = "https://github.com/stablyai/agent-slack";
+      license = lib.licenses.mit;
+      platforms = builtins.attrNames assetBySystem;
+      mainProgram = "agent-slack";
+      sourceProvenance = with lib.sourceTypes; [binaryNativeCode];
+    };
+  }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,0 +1,9 @@
+{
+  "version": "0.5.2",
+  "hashes": {
+    "aarch64-darwin": "sha256-/amxMaLwMxmfyHqUZn8bKd6/bjrx/glCSzLSbFs+kKk=",
+    "x86_64-darwin": "sha256-w/uvefbqwaeiAsTSGt4VxY/VYWkFVQokQkjyIcL2EDw=",
+    "aarch64-linux": "sha256-CvpfyhuwI1V4XPSM6tiATq7h2tNHeK/Q1Ohwyq1ZFNw=",
+    "x86_64-linux": "sha256-7C+Z6CgXsagfgo+RPIj9dz7edwwzcqgpX2aJmRs2Xuc="
+  }
+}

--- a/scripts/update-nix-sources.sh
+++ b/scripts/update-nix-sources.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="stablyai/agent-slack"
+latest_api="https://api.github.com/repos/${repo}/releases/latest"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: jq is required" >&2
+  exit 1
+fi
+
+if ! command -v nix >/dev/null 2>&1; then
+  echo "error: nix is required" >&2
+  exit 1
+fi
+
+tag="$(curl -fsSL "$latest_api" | jq -r '.tag_name')"
+if [[ -z "$tag" || "$tag" == "null" ]]; then
+  echo "error: unable to resolve latest release tag" >&2
+  exit 1
+fi
+
+version="${tag#v}"
+checksums_url="https://github.com/${repo}/releases/download/${tag}/checksums-sha256.txt"
+checksums="$(curl -fsSL "$checksums_url")"
+
+get_sri() {
+  local asset="$1"
+  local hex
+  hex="$(awk -v asset="$asset" '$2 == asset { print $1 }' <<<"$checksums")"
+
+  if [[ -z "$hex" ]]; then
+    echo "error: missing checksum for ${asset}" >&2
+    exit 1
+  fi
+
+  nix hash convert --hash-algo sha256 --to sri "$hex"
+}
+
+arm64_darwin="$(get_sri agent-slack-darwin-arm64)"
+x64_darwin="$(get_sri agent-slack-darwin-x64)"
+arm64_linux="$(get_sri agent-slack-linux-arm64)"
+x64_linux="$(get_sri agent-slack-linux-x64)"
+
+jq -n \
+  --arg version "$version" \
+  --arg aarch64_darwin "$arm64_darwin" \
+  --arg x86_64_darwin "$x64_darwin" \
+  --arg aarch64_linux "$arm64_linux" \
+  --arg x86_64_linux "$x64_linux" \
+  '{
+    version: $version,
+    hashes: {
+      "aarch64-darwin": $aarch64_darwin,
+      "x86_64-darwin": $x86_64_darwin,
+      "aarch64-linux": $aarch64_linux,
+      "x86_64-linux": $x86_64_linux
+    }
+  }' > nix/sources.json
+
+echo "Updated nix/sources.json to ${version}"

--- a/skills/agent-slack/SKILL.md
+++ b/skills/agent-slack/SKILL.md
@@ -15,7 +15,8 @@ description: |
 
 # Slack automation with `agent-slack`
 
-`agent-slack` is a CLI binary installed on `$PATH`. Invoke it directly (e.g. `agent-slack user list`)
+`agent-slack` is a CLI binary installed on `$PATH`. Invoke it directly (e.g. `agent-slack user list`).
+If installed via Nix flake only, run commands with `nix run github:stablyai/agent-slack -- <args>`.
 
 ## Quick start (auth)
 


### PR DESCRIPTION
## Summary
- add a flake exposing `packages.<system>.agent-slack` and default app/package
- package release binaries via `nix/package.nix` with per-system pinned hashes in `nix/sources.json`
- add scheduled/manual workflow to refresh `nix/sources.json` from latest GitHub release checksums
- document Nix run path in README and skill docs

## Verification
- `nix build .#agent-slack`
- `nix run .#agent-slack -- --version` (returns `0.5.2`)
- `./scripts/update-nix-sources.sh`
