### PR TITLE
fix: case-insensitive user handle resolution

### DIFF
--- a/src/slack/users.ts
+++ b/src/slack/users.ts
@@ -114,12 +114,13 @@ export async function resolveUserId(client: SlackApiClient, input: string): Prom
     return null;
   }
 
+  const handleLower = handle.toLowerCase();
   let cursor: string | undefined;
   for (;;) {
     const resp = await client.api("users.list", { limit: 200, cursor });
     const members = asArray(resp.members).filter(isRecord);
     const found = members.find((m) => {
-      if (getString(m.name) === handle) {
+      if (getString(m.name)?.toLowerCase() === handleLower) {
         return true;
       }
       if (looksLikeEmail) {

--- a/test/users.test.ts
+++ b/test/users.test.ts
@@ -38,6 +38,19 @@ describe("resolveUserId", () => {
     expect(await resolveUserId(client as never, "alice@example.com")).toBe("U03EMAIL");
   });
 
+  test("resolves @handle case-insensitively", async () => {
+    const client = {
+      api: async (method: string) => {
+        expect(method).toBe("users.list");
+        return {
+          ok: true,
+          members: [{ id: "U05HANDLE", name: "jinjing" }],
+        };
+      },
+    };
+    expect(await resolveUserId(client as never, "@Jinjing")).toBe("U05HANDLE");
+  });
+
   test("falls back to users.list when lookupByEmail is unavailable", async () => {
     const client = {
       api: async (method: string) => {


### PR DESCRIPTION
## Summary
- `resolveUserId` used strict equality (`===`) when matching `@handle` inputs against Slack usernames, so `@Jinjing` failed to resolve a user with handle `jinjing`
- Now compares lowercase on both sides, matching Slack's own case-insensitive handle behavior
- Added test for case-insensitive handle resolution

## Test plan
- [x] Existing tests pass (5/5 in users.test.ts)
- [x] New test: `resolves @handle case-insensitively`
- [x] Full suite passes (180 tests)