### PR TITLE
Preserve rich formatting on message edits

### DIFF
--- a/src/cli/message-actions.ts
+++ b/src/cli/message-actions.ts
@@ -268,6 +268,9 @@ export async function editMessage(input: {
   }
   const workspaceUrl = input.ctx.effectiveWorkspaceUrl(input.options.workspace);
   const formattedText = formatOutboundSlackText(input.text);
+  const blocks = input.text
+    ? textToRichTextBlocks(input.text, { includeInlineFormatting: true })
+    : null;
 
   await input.ctx.withAutoRefresh({
     workspaceUrl: target.kind === "url" ? target.ref.workspace_url : workspaceUrl,
@@ -280,6 +283,7 @@ export async function editMessage(input: {
           channel: ref.channel_id,
           ts: ref.message_ts,
           text: formattedText,
+          ...(blocks ? { blocks } : {}),
         });
         return;
       }
@@ -295,6 +299,7 @@ export async function editMessage(input: {
         channel: channelId,
         ts,
         text: formattedText,
+        ...(blocks ? { blocks } : {}),
       });
     },
   });

--- a/src/slack/rich-text.ts
+++ b/src/slack/rich-text.ts
@@ -27,6 +27,10 @@ type RichTextBlock = {
   elements: RichTextElement[];
 };
 
+type TextToRichTextBlocksOptions = {
+  includeInlineFormatting?: boolean;
+};
+
 const BULLET_RE = /^(\s*)[•◦▪▫▸‣●○◆◇\-*]\s+(.*)$/;
 const ORDERED_RE = /^(\s*)\d+[.)]\s+(.*)$/;
 const CODE_BLOCK_START = /^```/;
@@ -86,8 +90,10 @@ export function parseInlineElements(text: string): InlineElement[] {
       });
     } else if (linkUrl != null && linkText != null) {
       elements.push({ type: "link", url: linkUrl, text: linkText });
-    } else if (bareUrl != null) {
+    } else if (bareUrl != null && /^https?:\/\//i.test(bareUrl)) {
       elements.push({ type: "link", url: bareUrl });
+    } else if (bareUrl != null) {
+      elements.push({ type: "text", text: `<${bareUrl}>` });
     } else if (bareUserId != null) {
       elements.push({ type: "user", user_id: bareUserId });
     } else if (bareBroadcast != null) {
@@ -112,10 +118,14 @@ export function parseInlineElements(text: string): InlineElement[] {
  * lists are detected. Returns `null` when the text contains no lists,
  * so the caller can fall back to plain `text`.
  */
-export function textToRichTextBlocks(text: string): RichTextBlock[] | null {
+export function textToRichTextBlocks(
+  text: string,
+  options: TextToRichTextBlocksOptions = {},
+): RichTextBlock[] | null {
   const lines = text.split("\n");
   const elements: RichTextElement[] = [];
   let hasLists = false;
+  let hasFormatting = false;
   let idx = 0;
 
   while (idx < lines.length) {
@@ -136,6 +146,7 @@ export function textToRichTextBlocks(text: string): RichTextBlock[] | null {
         type: "rich_text_preformatted",
         elements: [{ type: "text", text: codeLines.join("\n") }],
       });
+      hasFormatting = true;
       continue;
     }
 
@@ -155,6 +166,7 @@ export function textToRichTextBlocks(text: string): RichTextBlock[] | null {
         type: "rich_text_quote",
         elements: parseInlineElements(quoteLines.join("\n")),
       });
+      hasFormatting = true;
       continue;
     }
 
@@ -189,18 +201,26 @@ export function textToRichTextBlocks(text: string): RichTextBlock[] | null {
     }
     const content = textLines.join("\n");
     if (content.trim()) {
+      const inlineElements = parseInlineElements(content.endsWith("\n") ? content : `${content}\n`);
+      if (hasRichInlineFormatting(inlineElements)) {
+        hasFormatting = true;
+      }
       elements.push({
         type: "rich_text_section",
-        elements: parseInlineElements(content.endsWith("\n") ? content : `${content}\n`),
+        elements: inlineElements,
       });
     }
   }
 
-  if (!hasLists) {
+  if (!hasLists && !(options.includeInlineFormatting && hasFormatting)) {
     return null;
   }
 
   return [{ type: "rich_text", elements }];
+}
+
+function hasRichInlineFormatting(elements: InlineElement[]): boolean {
+  return elements.some((element) => element.type !== "text" || Boolean(element.style));
 }
 
 function collectList(input: {

--- a/test/message-send.test.ts
+++ b/test/message-send.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { CliContext } from "../src/cli/context.ts";
-import { sendMessage } from "../src/cli/message-actions.ts";
+import { editMessage, sendMessage } from "../src/cli/message-actions.ts";
 
 function createContext(calls: { method: string; params: Record<string, unknown> }[]) {
   const client = {
@@ -350,5 +350,116 @@ describe("sendMessage", () => {
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
+  });
+});
+
+describe("editMessage", () => {
+  test("edits a normal text message without blocks", async () => {
+    const calls: { method: string; params: Record<string, unknown> }[] = [];
+    const ctx = createContext(calls);
+
+    await editMessage({
+      ctx,
+      targetInput: "C12345678",
+      text: "hello",
+      options: { workspace: "https://workspace.slack.com", ts: "1770165109.628379" },
+    });
+
+    expect(calls).toEqual([
+      {
+        method: "chat.update",
+        params: {
+          channel: "C12345678",
+          ts: "1770165109.628379",
+          text: "hello",
+        },
+      },
+    ]);
+  });
+
+  test("edits literal angle bracket text without blocks", async () => {
+    const calls: { method: string; params: Record<string, unknown> }[] = [];
+    const ctx = createContext(calls);
+
+    await editMessage({
+      ctx,
+      targetInput: "C12345678",
+      text: "please use <fix>",
+      options: { workspace: "https://workspace.slack.com", ts: "1770165109.628379" },
+    });
+
+    expect(calls).toEqual([
+      {
+        method: "chat.update",
+        params: {
+          channel: "C12345678",
+          ts: "1770165109.628379",
+          text: "please use &lt;fix&gt;",
+        },
+      },
+    ]);
+  });
+
+  test("edits a message URL with rich text blocks when text contains a link label", async () => {
+    const calls: { method: string; params: Record<string, unknown> }[] = [];
+    const ctx = createContext(calls);
+
+    await editMessage({
+      ctx,
+      targetInput: "https://workspace.slack.com/archives/C12345678/p1770165109628379",
+      text: "Visit <https://example.com|Example>",
+      options: {},
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.method).toBe("chat.update");
+    expect(calls[0]?.params.channel).toBe("C12345678");
+    expect(calls[0]?.params.ts).toBe("1770165109.628379");
+    expect(calls[0]?.params.text).toBe("Visit <https://example.com|Example>");
+    expect(calls[0]?.params.blocks).toEqual([
+      {
+        type: "rich_text",
+        elements: [
+          {
+            type: "rich_text_section",
+            elements: [
+              { type: "text", text: "Visit " },
+              { type: "link", url: "https://example.com", text: "Example" },
+              { type: "text", text: "\n" },
+            ],
+          },
+        ],
+      },
+    ]);
+  });
+
+  test("edits a channel target with rich text blocks when text contains formatting", async () => {
+    const calls: { method: string; params: Record<string, unknown> }[] = [];
+    const ctx = createContext(calls);
+
+    await editMessage({
+      ctx,
+      targetInput: "C12345678",
+      text: "Update *now*",
+      options: { workspace: "https://workspace.slack.com", ts: "1770165109.628379" },
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.method).toBe("chat.update");
+    expect(calls[0]?.params.blocks).toEqual([
+      {
+        type: "rich_text",
+        elements: [
+          {
+            type: "rich_text_section",
+            elements: [
+              { type: "text", text: "Update " },
+              { type: "text", text: "now", style: { bold: true } },
+              { type: "text", text: "\n" },
+            ],
+          },
+        ],
+      },
+    ]);
   });
 });

--- a/test/rich-text.test.ts
+++ b/test/rich-text.test.ts
@@ -47,11 +47,61 @@ describe("parseInlineElements", () => {
       { type: "link", url: "https://example.com" },
     ]);
   });
+
+  test("non-url angle bracket text is preserved as text", () => {
+    expect(parseInlineElements("Use <fix>")).toEqual([
+      { type: "text", text: "Use " },
+      { type: "text", text: "<fix>" },
+    ]);
+  });
 });
 
 describe("textToRichTextBlocks", () => {
   test("plain text returns null", () => {
     expect(textToRichTextBlocks("Hello world")).toBeNull();
+  });
+
+  test("inline-only formatting returns null by default", () => {
+    expect(textToRichTextBlocks("Visit <https://example.com|Example>")).toBeNull();
+  });
+
+  test("non-url angle bracket text does not trigger rich text blocks", () => {
+    expect(textToRichTextBlocks("Use <fix>", { includeInlineFormatting: true })).toBeNull();
+  });
+
+  test("mixed non-url angle bracket text and formatting preserves brackets", () => {
+    const result = textToRichTextBlocks("Use <fix> and *bold*", {
+      includeInlineFormatting: true,
+    })!;
+    expect(result[0]!.elements).toEqual([
+      {
+        type: "rich_text_section",
+        elements: [
+          { type: "text", text: "Use " },
+          { type: "text", text: "<fix>" },
+          { type: "text", text: " and " },
+          { type: "text", text: "bold", style: { bold: true } },
+          { type: "text", text: "\n" },
+        ],
+      },
+    ]);
+  });
+
+  test("inline-only formatting can produce rich text blocks", () => {
+    const result = textToRichTextBlocks("Visit <https://example.com|Example>", {
+      includeInlineFormatting: true,
+    })!;
+    expect(result).not.toBeNull();
+    expect(result[0]!.elements).toEqual([
+      {
+        type: "rich_text_section",
+        elements: [
+          { type: "text", text: "Visit " },
+          { type: "link", url: "https://example.com", text: "Example" },
+          { type: "text", text: "\n" },
+        ],
+      },
+    ]);
   });
 
   test("bullet list with - prefix", () => {


### PR DESCRIPTION
## Summary

Preserves supported rich formatting when editing Slack messages via `chat.update`, without changing plain text edit behavior.

## What changed

- Adds an opt-in mode to the existing rich-text block converter for inline formatting such as links, bold, italic, strike, inline code, mentions, and broadcasts.
- Uses that mode from `message edit` so formatted edits include Slack `rich_text` blocks.
- Keeps plain text edits text-only.
- Keeps existing `message send` behavior unchanged.

## Tests

- Plain text edits do not send `blocks`.
- Literal angle-bracket text such as `<fix>` stays escaped text and does not become blocks.
- Message URL edits with `<https://example.com|label>` send rich-text blocks.
- Channel + timestamp edits with formatting send rich-text blocks.
- Rich-text converter default behavior is unchanged unless the new opt-in flag is used.

Prepared by GPT-5.5 Medium using a custom sub-agent review process.

This change was reviewed by 5 sub-agents:
- 1 decomposition reviewer.
- 1 bailout-gate reviewer for the `chat.update` formatting approach.
- 2 implementation/test/maintainer reviewers.
- 1 follow-up confirmation reviewer for the literal angle-bracket regression fix.
