### PR TITLE
fix: escape mentions and HTML-ish chars in outbound message text

### DIFF
--- a/skills/agent-slack/SKILL.md
+++ b/skills/agent-slack/SKILL.md
@@ -164,6 +164,8 @@ Attach options for `message send`:
 
 `message send` returns `channel_id` plus the posted `ts` and a `permalink` (for non-attachment sends). `thread_ts` appears only when replying in a thread.
 
+Mentions: just write `@U05BRPTKL6A`, `@here`, `@channel`, or `@everyone` — the CLI converts them to real Slack mention tokens and escapes literal `&`/`<`/`>` in your text. You don't need to wrap IDs yourself.
+
 ## List channels + create/invite users
 
 ```bash

--- a/src/cli/message-actions.ts
+++ b/src/cli/message-actions.ts
@@ -5,6 +5,7 @@ import { resolveChannelId, openDmChannel } from "../slack/channels.ts";
 import { normalizeSlackReactionName } from "../slack/emoji.ts";
 import { warnOnTruncatedSlackUrl } from "./message-url-warning.ts";
 import { textToRichTextBlocks } from "../slack/rich-text.ts";
+import { formatOutboundSlackText } from "../slack/format-outbound.ts";
 import type { SlackApiClient } from "../slack/client.ts";
 import { uploadLocalFileToSlack } from "../slack/upload.ts";
 import { buildSlackMessageUrl } from "../slack/url.ts";
@@ -82,6 +83,7 @@ export async function sendMessage(input: {
   options: { workspace?: string; threadTs?: string; attach?: string[] };
 }): Promise<Record<string, unknown>> {
   const target = parseMsgTarget(String(input.targetInput));
+  const formattedText = formatOutboundSlackText(input.text);
   const blocks = input.text ? textToRichTextBlocks(input.text) : null;
   const attachPaths = normalizeAttachPaths(input.options.attach);
 
@@ -98,7 +100,7 @@ export async function sendMessage(input: {
           client,
           workspaceUrl: workspace_url ?? ref.workspace_url,
           channelId: ref.channel_id,
-          text: input.text,
+          text: formattedText,
           blocks,
           threadTs,
           attachPaths,
@@ -118,7 +120,7 @@ export async function sendMessage(input: {
           client,
           workspaceUrl: workspace_url ?? workspaceUrl,
           channelId: dmChannelId,
-          text: input.text,
+          text: formattedText,
           blocks,
           attachPaths,
         });
@@ -140,7 +142,7 @@ export async function sendMessage(input: {
         client,
         workspaceUrl: workspace_url ?? workspaceUrl,
         channelId,
-        text: input.text,
+        text: formattedText,
         blocks,
         threadTs: input.options.threadTs ? String(input.options.threadTs) : undefined,
         attachPaths,
@@ -236,6 +238,7 @@ export async function editMessage(input: {
     );
   }
   const workspaceUrl = input.ctx.effectiveWorkspaceUrl(input.options.workspace);
+  const formattedText = formatOutboundSlackText(input.text);
 
   await input.ctx.withAutoRefresh({
     workspaceUrl: target.kind === "url" ? target.ref.workspace_url : workspaceUrl,
@@ -247,7 +250,7 @@ export async function editMessage(input: {
         await client.api("chat.update", {
           channel: ref.channel_id,
           ts: ref.message_ts,
-          text: input.text,
+          text: formattedText,
         });
         return;
       }
@@ -262,7 +265,7 @@ export async function editMessage(input: {
       await client.api("chat.update", {
         channel: channelId,
         ts,
-        text: input.text,
+        text: formattedText,
       });
     },
   });

--- a/src/slack/format-outbound.ts
+++ b/src/slack/format-outbound.ts
@@ -1,0 +1,44 @@
+/**
+ * Prepare user-authored text for Slack's `chat.postMessage` / `chat.update`.
+ *
+ * Slack's mrkdwn contract requires:
+ *  - literal `&`, `<`, `>` escaped as `&amp;`, `&lt;`, `&gt;`
+ *  - user mentions wrapped as `<@U123>`, channel mentions as `<#C123>`,
+ *    broadcast mentions as `<!here>` / `<!channel>` / `<!everyone>`
+ *
+ * Humans (and LLMs piping text into the CLI) commonly write `@U123` and
+ * raw `&`/`<`/`>` — this helper normalizes that to what Slack expects,
+ * while leaving already-well-formed Slack tokens intact.
+ */
+export function formatOutboundSlackText(text: string): string {
+  if (!text) {
+    return "";
+  }
+
+  // Protect already-formatted Slack tokens so `<`/`>` inside them aren't escaped.
+  const stash: string[] = [];
+  let out = text.replace(
+    /<(?:@[UWB][A-Z0-9]+(?:\|[^>]*)?|#[CG][A-Z0-9]+(?:\|[^>]*)?|![a-zA-Z]+(?:\|[^>]*)?|https?:\/\/[^>]+)>/g,
+    (m) => {
+      stash.push(m);
+      return `\u0000${stash.length - 1}\u0000`;
+    },
+  );
+
+  // Escape literal HTML-ish characters per Slack's mrkdwn rules.
+  out = out.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+
+  // Promote bare user IDs (`@U05BRPTKL6A`) to real mentions.
+  out = out.replace(/(^|[^A-Za-z0-9_])@([UWB][A-Z0-9]{6,})\b/g, (_m, pre, id) => `${pre}<@${id}>`);
+
+  // Promote broadcast mentions.
+  out = out.replace(
+    /(^|[^A-Za-z0-9_])@(here|channel|everyone)\b/g,
+    (_m, pre, name) => `${pre}<!${name}>`,
+  );
+
+  // Restore protected tokens.
+  out = out.replace(/\u0000(\d+)\u0000/g, (_m, idx) => stash[Number(idx)]!);
+
+  return out;
+}

--- a/src/slack/rich-text.ts
+++ b/src/slack/rich-text.ts
@@ -2,7 +2,9 @@ type InlineStyle = { bold?: true; italic?: true; strike?: true; code?: true };
 
 type InlineElement =
   | { type: "text"; text: string; style?: InlineStyle }
-  | { type: "link"; url: string; text?: string; style?: InlineStyle };
+  | { type: "link"; url: string; text?: string; style?: InlineStyle }
+  | { type: "user"; user_id: string }
+  | { type: "broadcast"; range: "here" | "channel" | "everyone" };
 
 type RichTextElement =
   | { type: "rich_text_section"; elements: InlineElement[] }
@@ -37,16 +39,36 @@ const BLOCKQUOTE_RE = /^> (.*)$/;
  */
 export function parseInlineElements(text: string): InlineElement[] {
   const elements: InlineElement[] = [];
-  const re = /`([^`]+)`|\*([^*]+)\*|_([^_]+)_|~([^~]+)~|<([^>|]+)\|([^>]+)>|<([^>|]+)>/g;
+  const re =
+    /`([^`]+)`|\*([^*]+)\*|_([^_]+)_|~([^~]+)~|<@([UWB][A-Z0-9]+)(?:\|[^>]*)?>|<!(here|channel|everyone)(?:\|[^>]*)?>|<([^>|]+)\|([^>]+)>|<([^>|]+)>|(?:^|(?<=[^A-Za-z0-9_]))@([UWB][A-Z0-9]{6,})\b|(?:^|(?<=[^A-Za-z0-9_]))@(here|channel|everyone)\b/g;
   let lastIndex = 0;
   let match: RegExpExecArray | null;
 
+  const pushText = (slice: string): void => {
+    if (slice) {
+      elements.push({ type: "text", text: slice });
+    }
+  };
+
   while ((match = re.exec(text)) !== null) {
     if (match.index > lastIndex) {
-      elements.push({ type: "text", text: text.slice(lastIndex, match.index) });
+      pushText(text.slice(lastIndex, match.index));
     }
 
-    const [, code, bold, italic, strike, linkUrl, linkText, bareUrl] = match;
+    const [
+      ,
+      code,
+      bold,
+      italic,
+      strike,
+      userToken,
+      broadcastToken,
+      linkUrl,
+      linkText,
+      bareUrl,
+      bareUserId,
+      bareBroadcast,
+    ] = match;
     if (code != null) {
       elements.push({ type: "text", text: code, style: { code: true } });
     } else if (bold != null) {
@@ -55,17 +77,31 @@ export function parseInlineElements(text: string): InlineElement[] {
       elements.push({ type: "text", text: italic, style: { italic: true } });
     } else if (strike != null) {
       elements.push({ type: "text", text: strike, style: { strike: true } });
+    } else if (userToken != null) {
+      elements.push({ type: "user", user_id: userToken });
+    } else if (broadcastToken != null) {
+      elements.push({
+        type: "broadcast",
+        range: broadcastToken as "here" | "channel" | "everyone",
+      });
     } else if (linkUrl != null && linkText != null) {
       elements.push({ type: "link", url: linkUrl, text: linkText });
     } else if (bareUrl != null) {
       elements.push({ type: "link", url: bareUrl });
+    } else if (bareUserId != null) {
+      elements.push({ type: "user", user_id: bareUserId });
+    } else if (bareBroadcast != null) {
+      elements.push({
+        type: "broadcast",
+        range: bareBroadcast as "here" | "channel" | "everyone",
+      });
     }
 
     lastIndex = match.index + match[0].length;
   }
 
   if (lastIndex < text.length) {
-    elements.push({ type: "text", text: text.slice(lastIndex) });
+    pushText(text.slice(lastIndex));
   }
 
   return elements.length > 0 ? elements : [{ type: "text", text }];

--- a/test/format-outbound.test.ts
+++ b/test/format-outbound.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import { formatOutboundSlackText } from "../src/slack/format-outbound.ts";
+
+describe("formatOutboundSlackText", () => {
+  test("promotes bare user IDs to Slack mention tokens", () => {
+    expect(formatOutboundSlackText("@U05BRPTKL6A heads up")).toBe("<@U05BRPTKL6A> heads up");
+    expect(formatOutboundSlackText("cc @W123456A and @BABCDEFG")).toBe(
+      "cc <@W123456A> and <@BABCDEFG>",
+    );
+  });
+
+  test("leaves already-formatted mention tokens alone", () => {
+    expect(formatOutboundSlackText("hi <@U123456A>!")).toBe("hi <@U123456A>!");
+    expect(formatOutboundSlackText("hi <@U123456A|nick>!")).toBe("hi <@U123456A|nick>!");
+  });
+
+  test("promotes broadcast mentions", () => {
+    expect(formatOutboundSlackText("@here ping")).toBe("<!here> ping");
+    expect(formatOutboundSlackText("cc @channel and @everyone")).toBe(
+      "cc <!channel> and <!everyone>",
+    );
+  });
+
+  test("escapes bare < > & in literal text", () => {
+    expect(formatOutboundSlackText("a < b && c > d")).toBe("a &lt; b &amp;&amp; c &gt; d");
+  });
+
+  test("does not escape inside already-formatted Slack tokens", () => {
+    expect(formatOutboundSlackText("see <https://example.com|link>")).toBe(
+      "see <https://example.com|link>",
+    );
+    expect(formatOutboundSlackText("see <https://a.test/?x=1&y=2>")).toBe(
+      "see <https://a.test/?x=1&y=2>",
+    );
+  });
+
+  test("does not promote email-like or mid-word @", () => {
+    expect(formatOutboundSlackText("mail me at user@Udomain.com")).toBe(
+      "mail me at user@Udomain.com",
+    );
+  });
+
+  test("handles empty input", () => {
+    expect(formatOutboundSlackText("")).toBe("");
+  });
+
+  test("real-world CI dump stays readable with mention + URL", () => {
+    const input =
+      '@U05BRPTKL6A heads up: CI "Install dependencies" is failing: https://github.com/x/y/actions/runs/1 & it needs <fix>';
+    expect(formatOutboundSlackText(input)).toBe(
+      '<@U05BRPTKL6A> heads up: CI "Install dependencies" is failing: https://github.com/x/y/actions/runs/1 &amp; it needs &lt;fix&gt;',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- `agent-slack message send` / `edit` previously forwarded user text raw to `chat.postMessage`, so `@U05BRPTKL6A` arrived as literal text (no ping) and bare `<`/`>`/`&` were dropped/mangled by Slack.
- Added `formatOutboundSlackText` to promote bare user IDs (`@U…`/`@W…`/`@B…`) and broadcasts (`@here`/`@channel`/`@everyone`) to real Slack tokens and HTML-escape literal `&`/`<`/`>`, leaving already-formed `<@…>`, `<#…>`, `<!…>`, and `<https://…>` tokens intact.
- Extended the rich_text inline parser to emit `user`/`broadcast` elements so list-style messages mention correctly too.
- Skill note updated so downstream agents don't need to hand-wrap IDs.

## Test plan
- [x] `bun test` (193 pass)
- [x] `bun run typecheck`
- [ ] Manual send: `agent-slack message send "#ci-alerts" "@U05BRPTKL6A heads up <fix> & go"` renders as a real mention with escaped `<fix>` & `&`

Made with [Orca](https://github.com/stablyai/orca) 🐋
