### PR TITLE
fix(auth): clearer import-brave error + add to README/skill docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Notes:
 On macOS and Windows, authentication happens automatically:
 
 - Default: reads Slack Desktop local data (no need to quit Slack)
-- Fallbacks: if that fails, tries Brave/Chrome/Firefox extraction (macOS)
+- Fallbacks: if that fails, tries Chrome/Brave/Firefox extraction (macOS)
 
 You can also run manual imports:
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ agent-slack
 │   ├── whoami
 │   ├── test
 │   ├── import-desktop
+│   ├── import-brave
 │   ├── import-chrome
 │   ├── import-firefox
 │   └── parse-curl
@@ -109,17 +110,21 @@ Notes:
 On macOS and Windows, authentication happens automatically:
 
 - Default: reads Slack Desktop local data (no need to quit Slack)
-- Fallbacks: if that fails, tries Chrome/Firefox extraction (macOS)
+- Fallbacks: if that fails, tries Brave/Chrome/Firefox extraction (macOS)
 
 You can also run manual imports:
 
 ```bash
 agent-slack auth whoami
 agent-slack auth import-desktop
+agent-slack auth import-brave
 agent-slack auth import-chrome
 agent-slack auth import-firefox
 agent-slack auth test
 ```
+
+> [!NOTE]
+> `import-brave` / `import-chrome` read tokens from a logged-in Slack tab via AppleScript. Both browsers ship with **Allow JavaScript from Apple Events** disabled by default — enable it in **View → Developer** before running these commands. macOS will prompt for your password the first time.
 
 Alternatively, set env vars:
 

--- a/skills/agent-slack/SKILL.md
+++ b/skills/agent-slack/SKILL.md
@@ -46,7 +46,7 @@ Claude Code's permission checker has security heuristics that force manual appro
 
 ## Quick start (auth)
 
-Authentication is automatic on macOS and Windows (Slack Desktop first, then Chrome/Firefox fallbacks on macOS).
+Authentication is automatic on macOS and Windows (Slack Desktop first, then Brave/Chrome/Firefox fallbacks on macOS).
 
 If credentials aren’t available, run one of:
 
@@ -54,6 +54,13 @@ If credentials aren’t available, run one of:
 
 ```bash
 agent-slack auth import-desktop
+agent-slack auth test
+```
+
+- Brave fallback (requires View → Developer → Allow JavaScript from Apple Events):
+
+```bash
+agent-slack auth import-brave
 agent-slack auth test
 ```
 

--- a/skills/agent-slack/SKILL.md
+++ b/skills/agent-slack/SKILL.md
@@ -46,7 +46,7 @@ Claude Code's permission checker has security heuristics that force manual appro
 
 ## Quick start (auth)
 
-Authentication is automatic on macOS and Windows (Slack Desktop first, then Brave/Chrome/Firefox fallbacks on macOS).
+Authentication is automatic on macOS and Windows (Slack Desktop first, then Chrome/Brave/Firefox fallbacks on macOS).
 
 If credentials aren’t available, run one of:
 

--- a/skills/agent-slack/references/commands.md
+++ b/skills/agent-slack/references/commands.md
@@ -7,6 +7,7 @@ Run `agent-slack --help` (or `agent-slack <command> --help`) for the full option
 - `agent-slack auth whoami` — show configured workspaces + token sources (secrets redacted)
 - `agent-slack auth test [--workspace <url-or-unique-substring>]` — verify credentials (`auth.test`)
 - `agent-slack auth import-desktop` — import browser-style creds from Slack Desktop (macOS/Windows)
+- `agent-slack auth import-brave` — import creds from Brave (macOS; requires View → Developer → Allow JavaScript from Apple Events)
 - `agent-slack auth import-chrome` — import creds from Chrome (macOS)
 - `agent-slack auth import-firefox` — import creds from Firefox profile storage (macOS/Linux)
 - `agent-slack auth parse-curl` — read a copied Slack cURL command from stdin and save creds

--- a/src/auth/brave.ts
+++ b/src/auth/brave.ts
@@ -15,14 +15,47 @@ export type BraveExtracted = {
 
 const IS_MACOS = platform() === "darwin";
 
+// Brave (like Chrome) ships with `Allow JavaScript from Apple Events` OFF.
+// Without it, `execute javascript` from osascript fails — and that's how this
+// module reads `localStorage.localConfig_v2` from a Slack tab. We detect that
+// specific failure and surface an actionable message instead of swallowing it.
+export class BraveAppleScriptDisabledError extends Error {
+  constructor() {
+    super(
+      "Brave is blocking JavaScript from Apple Events.\n" +
+        "Enable it: Brave menu → View → Developer → Allow JavaScript from Apple Events\n" +
+        "(macOS will prompt for your password the first time.)\n" +
+        "Then re-run: agent-slack auth import-brave",
+    );
+    this.name = "BraveAppleScriptDisabledError";
+  }
+}
+
 // --- AppleScript helpers (for extracting teams from Brave tabs) ---
 
+const APPLESCRIPT_JS_DISABLED_MARKER = "Executing JavaScript through AppleScript is turned off";
+
 function osascript(script: string): string {
-  return execFileSync("osascript", ["-e", script], {
-    encoding: "utf8",
-    timeout: 7000,
-    stdio: ["ignore", "pipe", "pipe"],
-  }).trim();
+  try {
+    return execFileSync("osascript", ["-e", script], {
+      encoding: "utf8",
+      timeout: 7000,
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+  } catch (err: unknown) {
+    const stderr =
+      err && typeof err === "object" && "stderr" in err
+        ? String((err as { stderr: unknown }).stderr ?? "")
+        : "";
+    const message = err instanceof Error ? err.message : String(err);
+    if (
+      stderr.includes(APPLESCRIPT_JS_DISABLED_MARKER) ||
+      message.includes(APPLESCRIPT_JS_DISABLED_MARKER)
+    ) {
+      throw new BraveAppleScriptDisabledError();
+    }
+    throw err;
+  }
 }
 
 const TEAM_JSON_PATHS = [
@@ -179,7 +212,10 @@ export async function extractFromBrave(): Promise<BraveExtracted | null> {
     }
 
     return { cookie_d, teams };
-  } catch {
+  } catch (err) {
+    if (err instanceof BraveAppleScriptDisabledError) {
+      throw err;
+    }
     return null;
   }
 }

--- a/src/cli/auth-command.ts
+++ b/src/cli/auth-command.ts
@@ -105,13 +105,16 @@ export function registerAuthCommand(input: { program: Command; ctx: CliContext }
 
   auth
     .command("import-brave")
-    .description("Import xoxc/xoxd from a logged-in Slack tab in Brave Browser (macOS)")
+    .description(
+      "Import xoxc/xoxd from a logged-in Slack tab in Brave Browser (macOS). Requires View → Developer → Allow JavaScript from Apple Events to be enabled in Brave.",
+    )
     .action(async () => {
       try {
         const extracted = await input.ctx.importBrave();
         if (!extracted) {
           throw new Error(
-            "Could not extract tokens from Brave. Open Slack in Brave and ensure you're logged in.",
+            "Could not extract tokens from Brave. Open Slack in Brave and ensure you're logged in. " +
+              "If Brave is open with a Slack tab, also confirm View → Developer → Allow JavaScript from Apple Events is enabled.",
           );
         }
 

--- a/src/cli/context-client-resolver.ts
+++ b/src/cli/context-client-resolver.ts
@@ -1,4 +1,4 @@
-import { extractFromBrave } from "../auth/brave.ts";
+import { BraveAppleScriptDisabledError, extractFromBrave } from "../auth/brave.ts";
 import { extractFromChrome } from "../auth/chrome.ts";
 import { extractFromSlackDesktop } from "../auth/desktop.ts";
 import { extractFromFirefox } from "../auth/firefox.ts";
@@ -144,9 +144,15 @@ export async function getClientForWorkspace(workspaceUrl?: string): Promise<{
   if (chromeResult && chromeResult.teams.length > 0) {
     browserSources.push(chromeResult);
   }
-  const braveResult = await extractFromBrave();
-  if (braveResult && braveResult.teams.length > 0) {
-    browserSources.push(braveResult);
+  try {
+    const braveResult = await extractFromBrave();
+    if (braveResult && braveResult.teams.length > 0) {
+      browserSources.push(braveResult);
+    }
+  } catch (err) {
+    if (!(err instanceof BraveAppleScriptDisabledError)) {
+      throw err;
+    }
   }
   const firefoxResult = await extractFromFirefox();
   if (firefoxResult && firefoxResult.teams.length > 0) {


### PR DESCRIPTION
## Summary

- `import-brave` silently failed on first run because `extractFromBrave()` wrapped its body in `try { ... } catch { return null }`, hiding the specific "Allow JavaScript from Apple Events is turned off" failure behind a generic "ensure you're logged in" message.
- That toggle ships **OFF** in Brave (and every Chromium browser), so the very first `agent-slack auth import-brave` consistently looks like an auth problem instead of a one-time browser setting.
- Adds `import-brave` to README + skill docs, where it was previously undocumented despite being wired into the auto-detection fallback chain (`src/cli/context-client-resolver.ts:138`).

## What changed

- `src/auth/brave.ts`: detect the AppleScript-disabled error in `osascript()` and throw a typed `BraveAppleScriptDisabledError` with an actionable message (menu path + re-run hint). Other failure modes keep the existing null-return behavior, so the generic "ensure you're logged in" message still applies when no Slack tab is open or cookie decryption fails.
- `src/cli/auth-command.ts`: `import-brave`'s description and fallback `throw new Error` message both reference the `View → Developer → Allow JavaScript from Apple Events` requirement.
- `README.md`: list `import-brave` in the command tree and manual-imports block; add a NOTE block explaining the AppleScript-JS prereq applies to both `import-brave` and `import-chrome`.
- `skills/agent-slack/SKILL.md`: add a Brave fallback section and update the intro to `Brave/Chrome/Firefox` (Brave is already in the auto-fallback chain).
- `skills/agent-slack/references/commands.md`: add `import-brave` to the auth command list with the AppleScript prereq inline.

## Notes

`src/auth/chrome.ts` has the same bug pattern (identical `try { ... } catch { return null }` wrapping + identical `execute t javascript` AppleScript path). Out of scope for this PR — happy to send a follow-up.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run test` — 198/198 pass
- [x] `bun run format:check` clean
- [x] `agent-slack auth import-brave` happy path: still imports tokens (2 workspaces in my case)
- [x] Manually reproduced AppleScript-disabled failure (`View → Developer → Allow JavaScript from Apple Events` OFF) and confirmed `osascript()` reports the exact marker string that the new detection relies on
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)