### PR TITLE
fix: use default_workspace_url for channel-name disambiguation (#61)

### DIFF
--- a/src/cli/context.ts
+++ b/src/cli/context.ts
@@ -68,11 +68,17 @@ async function assertWorkspaceSpecifiedForChannelNames(input: {
     return;
   }
 
-  if (!input.workspaceUrl) {
-    throw new Error(
-      'Ambiguous channel name across multiple workspaces. Pass --workspace "<url-or-unique-substring>" (or set SLACK_WORKSPACE_URL).',
-    );
+  if (input.workspaceUrl) {
+    return;
   }
+
+  if (creds.default_workspace_url) {
+    return;
+  }
+
+  throw new Error(
+    'Ambiguous channel name across multiple workspaces. Pass --workspace "<url-or-unique-substring>" (or set SLACK_WORKSPACE_URL, or run "agent-slack auth set-default <url>").',
+  );
 }
 
 function isAuthErrorMessage(message: string): boolean {


### PR DESCRIPTION
Fixes #61.

## What changed

`assertWorkspaceSpecifiedForChannelNames` (`src/cli/context.ts`) now treats `default_workspace_url` as a valid disambiguator. When a user has run `auth set-default <url>`, channel-name commands no longer throw "Ambiguous channel name across multiple workspaces".

## Why this matters

`getClientForWorkspace` already falls through to `resolveDefaultWorkspace()` when no workspace selector is supplied, so the default workspace was usable for everything *except* channel-name commands. The assertion fired before the resolver ever ran. That meant a user who'd configured `default_workspace_url` still had to pass `--workspace` or `SLACK_WORKSPACE_URL` for every channel-name command, which is exactly the friction `auth set-default` was meant to eliminate.

The proposal in #61 lists nine call sites that hit this path; all of them go through the same assertion, so the single-line behavior change covers every affected command:

- `message get/list/send/edit/delete/react #channel`
- `search --channel #channel`
- `message draft #channel`
- `channel invite --channel #channel`

## Behavior summary

| Workspaces configured | `--workspace` | `SLACK_WORKSPACE_URL` | `default_workspace_url` | Before | After |
|---|---|---|---|---|---|
| 0 or 1 | any | any | any | OK | OK (unchanged) |
| 2+ | set | any | any | OK | OK (unchanged) |
| 2+ | unset | set | any | OK | OK (unchanged) |
| 2+ | unset | unset | set | error | OK (new) |
| 2+ | unset | unset | unset | error | error (with updated message) |

The error message is also updated to mention `auth set-default <url>` so users discover the third option.

## Verification

- `bun test`: 193 pass, 0 fail.
- `bun run build`: succeeds (340 modules bundled).
- `bun run lint`: no new warnings.