### PR TITLE
feat: return sent message metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ agent-slack message delete "#general" --workspace "myteam" --ts "1770165109.6283
 Attach options for `message send`:
 
 - `--attach <path>` upload a local file (repeatable)
-- plain `message send` output includes `channel_id`, and for normal message posts also includes the posted `ts`, `thread_ts`, and `url`
+- plain `message send` output includes `channel_id`, `workspace_url` when known, and for normal message posts also includes the posted `ts`, `thread_ts`, and `url`
 
 ### List, create, and invite channels
 

--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ agent-slack message delete "#general" --workspace "myteam" --ts "1770165109.6283
 Attach options for `message send`:
 
 - `--attach <path>` upload a local file (repeatable)
+- plain `message send` output includes `channel_id`, and for normal message posts also includes the posted `ts`, `thread_ts`, and `url`
 
 ### List, create, and invite channels
 

--- a/README.md
+++ b/README.md
@@ -230,7 +230,8 @@ agent-slack message delete "#general" --workspace "myteam" --ts "1770165109.6283
 Attach options for `message send`:
 
 - `--attach <path>` upload a local file (repeatable)
-- plain `message send` output includes `channel_id`, `workspace_url` when known, and for normal message posts also includes the posted `ts`, `thread_ts`, and `url`
+
+`message send` returns `channel_id` plus the posted `ts` and a `permalink` (for non-attachment sends). `thread_ts` appears only when replying in a thread.
 
 ### List, create, and invite channels
 

--- a/skills/agent-slack/SKILL.md
+++ b/skills/agent-slack/SKILL.md
@@ -161,6 +161,7 @@ agent-slack message delete "general" --workspace "myteam" --ts "1770165109.62837
 Attach options for `message send`:
 
 - `--attach <path>` upload a local file (repeatable)
+- plain `message send` output includes `channel_id`, and for normal message posts also includes the posted `ts`, `thread_ts`, and `url`
 
 ## List channels + create/invite users
 

--- a/skills/agent-slack/SKILL.md
+++ b/skills/agent-slack/SKILL.md
@@ -161,7 +161,8 @@ agent-slack message delete "general" --workspace "myteam" --ts "1770165109.62837
 Attach options for `message send`:
 
 - `--attach <path>` upload a local file (repeatable)
-- plain `message send` output includes `channel_id`, `workspace_url` when known, and for normal message posts also includes the posted `ts`, `thread_ts`, and `url`
+
+`message send` returns `channel_id` plus the posted `ts` and a `permalink` (for non-attachment sends). `thread_ts` appears only when replying in a thread.
 
 ## List channels + create/invite users
 

--- a/skills/agent-slack/SKILL.md
+++ b/skills/agent-slack/SKILL.md
@@ -161,7 +161,7 @@ agent-slack message delete "general" --workspace "myteam" --ts "1770165109.62837
 Attach options for `message send`:
 
 - `--attach <path>` upload a local file (repeatable)
-- plain `message send` output includes `channel_id`, and for normal message posts also includes the posted `ts`, `thread_ts`, and `url`
+- plain `message send` output includes `channel_id`, `workspace_url` when known, and for normal message posts also includes the posted `ts`, `thread_ts`, and `url`
 
 ## List channels + create/invite users
 

--- a/skills/agent-slack/references/output.md
+++ b/skills/agent-slack/references/output.md
@@ -22,6 +22,7 @@ All commands print JSON to stdout.
 - `message send` returns:
   - `ok: true`
   - `channel_id: "C..." | "D..."`
+  - `workspace_url?: "https://...slack.com"` (present when the workspace is known)
   - `ts?: "<seconds>.<micros>"` (present for plain message posts)
   - `thread_ts?: "<seconds>.<micros>"` (present when the destination thread is known)
   - `url?: "https://.../archives/..."` (present when the workspace URL and posted ts are known)

--- a/skills/agent-slack/references/output.md
+++ b/skills/agent-slack/references/output.md
@@ -22,10 +22,9 @@ All commands print JSON to stdout.
 - `message send` returns:
   - `ok: true`
   - `channel_id: "C..." | "D..."`
-  - `workspace_url?: "https://...slack.com"` (present when the workspace is known)
-  - `ts?: "<seconds>.<micros>"` (present for plain message posts)
-  - `thread_ts?: "<seconds>.<micros>"` (present when the destination thread is known)
-  - `url?: "https://.../archives/..."` (present when the workspace URL and posted ts are known)
+  - `ts?: "<seconds>.<micros>"` — the posted message's ts; absent on file-attachment sends
+  - `thread_ts?: "<seconds>.<micros>"` — present only when the send was into an existing thread
+  - `permalink?: "https://.../archives/..."` — present when `ts` is known and a workspace URL was resolvable
 
 Message payload fields keep canonical user IDs (for example `author.user_id`, reaction `users[]`, and `@U...` mentions in rendered content).
 `referenced_users` provides display metadata for those IDs. The cache is per-workspace with a 24-hour per-entry TTL.

--- a/skills/agent-slack/references/output.md
+++ b/skills/agent-slack/references/output.md
@@ -19,6 +19,13 @@ All commands print JSON to stdout.
   - `referenced_users?: { [user_id]: { id, name?, real_name?, display_name?, ... } }`
   - Messages are compact and omit redundant fields on each item where possible.
 
+- `message send` returns:
+  - `ok: true`
+  - `channel_id: "C..." | "D..."`
+  - `ts?: "<seconds>.<micros>"` (present for plain message posts)
+  - `thread_ts?: "<seconds>.<micros>"` (present when the destination thread is known)
+  - `url?: "https://.../archives/..."` (present when the workspace URL and posted ts are known)
+
 Message payload fields keep canonical user IDs (for example `author.user_id`, reaction `users[]`, and `@U...` mentions in rendered content).
 `referenced_users` provides display metadata for those IDs. The cache is per-workspace with a 24-hour per-entry TTL.
 This behavior is opt-in and requires passing the `--resolve-users` flag (or `--refresh-users` to bypass the cache).

--- a/src/cli/message-actions.ts
+++ b/src/cli/message-actions.ts
@@ -180,22 +180,21 @@ async function sendMessageToChannel(input: {
     });
     const ts = typeof resp.ts === "string" ? resp.ts : undefined;
     const channelId = typeof resp.channel === "string" ? resp.channel : input.channelId;
-    const threadTs = input.threadTs ?? ts;
+    const permalink =
+      input.workspaceUrl && ts
+        ? buildSlackMessageUrl({
+            workspace_url: input.workspaceUrl,
+            channel_id: channelId,
+            message_ts: ts,
+            thread_ts: input.threadTs,
+          })
+        : undefined;
     return {
       ok: true,
       channel_id: channelId,
-      workspace_url: input.workspaceUrl,
       ts,
-      thread_ts: threadTs,
-      url:
-        input.workspaceUrl && ts
-          ? buildSlackMessageUrl({
-              workspace_url: input.workspaceUrl,
-              channel_id: channelId,
-              message_ts: ts,
-              thread_ts: threadTs,
-            })
-          : undefined,
+      thread_ts: input.threadTs,
+      permalink,
     };
   }
 
@@ -220,7 +219,6 @@ async function sendMessageToChannel(input: {
   return {
     ok: true,
     channel_id: input.channelId,
-    workspace_url: input.workspaceUrl,
     thread_ts: input.threadTs,
   };
 }

--- a/src/cli/message-actions.ts
+++ b/src/cli/message-actions.ts
@@ -91,12 +91,12 @@ export async function sendMessage(input: {
     return await input.ctx.withAutoRefresh({
       workspaceUrl: ref.workspace_url,
       work: async () => {
-        const { client } = await input.ctx.getClientForWorkspace(ref.workspace_url);
+        const { client, workspace_url } = await input.ctx.getClientForWorkspace(ref.workspace_url);
         const msg = await fetchMessage(client, { ref });
         const threadTs = msg.thread_ts ?? msg.ts;
         return await sendMessageToChannel({
           client,
-          workspaceUrl: ref.workspace_url,
+          workspaceUrl: workspace_url ?? ref.workspace_url,
           channelId: ref.channel_id,
           text: input.text,
           blocks,
@@ -112,11 +112,11 @@ export async function sendMessage(input: {
     return await input.ctx.withAutoRefresh({
       workspaceUrl,
       work: async () => {
-        const { client } = await input.ctx.getClientForWorkspace(workspaceUrl);
+        const { client, workspace_url } = await input.ctx.getClientForWorkspace(workspaceUrl);
         const dmChannelId = await openDmChannel(client, target.userId);
         return await sendMessageToChannel({
           client,
-          workspaceUrl,
+          workspaceUrl: workspace_url ?? workspaceUrl,
           channelId: dmChannelId,
           text: input.text,
           blocks,
@@ -134,11 +134,11 @@ export async function sendMessage(input: {
   return await input.ctx.withAutoRefresh({
     workspaceUrl,
     work: async () => {
-      const { client } = await input.ctx.getClientForWorkspace(workspaceUrl);
+      const { client, workspace_url } = await input.ctx.getClientForWorkspace(workspaceUrl);
       const channelId = await resolveChannelId(client, String(target.channel));
       return await sendMessageToChannel({
         client,
-        workspaceUrl,
+        workspaceUrl: workspace_url ?? workspaceUrl,
         channelId,
         text: input.text,
         blocks,
@@ -184,16 +184,18 @@ async function sendMessageToChannel(input: {
     return {
       ok: true,
       channel_id: channelId,
+      workspace_url: input.workspaceUrl,
       ts,
       thread_ts: threadTs,
-      url: input.workspaceUrl && ts
-        ? buildSlackMessageUrl({
-            workspace_url: input.workspaceUrl,
-            channel_id: channelId,
-            message_ts: ts,
-            thread_ts: threadTs,
-          })
-        : undefined,
+      url:
+        input.workspaceUrl && ts
+          ? buildSlackMessageUrl({
+              workspace_url: input.workspaceUrl,
+              channel_id: channelId,
+              message_ts: ts,
+              thread_ts: threadTs,
+            })
+          : undefined,
     };
   }
 
@@ -218,6 +220,7 @@ async function sendMessageToChannel(input: {
   return {
     ok: true,
     channel_id: input.channelId,
+    workspace_url: input.workspaceUrl,
     thread_ts: input.threadTs,
   };
 }

--- a/src/cli/message-actions.ts
+++ b/src/cli/message-actions.ts
@@ -7,6 +7,7 @@ import { warnOnTruncatedSlackUrl } from "./message-url-warning.ts";
 import { textToRichTextBlocks } from "../slack/rich-text.ts";
 import type { SlackApiClient } from "../slack/client.ts";
 import { uploadLocalFileToSlack } from "../slack/upload.ts";
+import { buildSlackMessageUrl } from "../slack/url.ts";
 
 export type MessageCommandOptions = {
   maxBodyChars: string;
@@ -87,14 +88,15 @@ export async function sendMessage(input: {
   if (target.kind === "url") {
     const { ref } = target;
     warnOnTruncatedSlackUrl(ref);
-    await input.ctx.withAutoRefresh({
+    return await input.ctx.withAutoRefresh({
       workspaceUrl: ref.workspace_url,
       work: async () => {
         const { client } = await input.ctx.getClientForWorkspace(ref.workspace_url);
         const msg = await fetchMessage(client, { ref });
         const threadTs = msg.thread_ts ?? msg.ts;
-        await sendMessageToChannel({
+        return await sendMessageToChannel({
           client,
+          workspaceUrl: ref.workspace_url,
           channelId: ref.channel_id,
           text: input.text,
           blocks,
@@ -103,18 +105,18 @@ export async function sendMessage(input: {
         });
       },
     });
-    return { ok: true };
   }
 
   if (target.kind === "user") {
     const workspaceUrl = input.ctx.effectiveWorkspaceUrl(input.options.workspace);
-    await input.ctx.withAutoRefresh({
+    return await input.ctx.withAutoRefresh({
       workspaceUrl,
       work: async () => {
         const { client } = await input.ctx.getClientForWorkspace(workspaceUrl);
         const dmChannelId = await openDmChannel(client, target.userId);
-        await sendMessageToChannel({
+        return await sendMessageToChannel({
           client,
+          workspaceUrl,
           channelId: dmChannelId,
           text: input.text,
           blocks,
@@ -122,7 +124,6 @@ export async function sendMessage(input: {
         });
       },
     });
-    return { ok: true };
   }
 
   const workspaceUrl = input.ctx.effectiveWorkspaceUrl(input.options.workspace);
@@ -130,13 +131,14 @@ export async function sendMessage(input: {
     workspaceUrl,
     channels: [String(target.channel)],
   });
-  await input.ctx.withAutoRefresh({
+  return await input.ctx.withAutoRefresh({
     workspaceUrl,
     work: async () => {
       const { client } = await input.ctx.getClientForWorkspace(workspaceUrl);
       const channelId = await resolveChannelId(client, String(target.channel));
-      await sendMessageToChannel({
+      return await sendMessageToChannel({
         client,
+        workspaceUrl,
         channelId,
         text: input.text,
         blocks,
@@ -145,7 +147,6 @@ export async function sendMessage(input: {
       });
     },
   });
-  return { ok: true };
 }
 
 function normalizeAttachPaths(raw: string[] | undefined): string[] {
@@ -163,20 +164,37 @@ function normalizeAttachPaths(raw: string[] | undefined): string[] {
 
 async function sendMessageToChannel(input: {
   client: SlackApiClient;
+  workspaceUrl?: string;
   channelId: string;
   text: string;
   blocks?: unknown[] | null;
   threadTs?: string;
   attachPaths: string[];
-}): Promise<void> {
+}): Promise<Record<string, unknown>> {
   if (input.attachPaths.length === 0) {
-    await input.client.api("chat.postMessage", {
+    const resp = await input.client.api("chat.postMessage", {
       channel: input.channelId,
       text: input.text,
       thread_ts: input.threadTs,
       ...(input.blocks ? { blocks: input.blocks } : {}),
     });
-    return;
+    const ts = typeof resp.ts === "string" ? resp.ts : undefined;
+    const channelId = typeof resp.channel === "string" ? resp.channel : input.channelId;
+    const threadTs = input.threadTs ?? ts;
+    return {
+      ok: true,
+      channel_id: channelId,
+      ts,
+      thread_ts: threadTs,
+      url: input.workspaceUrl && ts
+        ? buildSlackMessageUrl({
+            workspace_url: input.workspaceUrl,
+            channel_id: channelId,
+            message_ts: ts,
+            thread_ts: threadTs,
+          })
+        : undefined,
+    };
   }
 
   if (input.blocks) {
@@ -196,6 +214,12 @@ async function sendMessageToChannel(input: {
     });
     initialComment = "";
   }
+
+  return {
+    ok: true,
+    channel_id: input.channelId,
+    thread_ts: input.threadTs,
+  };
 }
 
 export async function editMessage(input: {

--- a/src/slack/url.ts
+++ b/src/slack/url.ts
@@ -53,3 +53,19 @@ export function parseSlackMessageUrl(input: string): SlackMessageRef {
   const workspace_url = `${url.protocol}//${url.host}`;
   return { workspace_url, channel_id, message_ts, thread_ts_hint, raw: input, possiblyTruncated };
 }
+
+export function buildSlackMessageUrl(input: {
+  workspace_url: string;
+  channel_id: string;
+  message_ts: string;
+  thread_ts?: string;
+}): string {
+  const workspaceUrl = input.workspace_url.replace(/\/$/, "");
+  const digits = input.message_ts.replace(".", "");
+  const url = new URL(`${workspaceUrl}/archives/${input.channel_id}/p${digits}`);
+  if (input.thread_ts && input.thread_ts !== input.message_ts) {
+    url.searchParams.set("thread_ts", input.thread_ts);
+    url.searchParams.set("cid", input.channel_id);
+  }
+  return url.toString();
+}

--- a/test/message-send.test.ts
+++ b/test/message-send.test.ts
@@ -29,6 +29,7 @@ function createContext(calls: { method: string; params: Record<string, unknown> 
     getClientForWorkspace: async () => ({
       client: client as never,
       auth: { auth_type: "standard", token: "x" as const },
+      workspace_url: "https://workspace.slack.com",
     }),
     normalizeUrl: (u: string) => u,
     errorMessage: (err: unknown) => (err instanceof Error ? err.message : String(err)),
@@ -80,6 +81,38 @@ describe("sendMessage", () => {
     expect(result).toEqual({
       ok: true,
       channel_id: "C12345678",
+      workspace_url: "https://workspace.slack.com",
+      ts: "1770165109.628379",
+      thread_ts: "1770165109.628379",
+      url: "https://workspace.slack.com/archives/C12345678/p1770165109628379",
+    });
+  });
+
+  test("returns a permalink when the workspace was resolved implicitly", async () => {
+    const calls: { method: string; params: Record<string, unknown> }[] = [];
+    const ctx = createContext(calls);
+
+    const result = await sendMessage({
+      ctx,
+      targetInput: "C12345678",
+      text: "hello",
+      options: {},
+    });
+
+    expect(calls).toEqual([
+      {
+        method: "chat.postMessage",
+        params: {
+          channel: "C12345678",
+          text: "hello",
+          thread_ts: undefined,
+        },
+      },
+    ]);
+    expect(result).toEqual({
+      ok: true,
+      channel_id: "C12345678",
+      workspace_url: "https://workspace.slack.com",
       ts: "1770165109.628379",
       thread_ts: "1770165109.628379",
       url: "https://workspace.slack.com/archives/C12345678/p1770165109628379",

--- a/test/message-send.test.ts
+++ b/test/message-send.test.ts
@@ -81,10 +81,9 @@ describe("sendMessage", () => {
     expect(result).toEqual({
       ok: true,
       channel_id: "C12345678",
-      workspace_url: "https://workspace.slack.com",
       ts: "1770165109.628379",
-      thread_ts: "1770165109.628379",
-      url: "https://workspace.slack.com/archives/C12345678/p1770165109628379",
+      thread_ts: undefined,
+      permalink: "https://workspace.slack.com/archives/C12345678/p1770165109628379",
     });
   });
 
@@ -112,10 +111,30 @@ describe("sendMessage", () => {
     expect(result).toEqual({
       ok: true,
       channel_id: "C12345678",
-      workspace_url: "https://workspace.slack.com",
       ts: "1770165109.628379",
-      thread_ts: "1770165109.628379",
-      url: "https://workspace.slack.com/archives/C12345678/p1770165109628379",
+      thread_ts: undefined,
+      permalink: "https://workspace.slack.com/archives/C12345678/p1770165109628379",
+    });
+  });
+
+  test("threaded reply returns thread_ts distinct from ts", async () => {
+    const calls: { method: string; params: Record<string, unknown> }[] = [];
+    const ctx = createContext(calls);
+
+    const result = await sendMessage({
+      ctx,
+      targetInput: "C12345678",
+      text: "reply",
+      options: { threadTs: "1770160000.000001" },
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      channel_id: "C12345678",
+      ts: "1770165109.628379",
+      thread_ts: "1770160000.000001",
+      permalink:
+        "https://workspace.slack.com/archives/C12345678/p1770165109628379?thread_ts=1770160000.000001&cid=C12345678",
     });
   });
 

--- a/test/message-send.test.ts
+++ b/test/message-send.test.ts
@@ -12,6 +12,9 @@ function createContext(calls: { method: string; params: Record<string, unknown> 
       if (method === "files.getUploadURLExternal") {
         return { ok: true, upload_url: "https://upload.example/file", file_id: "F123" };
       }
+      if (method === "chat.postMessage") {
+        return { ok: true, channel: String(params.channel), ts: "1770165109.628379" };
+      }
       return { ok: true };
     },
   };
@@ -57,11 +60,11 @@ describe("sendMessage", () => {
     const calls: { method: string; params: Record<string, unknown> }[] = [];
     const ctx = createContext(calls);
 
-    await sendMessage({
+    const result = await sendMessage({
       ctx,
       targetInput: "C12345678",
       text: "hello",
-      options: {},
+      options: { workspace: "https://workspace.slack.com" },
     });
 
     expect(calls).toEqual([
@@ -74,6 +77,13 @@ describe("sendMessage", () => {
         },
       },
     ]);
+    expect(result).toEqual({
+      ok: true,
+      channel_id: "C12345678",
+      ts: "1770165109.628379",
+      thread_ts: "1770165109.628379",
+      url: "https://workspace.slack.com/archives/C12345678/p1770165109628379",
+    });
   });
 
   test("uploads attachment and uses message text as initial comment", async () => {

--- a/test/url.test.ts
+++ b/test/url.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { parseSlackMessageUrl } from "../src/slack/url.ts";
+import { buildSlackMessageUrl, parseSlackMessageUrl } from "../src/slack/url.ts";
 
 describe("parseSlackMessageUrl", () => {
   test("parses archives URL with p<digits>", () => {
@@ -17,5 +17,26 @@ describe("parseSlackMessageUrl", () => {
     );
     expect(ref.message_ts).toBe("1770165109.628379");
     expect(ref.thread_ts_hint).toBe("1770160000.000001");
+  });
+});
+
+describe("buildSlackMessageUrl", () => {
+  test("builds a permalink for a root message", () => {
+    expect(buildSlackMessageUrl({
+      workspace_url: "https://stablygroup.slack.com/",
+      channel_id: "C060RS20UMV",
+      message_ts: "1770165109.628379",
+    })).toBe("https://stablygroup.slack.com/archives/C060RS20UMV/p1770165109628379");
+  });
+
+  test("includes thread metadata for replies", () => {
+    expect(buildSlackMessageUrl({
+      workspace_url: "https://stablygroup.slack.com",
+      channel_id: "C060RS20UMV",
+      message_ts: "1770165110.000001",
+      thread_ts: "1770165109.628379",
+    })).toBe(
+      "https://stablygroup.slack.com/archives/C060RS20UMV/p1770165110000001?thread_ts=1770165109.628379&cid=C060RS20UMV",
+    );
   });
 });

--- a/test/url.test.ts
+++ b/test/url.test.ts
@@ -22,20 +22,24 @@ describe("parseSlackMessageUrl", () => {
 
 describe("buildSlackMessageUrl", () => {
   test("builds a permalink for a root message", () => {
-    expect(buildSlackMessageUrl({
-      workspace_url: "https://stablygroup.slack.com/",
-      channel_id: "C060RS20UMV",
-      message_ts: "1770165109.628379",
-    })).toBe("https://stablygroup.slack.com/archives/C060RS20UMV/p1770165109628379");
+    expect(
+      buildSlackMessageUrl({
+        workspace_url: "https://stablygroup.slack.com/",
+        channel_id: "C060RS20UMV",
+        message_ts: "1770165109.628379",
+      }),
+    ).toBe("https://stablygroup.slack.com/archives/C060RS20UMV/p1770165109628379");
   });
 
   test("includes thread metadata for replies", () => {
-    expect(buildSlackMessageUrl({
-      workspace_url: "https://stablygroup.slack.com",
-      channel_id: "C060RS20UMV",
-      message_ts: "1770165110.000001",
-      thread_ts: "1770165109.628379",
-    })).toBe(
+    expect(
+      buildSlackMessageUrl({
+        workspace_url: "https://stablygroup.slack.com",
+        channel_id: "C060RS20UMV",
+        message_ts: "1770165110.000001",
+        thread_ts: "1770165109.628379",
+      }),
+    ).toBe(
       "https://stablygroup.slack.com/archives/C060RS20UMV/p1770165110000001?thread_ts=1770165109.628379&cid=C060RS20UMV",
     );
   });


### PR DESCRIPTION
## Summary
- return posted channel/message metadata from `agent-slack message send`
- build permalinks for posted messages when the workspace URL is known
- document and test the new output shape

## Test Plan
- `bun test test/message-send.test.ts test/url.test.ts`
