### PR TITLE
feat(message send): add --blocks flag for raw Block Kit payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,36 @@ agent-slack message delete "#general" --workspace "myteam" --ts "1770165109.6283
 Attach options for `message send`:
 
 - `--attach <path>` upload a local file (repeatable)
+- `--blocks <path>` send raw [Block Kit](https://docs.slack.dev/block-kit/) blocks from a JSON file (or `-` for stdin). Bypasses the automatic markdown-to-rich-text conversion, unlocking header/divider/section/table blocks and other structured layouts. Cannot be combined with `--attach`.
+
+Example — post a message with a native Slack table block:
+
+```bash
+cat > /tmp/blocks.json <<'EOF'
+[
+  {
+    "type": "header",
+    "text": { "type": "plain_text", "text": "Weekly digest" }
+  },
+  {
+    "type": "table",
+    "rows": [
+      [
+        { "type": "raw_text", "text": "Name" },
+        { "type": "raw_text", "text": "Why" }
+      ],
+      [
+        { "type": "raw_text", "text": "Caveman MCP" },
+        { "type": "raw_text", "text": "~80% token cut on nav" }
+      ]
+    ]
+  }
+]
+EOF
+agent-slack message send "#alerts-staging" --blocks /tmp/blocks.json
+```
+
+When `--blocks` is used, the positional `<text>` argument (if provided) is still sent as the message's `text` fallback (for notifications and unfurls).
 
 ### List, create, and invite channels
 

--- a/skills/agent-slack/SKILL.md
+++ b/skills/agent-slack/SKILL.md
@@ -161,6 +161,7 @@ agent-slack message delete "general" --workspace "myteam" --ts "1770165109.62837
 Attach options for `message send`:
 
 - `--attach <path>` upload a local file (repeatable)
+- `--blocks <path>` send raw [Block Kit](https://docs.slack.dev/block-kit/) blocks from a JSON file (or `-` for stdin). Enables headers, dividers, table blocks, and other structured layouts. Incompatible with `--attach`.
 
 ## List channels + create/invite users
 

--- a/skills/agent-slack/references/commands.md
+++ b/skills/agent-slack/references/commands.md
@@ -67,6 +67,7 @@ Run `agent-slack --help` (or `agent-slack <command> --help`) for the full option
     - `--workspace <url-or-unique-substring>` (needed for channel _names_ across multiple workspaces)
     - `--thread-ts <seconds>.<micros>` (optional, channel mode only)
     - `--attach <path>` (repeatable; upload local files as attachments)
+    - `--blocks <path>` raw Block Kit blocks from a JSON file (or `-` for stdin). Bypasses markdown-to-rich-text conversion; enables header/divider/section/table blocks. Cannot be combined with `--attach`.
 
 - `agent-slack message edit <target> <text>`
   - URL target edits that exact message.

--- a/src/cli/message-actions.ts
+++ b/src/cli/message-actions.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import type { CliContext } from "./context.ts";
 import { fetchMessage } from "../slack/messages.ts";
 import { parseMsgTarget } from "./targets.ts";
@@ -7,6 +8,22 @@ import { warnOnTruncatedSlackUrl } from "./message-url-warning.ts";
 import { textToRichTextBlocks } from "../slack/rich-text.ts";
 import type { SlackApiClient } from "../slack/client.ts";
 import { uploadLocalFileToSlack } from "../slack/upload.ts";
+
+function loadBlocksFromPath(path: string): unknown[] {
+  const raw = path === "-" ? readFileSync(0, "utf8") : readFileSync(path, "utf8");
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `--blocks: failed to parse JSON from ${path === "-" ? "stdin" : path}: ${(err as Error).message}`,
+    );
+  }
+  if (!Array.isArray(parsed)) {
+    throw new Error(`--blocks: expected a JSON array of Block Kit blocks, got ${typeof parsed}`);
+  }
+  return parsed;
+}
 
 export type MessageCommandOptions = {
   maxBodyChars: string;
@@ -78,10 +95,14 @@ export async function sendMessage(input: {
   ctx: CliContext;
   targetInput: string;
   text: string;
-  options: { workspace?: string; threadTs?: string; attach?: string[] };
+  options: { workspace?: string; threadTs?: string; attach?: string[]; blocks?: string };
 }): Promise<Record<string, unknown>> {
   const target = parseMsgTarget(String(input.targetInput));
-  const blocks = input.text ? textToRichTextBlocks(input.text) : null;
+  const blocks = input.options.blocks
+    ? loadBlocksFromPath(input.options.blocks)
+    : input.text
+      ? textToRichTextBlocks(input.text)
+      : null;
   const attachPaths = normalizeAttachPaths(input.options.attach);
 
   if (target.kind === "url") {

--- a/src/cli/message-command.ts
+++ b/src/cli/message-command.ts
@@ -164,15 +164,25 @@ export function registerMessageCommand(input: { program: Command; ctx: CliContex
     )
     .option("--thread-ts <ts>", "Thread root ts to post into (optional)")
     .option("--attach <path>", "Attach a local file path (repeatable)", collectOptionValue, [])
+    .option(
+      "--blocks <path>",
+      "Path to a JSON file containing a Block Kit blocks array. Bypasses automatic markdown-to-rich-text conversion. Use '-' to read from stdin. Cannot be combined with --attach.",
+    )
     .action(async (...args) => {
       const [targetInput, text, options] = args as [
         string,
         string | undefined,
-        { workspace?: string; threadTs?: string; attach?: string[] },
+        { workspace?: string; threadTs?: string; attach?: string[]; blocks?: string },
       ];
       const hasAttach = (options.attach ?? []).length > 0;
-      if (!text && !hasAttach) {
-        console.error("Error: <text> is required when no --attach files are provided.");
+      const hasBlocks = options.blocks !== undefined;
+      if (!text && !hasAttach && !hasBlocks) {
+        console.error("Error: <text> is required when no --attach files or --blocks are provided.");
+        process.exitCode = 1;
+        return;
+      }
+      if (hasBlocks && hasAttach) {
+        console.error("Error: --blocks cannot be combined with --attach.");
         process.exitCode = 1;
         return;
       }

--- a/test/message-send.test.ts
+++ b/test/message-send.test.ts
@@ -160,4 +160,112 @@ describe("sendMessage", () => {
     expect(calls[1]?.params.initial_comment).toBeUndefined();
     expect(calls.some((c) => c.method === "chat.postMessage")).toBe(false);
   });
+
+  test("--blocks: reads Block Kit JSON from file and passes through unchanged", async () => {
+    const calls: { method: string; params: Record<string, unknown> }[] = [];
+    const ctx = createContext(calls);
+    const dir = await mkdtemp(join(tmpdir(), "agent-slack-send-test-"));
+    const blocksPath = join(dir, "blocks.json");
+    const blocks = [
+      { type: "header", text: { type: "plain_text", text: "Digest" } },
+      {
+        type: "table",
+        rows: [
+          [
+            { type: "raw_text", text: "Name" },
+            { type: "raw_text", text: "Why" },
+          ],
+          [
+            { type: "raw_text", text: "Caveman" },
+            { type: "raw_text", text: "token cut" },
+          ],
+        ],
+      },
+    ];
+    await writeFile(blocksPath, JSON.stringify(blocks));
+
+    try {
+      await sendMessage({
+        ctx,
+        targetInput: "C12345678",
+        text: "fallback text",
+        options: { blocks: blocksPath },
+      });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.method).toBe("chat.postMessage");
+    expect(calls[0]?.params).toEqual({
+      channel: "C12345678",
+      text: "fallback text",
+      thread_ts: undefined,
+      blocks,
+    });
+  });
+
+  test("--blocks: errors when JSON is not an array", async () => {
+    const calls: { method: string; params: Record<string, unknown> }[] = [];
+    const ctx = createContext(calls);
+    const dir = await mkdtemp(join(tmpdir(), "agent-slack-send-test-"));
+    const blocksPath = join(dir, "blocks.json");
+    await writeFile(blocksPath, JSON.stringify({ type: "header" }));
+
+    try {
+      expect(
+        sendMessage({
+          ctx,
+          targetInput: "C12345678",
+          text: "",
+          options: { blocks: blocksPath },
+        }),
+      ).rejects.toThrow(/expected a JSON array/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("--blocks: errors on malformed JSON", async () => {
+    const calls: { method: string; params: Record<string, unknown> }[] = [];
+    const ctx = createContext(calls);
+    const dir = await mkdtemp(join(tmpdir(), "agent-slack-send-test-"));
+    const blocksPath = join(dir, "blocks.json");
+    await writeFile(blocksPath, "{not valid json");
+
+    try {
+      expect(
+        sendMessage({
+          ctx,
+          targetInput: "C12345678",
+          text: "",
+          options: { blocks: blocksPath },
+        }),
+      ).rejects.toThrow(/failed to parse JSON/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("--blocks: overrides markdown-to-rich-text conversion when text is also provided", async () => {
+    const calls: { method: string; params: Record<string, unknown> }[] = [];
+    const ctx = createContext(calls);
+    const dir = await mkdtemp(join(tmpdir(), "agent-slack-send-test-"));
+    const blocksPath = join(dir, "blocks.json");
+    const blocks = [{ type: "divider" }];
+    await writeFile(blocksPath, JSON.stringify(blocks));
+
+    try {
+      await sendMessage({
+        ctx,
+        targetInput: "C12345678",
+        text: "- bullet one\n- bullet two",
+        options: { blocks: blocksPath },
+      });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+
+    expect(calls[0]?.params.blocks).toEqual(blocks);
+  });
 });


### PR DESCRIPTION
## Summary

Adds a `--blocks <path>` option to `message send` that reads a JSON array of Block Kit blocks from a file (or `-` for stdin) and passes it to `chat.postMessage` as-is, bypassing the built-in markdown-to-rich-text conversion.

This unlocks structured layouts that the markdown converter can't express — `header`, `divider`, `context`, `section` (with `accessory`), and especially the [`table` block](https://docs.slack.dev/reference/block-kit/blocks/table-block/) introduced by Slack in August 2025. User tokens already carry the `chat:write` scope needed; no new auth is required.

### Example

```bash
cat > blocks.json <<'JSON'
[
  { "type": "header", "text": { "type": "plain_text", "text": "Weekly digest" } },
  {
    "type": "table",
    "rows": [
      [{ "type": "raw_text", "text": "Name" }, { "type": "raw_text", "text": "Why" }],
      [{ "type": "raw_text", "text": "Caveman MCP" }, { "type": "raw_text", "text": "~80% token cut" }]
    ]
  }
]
JSON
agent-slack message send "#alerts-staging" --blocks blocks.json
```

### Behavior

- `--blocks` and `--attach` are mutually exclusive (uploads take a separate code path that doesn't carry blocks)
- Positional `<text>` remains optional when `--blocks` is set, but if provided it is sent as the message `text` fallback used for notifications and unfurls
- Malformed JSON and non-array payloads produce clear CLI errors
- When `--blocks` is set, the automatic markdown→rich_text conversion is skipped

### Files

- `src/cli/message-command.ts` — add `--blocks` option + mutual-exclusion check
- `src/cli/message-actions.ts` — `loadBlocksFromPath()` reads/parses/validates; `sendMessage()` prefers loaded blocks over text-derived ones
- `README.md`, `skills/agent-slack/SKILL.md`, `skills/agent-slack/references/commands.md` — document the flag with a table-block example
- `test/message-send.test.ts` — 4 new cases (happy path, non-array JSON, malformed JSON, precedence over text)

## Test plan

- [x] `bun test` — all 185 tests pass (4 new)
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — no new warnings (5 pre-existing line-count warnings unchanged)
- [x] `bun run format:check` — clean
- [x] Built locally with `bun run build` and sent a real message to a DM with a header + table block; table rendered natively in the Slack client