### PR TITLE
docs: trim file upload examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,17 +235,7 @@ Attach options for `message send`:
 Upload files through `message send`:
 
 ```bash
-# Upload a file without a message
-agent-slack message send "#general" --attach ./report.md
-
-# Upload with an initial comment
 agent-slack message send "#general" "Coverage report" --attach ./report.md
-
-# Upload into a thread
-agent-slack message send "https://workspace.slack.com/archives/C123/p1700000000000000" --attach ./report.md
-
-# Upload multiple files
-agent-slack message send "#general" "Reports" --attach ./report.md --attach ./data.csv
 ```
 
 Example — post a message with a native Slack table block:

--- a/skills/agent-slack/SKILL.md
+++ b/skills/agent-slack/SKILL.md
@@ -164,13 +164,10 @@ Attach options for `message send`:
 - `--attach <path>` upload a local file (repeatable; message text is optional when attaching files)
 - `--blocks <path>` send raw [Block Kit](https://docs.slack.dev/block-kit/) blocks from a JSON file (or `-` for stdin). Enables headers, dividers, table blocks, and other structured layouts. Incompatible with `--attach`.
 
-File upload examples:
+File upload example:
 
 ```bash
-agent-slack message send "general" --attach ./report.md
 agent-slack message send "general" "Coverage report" --attach ./report.md
-agent-slack message send "https://workspace.slack.com/archives/C123/p1700000000000000" --attach ./report.md
-agent-slack message send "general" "Reports" --attach ./report.md --attach ./data.csv
 ```
 
 `message send` returns `channel_id` plus the posted `ts` and a `permalink` (for non-attachment sends). `thread_ts` appears only when replying in a thread.

--- a/skills/agent-slack/references/commands.md
+++ b/skills/agent-slack/references/commands.md
@@ -64,11 +64,7 @@ Run `agent-slack --help` (or `agent-slack <command> --help`) for the full option
   - Otherwise posts to the channel/DM.
   - `[text]` is optional when uploading files with `--attach`; when present, it becomes the initial comment on the first uploaded file.
   - Bullet lists (`- `, `* `, `• `, `1. `, etc.) are automatically converted to Slack’s native rich text format, so recipients see real editable bullets instead of plain-text dashes.
-  - Examples:
-    - `agent-slack message send "general" --attach ./report.md`
-    - `agent-slack message send "general" "Coverage report" --attach ./report.md`
-    - `agent-slack message send "https://workspace.slack.com/archives/C123/p1700000000000000" --attach ./report.md`
-    - `agent-slack message send "general" "Reports" --attach ./report.md --attach ./data.csv`
+  - Example: `agent-slack message send "general" "Coverage report" --attach ./report.md`
   - Options:
     - `--workspace <url-or-unique-substring>` (needed for channel _names_ across multiple workspaces)
     - `--thread-ts <seconds>.<micros>` (optional, channel mode only)


### PR DESCRIPTION
## Summary
- Reduce the file upload documentation block to one example
- Keep the concise note that `--attach` is repeatable and message text is optional
- Trim duplicate examples from README, SKILL.md, and the command reference

## Test plan
- [x] `bun run format:check`