### PR TITLE
feat(message send): add --reply-broadcast flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ agent-slack message edit "#general" "Updated text" --workspace "myteam" --ts "17
 agent-slack message delete "#general" --workspace "myteam" --ts "1770165109.628379"
 ```
 
-Attach options for `message send`:
+Send options for `message send`:
 
 - `--attach <path>` upload a local file (repeatable; `<text>` is optional when attaching files)
 - `--blocks <path>` send raw [Block Kit](https://docs.slack.dev/block-kit/) blocks from a JSON file (or `-` for stdin). Bypasses the automatic markdown-to-rich-text conversion, unlocking header/divider/section/table blocks and other structured layouts. Cannot be combined with `--attach`.

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ Attach options for `message send`:
 
 - `--attach <path>` upload a local file (repeatable; `<text>` is optional when attaching files)
 - `--blocks <path>` send raw [Block Kit](https://docs.slack.dev/block-kit/) blocks from a JSON file (or `-` for stdin). Bypasses the automatic markdown-to-rich-text conversion, unlocking header/divider/section/table blocks and other structured layouts. Cannot be combined with `--attach`.
-- `--reply-broadcast` when replying in a thread, also post the reply to the parent channel (Slack's "Also send to #channel" checkbox). Requires `--thread-ts`; cannot be combined with `--attach`.
+- `--reply-broadcast` when replying in a thread, also post the reply to the parent channel (Slack's "Also send to #channel" checkbox). For channel targets, pair with `--thread-ts`; for URL targets, the thread context is derived from the message. Not supported for DM targets; cannot be combined with `--attach`.
 
 Upload files through `message send`:
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ agent-slack
 ├── message
 │   ├── get   <target>             # fetch 1 message (+ thread meta )
 │   ├── list  <target>             # fetch thread or recent channel messages
-│   ├── send  <target> [text]      # send / reply (supports --attach)
+│   ├── send  <target> [text]      # send / reply (supports --attach, --blocks, --reply-broadcast)
 │   ├── draft <target> [text]      # open Slack-like editor in browser
 │   ├── edit  <target> <text>      # edit a message
 │   ├── delete <target>            # delete a message
@@ -231,11 +231,19 @@ Attach options for `message send`:
 
 - `--attach <path>` upload a local file (repeatable; `<text>` is optional when attaching files)
 - `--blocks <path>` send raw [Block Kit](https://docs.slack.dev/block-kit/) blocks from a JSON file (or `-` for stdin). Bypasses the automatic markdown-to-rich-text conversion, unlocking header/divider/section/table blocks and other structured layouts. Cannot be combined with `--attach`.
+- `--reply-broadcast` when replying in a thread, also post the reply to the parent channel (Slack's "Also send to #channel" checkbox). Requires `--thread-ts`; cannot be combined with `--attach`.
 
 Upload files through `message send`:
 
 ```bash
 agent-slack message send "#general" "Coverage report" --attach ./report.md
+```
+
+Broadcast a thread reply to the parent channel:
+
+```bash
+agent-slack message send "#general" "Decision: shipping v2 today" \
+  --thread-ts "1770160000.000001" --reply-broadcast
 ```
 
 Example — post a message with a native Slack table block:

--- a/skills/agent-slack/SKILL.md
+++ b/skills/agent-slack/SKILL.md
@@ -163,7 +163,7 @@ Attach options for `message send`:
 
 - `--attach <path>` upload a local file (repeatable; message text is optional when attaching files)
 - `--blocks <path>` send raw [Block Kit](https://docs.slack.dev/block-kit/) blocks from a JSON file (or `-` for stdin). Enables headers, dividers, table blocks, and other structured layouts. Incompatible with `--attach`.
-- `--reply-broadcast` when replying in a thread, also post the reply to the parent channel (Slack's "Also send to #channel" checkbox). Requires `--thread-ts`; incompatible with `--attach`.
+- `--reply-broadcast` when replying in a thread, also post the reply to the parent channel (Slack's "Also send to #channel" checkbox). For channel targets, pair with `--thread-ts`; for URL targets, the thread context is derived from the message. Not supported for DM targets; incompatible with `--attach`.
 
 File upload example:
 

--- a/skills/agent-slack/SKILL.md
+++ b/skills/agent-slack/SKILL.md
@@ -163,11 +163,19 @@ Attach options for `message send`:
 
 - `--attach <path>` upload a local file (repeatable; message text is optional when attaching files)
 - `--blocks <path>` send raw [Block Kit](https://docs.slack.dev/block-kit/) blocks from a JSON file (or `-` for stdin). Enables headers, dividers, table blocks, and other structured layouts. Incompatible with `--attach`.
+- `--reply-broadcast` when replying in a thread, also post the reply to the parent channel (Slack's "Also send to #channel" checkbox). Requires `--thread-ts`; incompatible with `--attach`.
 
 File upload example:
 
 ```bash
 agent-slack message send "general" "Coverage report" --attach ./report.md
+```
+
+Thread reply also broadcast to the channel:
+
+```bash
+agent-slack message send "#general" "Decision: shipping v2 today" \
+  --thread-ts "1770160000.000001" --reply-broadcast
 ```
 
 `message send` returns `channel_id` plus the posted `ts` and a `permalink` (for non-attachment sends). `thread_ts` appears only when replying in a thread.

--- a/skills/agent-slack/SKILL.md
+++ b/skills/agent-slack/SKILL.md
@@ -159,7 +159,7 @@ agent-slack message edit "general" "Updated text" --workspace "myteam" --ts "177
 agent-slack message delete "general" --workspace "myteam" --ts "1770165109.628379"
 ```
 
-Attach options for `message send`:
+Send options for `message send`:
 
 - `--attach <path>` upload a local file (repeatable; message text is optional when attaching files)
 - `--blocks <path>` send raw [Block Kit](https://docs.slack.dev/block-kit/) blocks from a JSON file (or `-` for stdin). Enables headers, dividers, table blocks, and other structured layouts. Incompatible with `--attach`.
@@ -174,7 +174,7 @@ agent-slack message send "general" "Coverage report" --attach ./report.md
 Thread reply also broadcast to the channel:
 
 ```bash
-agent-slack message send "#general" "Decision: shipping v2 today" \
+agent-slack message send "general" "Decision: shipping v2 today" \
   --thread-ts "1770160000.000001" --reply-broadcast
 ```
 

--- a/skills/agent-slack/references/commands.md
+++ b/skills/agent-slack/references/commands.md
@@ -70,6 +70,7 @@ Run `agent-slack --help` (or `agent-slack <command> --help`) for the full option
     - `--thread-ts <seconds>.<micros>` (optional, channel mode only)
     - `--attach <path>` (repeatable; upload local files as attachments)
     - `--blocks <path>` raw Block Kit blocks from a JSON file (or `-` for stdin). Bypasses markdown-to-rich-text conversion; enables header/divider/section/table blocks. Cannot be combined with `--attach`.
+    - `--reply-broadcast` when replying in a thread, also post the reply to the parent channel. For channel targets, pair with `--thread-ts`; for URL targets, the thread context is derived from the message. Not supported for DM targets; cannot be combined with `--attach`.
 
 - `agent-slack message edit <target> <text>`
   - URL target edits that exact message.

--- a/src/cli/message-actions.ts
+++ b/src/cli/message-actions.ts
@@ -105,8 +105,17 @@ export async function sendMessage(input: {
   ctx: CliContext;
   targetInput: string;
   text: string;
-  options: { workspace?: string; threadTs?: string; attach?: string[]; blocks?: string };
+  options: {
+    workspace?: string;
+    threadTs?: string;
+    attach?: string[];
+    blocks?: string;
+    replyBroadcast?: boolean;
+  };
 }): Promise<Record<string, unknown>> {
+  if (input.options.replyBroadcast && !input.options.threadTs) {
+    throw new Error("--reply-broadcast requires --thread-ts");
+  }
   const target = parseMsgTarget(String(input.targetInput));
   const formattedText = formatOutboundSlackText(input.text);
   const blocks = input.options.blocks
@@ -174,6 +183,7 @@ export async function sendMessage(input: {
         text: formattedText,
         blocks,
         threadTs: input.options.threadTs ? String(input.options.threadTs) : undefined,
+        replyBroadcast: input.options.replyBroadcast,
         attachPaths,
       });
     },
@@ -200,6 +210,7 @@ async function sendMessageToChannel(input: {
   text: string;
   blocks?: unknown[] | null;
   threadTs?: string;
+  replyBroadcast?: boolean;
   attachPaths: string[];
 }): Promise<Record<string, unknown>> {
   if (input.attachPaths.length === 0) {
@@ -208,6 +219,7 @@ async function sendMessageToChannel(input: {
       text: input.text,
       thread_ts: input.threadTs,
       ...(input.blocks ? { blocks: input.blocks } : {}),
+      ...(input.replyBroadcast && input.threadTs ? { reply_broadcast: true } : {}),
     });
     const ts = typeof resp.ts === "string" ? resp.ts : undefined;
     const channelId = typeof resp.channel === "string" ? resp.channel : input.channelId;

--- a/src/cli/message-actions.ts
+++ b/src/cli/message-actions.ts
@@ -113,9 +113,6 @@ export async function sendMessage(input: {
     replyBroadcast?: boolean;
   };
 }): Promise<Record<string, unknown>> {
-  if (input.options.replyBroadcast && !input.options.threadTs) {
-    throw new Error("--reply-broadcast requires --thread-ts");
-  }
   const target = parseMsgTarget(String(input.targetInput));
   const formattedText = formatOutboundSlackText(input.text);
   const blocks = input.options.blocks
@@ -141,6 +138,7 @@ export async function sendMessage(input: {
           text: formattedText,
           blocks,
           threadTs,
+          replyBroadcast: input.options.replyBroadcast,
           attachPaths,
         });
       },
@@ -148,6 +146,9 @@ export async function sendMessage(input: {
   }
 
   if (target.kind === "user") {
+    if (input.options.replyBroadcast) {
+      throw new Error("--reply-broadcast is not supported for DM targets");
+    }
     const workspaceUrl = input.ctx.effectiveWorkspaceUrl(input.options.workspace);
     return await input.ctx.withAutoRefresh({
       workspaceUrl,
@@ -166,6 +167,9 @@ export async function sendMessage(input: {
     });
   }
 
+  if (input.options.replyBroadcast && !input.options.threadTs) {
+    throw new Error("--reply-broadcast requires --thread-ts for channel targets");
+  }
   const workspaceUrl = input.ctx.effectiveWorkspaceUrl(input.options.workspace);
   await input.ctx.assertWorkspaceSpecifiedForChannelNames({
     workspaceUrl,

--- a/src/cli/message-command.ts
+++ b/src/cli/message-command.ts
@@ -163,6 +163,10 @@ export function registerMessageCommand(input: { program: Command; ctx: CliContex
       "Workspace selector (full URL or unique substring; needed when using #channel/channel id across multiple workspaces)",
     )
     .option("--thread-ts <ts>", "Thread root ts to post into (optional)")
+    .option(
+      "--reply-broadcast",
+      "Also broadcast this thread reply to the parent channel (requires --thread-ts; cannot be combined with --attach).",
+    )
     .option("--attach <path>", "Attach a local file path (repeatable)", collectOptionValue, [])
     .option(
       "--blocks <path>",
@@ -172,7 +176,13 @@ export function registerMessageCommand(input: { program: Command; ctx: CliContex
       const [targetInput, text, options] = args as [
         string,
         string | undefined,
-        { workspace?: string; threadTs?: string; attach?: string[]; blocks?: string },
+        {
+          workspace?: string;
+          threadTs?: string;
+          attach?: string[];
+          blocks?: string;
+          replyBroadcast?: boolean;
+        },
       ];
       const hasAttach = (options.attach ?? []).length > 0;
       const hasBlocks = options.blocks !== undefined;
@@ -183,6 +193,18 @@ export function registerMessageCommand(input: { program: Command; ctx: CliContex
       }
       if (hasBlocks && hasAttach) {
         console.error("Error: --blocks cannot be combined with --attach.");
+        process.exitCode = 1;
+        return;
+      }
+      if (options.replyBroadcast && hasAttach) {
+        console.error(
+          "Error: --reply-broadcast cannot be combined with --attach (Slack file uploads do not support thread broadcasts).",
+        );
+        process.exitCode = 1;
+        return;
+      }
+      if (options.replyBroadcast && !options.threadTs) {
+        console.error("Error: --reply-broadcast requires --thread-ts.");
         process.exitCode = 1;
         return;
       }

--- a/src/cli/message-command.ts
+++ b/src/cli/message-command.ts
@@ -165,7 +165,7 @@ export function registerMessageCommand(input: { program: Command; ctx: CliContex
     .option("--thread-ts <ts>", "Thread root ts to post into (optional)")
     .option(
       "--reply-broadcast",
-      "Also broadcast this thread reply to the parent channel (requires --thread-ts; cannot be combined with --attach).",
+      "Also broadcast this thread reply to the parent channel (requires thread context; use --thread-ts for channel targets; cannot be combined with --attach).",
     )
     .option("--attach <path>", "Attach a local file path (repeatable)", collectOptionValue, [])
     .option(

--- a/src/cli/message-command.ts
+++ b/src/cli/message-command.ts
@@ -203,11 +203,6 @@ export function registerMessageCommand(input: { program: Command; ctx: CliContex
         process.exitCode = 1;
         return;
       }
-      if (options.replyBroadcast && !options.threadTs) {
-        console.error("Error: --reply-broadcast requires --thread-ts.");
-        process.exitCode = 1;
-        return;
-      }
       try {
         const payload = await sendMessage({
           ctx: input.ctx,

--- a/test/message-send.test.ts
+++ b/test/message-send.test.ts
@@ -186,6 +186,63 @@ describe("sendMessage", () => {
     expect(calls).toHaveLength(0);
   });
 
+  test("--reply-broadcast on a URL target broadcasts using the message's derived thread_ts", async () => {
+    const calls: { method: string; params: Record<string, unknown> }[] = [];
+    const ctx: CliContext = {
+      ...createContext(calls),
+      getClientForWorkspace: async () => ({
+        client: {
+          api: async (method: string, params: Record<string, unknown>) => {
+            calls.push({ method, params });
+            if (method === "conversations.history") {
+              return {
+                ok: true,
+                messages: [
+                  { ts: "1770160500.000100", thread_ts: "1770160000.000001", text: "root" },
+                ],
+              };
+            }
+            if (method === "chat.postMessage") {
+              return { ok: true, channel: String(params.channel), ts: "1770165109.628379" };
+            }
+            return { ok: true };
+          },
+        } as never,
+        auth: { auth_type: "standard", token: "x" as const },
+        workspace_url: "https://workspace.slack.com",
+      }),
+    };
+
+    await sendMessage({
+      ctx,
+      targetInput: "https://workspace.slack.com/archives/C12345678/p1770160500000100",
+      text: "broadcast",
+      options: { replyBroadcast: true },
+    });
+
+    const post = calls.find((c) => c.method === "chat.postMessage");
+    expect(post).toBeDefined();
+    expect(post?.params.reply_broadcast).toBe(true);
+    expect(post?.params.thread_ts).toBe("1770160000.000001");
+  });
+
+  test("--reply-broadcast on a DM target throws (broadcasting is not meaningful for DMs)", async () => {
+    const calls: { method: string; params: Record<string, unknown> }[] = [];
+    const ctx = createContext(calls);
+
+    await expect(
+      sendMessage({
+        ctx,
+        targetInput: "U05BRPTKL6A",
+        text: "hi",
+        options: { threadTs: "1770160000.000001", replyBroadcast: true },
+      }),
+    ).rejects.toThrow(/--reply-broadcast is not supported for DM targets/);
+
+    expect(calls.some((c) => c.method === "chat.postMessage")).toBe(false);
+    expect(calls.some((c) => c.method === "conversations.open")).toBe(false);
+  });
+
   test("--reply-broadcast works alongside --blocks payload", async () => {
     const calls: { method: string; params: Record<string, unknown> }[] = [];
     const ctx = createContext(calls);

--- a/test/message-send.test.ts
+++ b/test/message-send.test.ts
@@ -138,6 +138,88 @@ describe("sendMessage", () => {
     });
   });
 
+  test("--reply-broadcast with --thread-ts sends reply_broadcast: true", async () => {
+    const calls: { method: string; params: Record<string, unknown> }[] = [];
+    const ctx = createContext(calls);
+
+    await sendMessage({
+      ctx,
+      targetInput: "C12345678",
+      text: "shipping today",
+      options: { threadTs: "1770160000.000001", replyBroadcast: true },
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.method).toBe("chat.postMessage");
+    expect(calls[0]?.params.reply_broadcast).toBe(true);
+    expect(calls[0]?.params.thread_ts).toBe("1770160000.000001");
+  });
+
+  test("--reply-broadcast omits the field from chat.postMessage when flag is absent", async () => {
+    const calls: { method: string; params: Record<string, unknown> }[] = [];
+    const ctx = createContext(calls);
+
+    await sendMessage({
+      ctx,
+      targetInput: "C12345678",
+      text: "reply",
+      options: { threadTs: "1770160000.000001" },
+    });
+
+    expect(calls).toHaveLength(1);
+    expect("reply_broadcast" in (calls[0]?.params ?? {})).toBe(false);
+  });
+
+  test("--reply-broadcast without --thread-ts throws", async () => {
+    const calls: { method: string; params: Record<string, unknown> }[] = [];
+    const ctx = createContext(calls);
+
+    await expect(
+      sendMessage({
+        ctx,
+        targetInput: "C12345678",
+        text: "oops",
+        options: { replyBroadcast: true },
+      }),
+    ).rejects.toThrow(/--reply-broadcast requires --thread-ts/);
+
+    expect(calls).toHaveLength(0);
+  });
+
+  test("--reply-broadcast works alongside --blocks payload", async () => {
+    const calls: { method: string; params: Record<string, unknown> }[] = [];
+    const ctx = createContext(calls);
+    const dir = await mkdtemp(join(tmpdir(), "agent-slack-send-test-"));
+    const blocksPath = join(dir, "blocks.json");
+    const blocks = [{ type: "section", text: { type: "mrkdwn", text: "summary" } }];
+    await writeFile(blocksPath, JSON.stringify(blocks));
+
+    try {
+      await sendMessage({
+        ctx,
+        targetInput: "C12345678",
+        text: "fallback",
+        options: {
+          threadTs: "1770160000.000001",
+          replyBroadcast: true,
+          blocks: blocksPath,
+        },
+      });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.method).toBe("chat.postMessage");
+    expect(calls[0]?.params).toEqual({
+      channel: "C12345678",
+      text: "fallback",
+      thread_ts: "1770160000.000001",
+      blocks,
+      reply_broadcast: true,
+    });
+  });
+
   test("uploads attachment and uses message text as initial comment", async () => {
     const calls: { method: string; params: Record<string, unknown> }[] = [];
     const ctx = createContext(calls);


### PR DESCRIPTION
## Summary

Adds a `--reply-broadcast` boolean flag on `message send` so a thread reply can also be broadcast to the parent channel — equivalent to ticking "Also send to #channel" in the Slack UI. Wires Slack's `reply_broadcast` parameter on `chat.postMessage`.

Closes #98.

```bash
agent-slack message send "#general" "Decision: shipping v2 today" \
  --thread-ts "1770160000.000001" --reply-broadcast
```

## Validation

- `--reply-broadcast` requires `--thread-ts` (Slack silently ignores it otherwise; we surface the misuse with a fast-fail error).
- `--reply-broadcast` cannot be combined with `--attach` — file uploads go through `files.completeUploadExternal`, which does not support thread broadcasts. Errors out at the CLI layer for parity with the existing `--blocks` + `--attach` guard.

## Tests

`test/message-send.test.ts` covers:

- Field included as `reply_broadcast: true` when flag set with `--thread-ts`.
- Field omitted entirely (not sent as `false`) when flag absent.
- Throws when `--reply-broadcast` is used without `--thread-ts`.
- Works alongside `--blocks` payloads (orthogonal to the Block Kit path).

All 202 tests pass (`bun test`), `bun run typecheck` and `bun run lint` clean.

## Open questions

- **Flag name:** went with `--reply-broadcast` to mirror Slack's API param. Open to `--broadcast` if you prefer shorter — happy to rename.
- **\`message edit\` parity:** Slack's docs are quiet on whether broadcasted thread replies can be retroactively edited via \`chat.update\`. Deferred for v1; happy to add if you want it.
- **Draft editor (\`message draft\`):** the in-browser draft editor also posts via \`chat.postMessage\` but its UX is interactive; broadcasting from there is a separate UX decision. Not touched here.

## Refs

- Slack API: [\`reply_broadcast\` on \`chat.postMessage\`](https://docs.slack.dev/reference/methods/chat.postMessage)
- Tracking issue: #98

- [x] I have assessed security implications of this change
- [x] I have tested this change (automating where feasible)
- [x] I have updated the documentation (where applicable)