### PR TITLE
fix: resolve real_name for Slack Connect users

### DIFF
--- a/src/slack/users.ts
+++ b/src/slack/users.ts
@@ -114,7 +114,7 @@ function toCompactUser(u: Record<string, unknown>): CompactSlackUser {
   return {
     id: getString(u.id) ?? "",
     name: getString(u.name) ?? undefined,
-    real_name: getString(u.real_name) ?? undefined,
+    real_name: getString(u.real_name) ?? getString(profile.real_name) ?? undefined,
     display_name: getString(profile.display_name) ?? undefined,
     email: getString(profile.email) ?? undefined,
     title: getString(profile.title) ?? undefined,


### PR DESCRIPTION
## Summary

- `toCompactUser` reads `real_name` from the top-level `users.info` response, but for Slack Connect users (external org), the API only populates `real_name` inside `profile.real_name`
- This causes `agent-slack user get` to return just the handle (e.g. `"bob"`) instead of the full name (e.g. `"Bob Smith"`) for Connect users
- Fix: fall back to `profile.real_name` when the top-level field is missing

## Change

One line in `src/slack/users.ts`:

```diff
-    real_name: getString(u.real_name) ?? undefined,
+    real_name: getString(u.real_name) ?? getString(profile.real_name) ?? undefined,
```

The `profile` variable is already extracted on the line above, so this is a minimal change.

## How to reproduce

1. Have a Slack Connect DM with someone from an external org
2. Run `agent-slack user get <connect-user-id>`
3. Notice `real_name` is missing — only `name` (the handle) is returned
4. With this fix, `real_name` is correctly populated from `profile.real_name`

🤖 Generated with [Claude Code](https://claude.com/claude-code)