### PR TITLE
Preserve rich formatting on message edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,8 @@ agent-slack message edit "#general" "Updated text" --workspace "myteam" --ts "17
 agent-slack message delete "#general" --workspace "myteam" --ts "1770165109.628379"
 ```
 
+`message edit` keeps inline formatting text-only and converts bullet/numbered lists to Slack native rich text.
+
 Send options for `message send`:
 
 - `--attach <path>` upload a local file (repeatable; `<text>` is optional when attaching files)

--- a/skills/agent-slack/SKILL.md
+++ b/skills/agent-slack/SKILL.md
@@ -166,6 +166,8 @@ agent-slack message edit "general" "Updated text" --workspace "myteam" --ts "177
 agent-slack message delete "general" --workspace "myteam" --ts "1770165109.628379"
 ```
 
+`message edit` keeps inline formatting text-only and converts bullet/numbered lists to Slack native rich text.
+
 Send options for `message send`:
 
 - `--attach <path>` upload a local file (repeatable; message text is optional when attaching files)

--- a/skills/agent-slack/references/commands.md
+++ b/skills/agent-slack/references/commands.md
@@ -76,6 +76,7 @@ Run `agent-slack --help` (or `agent-slack <command> --help`) for the full option
 - `agent-slack message edit <target> <text>`
   - URL target edits that exact message.
   - Channel target requires `--ts`.
+  - Inline formatting is sent as text; bullet/numbered lists are converted to Slack native rich text.
   - Options:
     - `--workspace <url-or-unique-substring>` (needed for channel _names_ across multiple workspaces)
     - `--ts <seconds>.<micros>` (required for channel targets)

--- a/src/cli/message-actions.ts
+++ b/src/cli/message-actions.ts
@@ -284,9 +284,7 @@ export async function editMessage(input: {
   }
   const workspaceUrl = input.ctx.effectiveWorkspaceUrl(input.options.workspace);
   const formattedText = formatOutboundSlackText(input.text);
-  const blocks = input.text
-    ? textToRichTextBlocks(input.text, { includeInlineFormatting: true })
-    : null;
+  const blocks = input.text ? textToRichTextBlocks(input.text) : null;
 
   await input.ctx.withAutoRefresh({
     workspaceUrl: target.kind === "url" ? target.ref.workspace_url : workspaceUrl,

--- a/src/cli/message-actions.ts
+++ b/src/cli/message-actions.ts
@@ -284,6 +284,9 @@ export async function editMessage(input: {
   }
   const workspaceUrl = input.ctx.effectiveWorkspaceUrl(input.options.workspace);
   const formattedText = formatOutboundSlackText(input.text);
+  const blocks = input.text
+    ? textToRichTextBlocks(input.text, { includeInlineFormatting: true })
+    : null;
 
   await input.ctx.withAutoRefresh({
     workspaceUrl: target.kind === "url" ? target.ref.workspace_url : workspaceUrl,
@@ -296,6 +299,7 @@ export async function editMessage(input: {
           channel: ref.channel_id,
           ts: ref.message_ts,
           text: formattedText,
+          ...(blocks ? { blocks } : {}),
         });
         return;
       }
@@ -311,6 +315,7 @@ export async function editMessage(input: {
         channel: channelId,
         ts,
         text: formattedText,
+        ...(blocks ? { blocks } : {}),
       });
     },
   });

--- a/src/slack/format-outbound.ts
+++ b/src/slack/format-outbound.ts
@@ -4,7 +4,8 @@
  * Slack's mrkdwn contract requires:
  *  - literal `&`, `<`, `>` escaped as `&amp;`, `&lt;`, `&gt;`
  *  - user mentions wrapped as `<@U123>`, channel mentions as `<#C123>`,
- *    broadcast mentions as `<!here>` / `<!channel>` / `<!everyone>`
+ *    usergroup mentions as `<!subteam^S123>`, and broadcast mentions as
+ *    `<!here>` / `<!channel>` / `<!everyone>`
  *
  * Humans (and LLMs piping text into the CLI) commonly write `@U123` and
  * raw `&`/`<`/`>` — this helper normalizes that to what Slack expects,
@@ -18,7 +19,7 @@ export function formatOutboundSlackText(text: string): string {
   // Protect already-formatted Slack tokens so `<`/`>` inside them aren't escaped.
   const stash: string[] = [];
   let out = text.replace(
-    /<(?:@[UWB][A-Z0-9]+(?:\|[^>]*)?|#[CG][A-Z0-9]+(?:\|[^>]*)?|![a-zA-Z]+(?:\|[^>]*)?|https?:\/\/[^>]+)>/g,
+    /<(?:@[UWB][A-Z0-9]+(?:\|[^>]*)?|#[CG][A-Z0-9]+(?:\|[^>]*)?|!subteam\^[A-Z0-9]+(?:\|[^>]*)?|![a-zA-Z]+(?:\|[^>]*)?|(?:https?:\/\/|mailto:)[^>]+)>/g,
     (m) => {
       stash.push(m);
       return `\u0000${stash.length - 1}\u0000`;

--- a/src/slack/rich-text.ts
+++ b/src/slack/rich-text.ts
@@ -27,6 +27,10 @@ type RichTextBlock = {
   elements: RichTextElement[];
 };
 
+type TextToRichTextBlocksOptions = {
+  includeInlineFormatting?: boolean;
+};
+
 const BULLET_RE = /^(\s*)[•◦▪▫▸‣●○◆◇\-*]\s+(.*)$/;
 const ORDERED_RE = /^(\s*)\d+[.)]\s+(.*)$/;
 const CODE_BLOCK_START = /^```/;
@@ -86,8 +90,10 @@ export function parseInlineElements(text: string): InlineElement[] {
       });
     } else if (linkUrl != null && linkText != null) {
       elements.push({ type: "link", url: linkUrl, text: linkText });
-    } else if (bareUrl != null) {
+    } else if (bareUrl != null && /^https?:\/\//i.test(bareUrl)) {
       elements.push({ type: "link", url: bareUrl });
+    } else if (bareUrl != null) {
+      elements.push({ type: "text", text: `<${bareUrl}>` });
     } else if (bareUserId != null) {
       elements.push({ type: "user", user_id: bareUserId });
     } else if (bareBroadcast != null) {
@@ -112,10 +118,14 @@ export function parseInlineElements(text: string): InlineElement[] {
  * lists are detected. Returns `null` when the text contains no lists,
  * so the caller can fall back to plain `text`.
  */
-export function textToRichTextBlocks(text: string): RichTextBlock[] | null {
+export function textToRichTextBlocks(
+  text: string,
+  options: TextToRichTextBlocksOptions = {},
+): RichTextBlock[] | null {
   const lines = text.split("\n");
   const elements: RichTextElement[] = [];
   let hasLists = false;
+  let hasFormatting = false;
   let idx = 0;
 
   while (idx < lines.length) {
@@ -136,6 +146,7 @@ export function textToRichTextBlocks(text: string): RichTextBlock[] | null {
         type: "rich_text_preformatted",
         elements: [{ type: "text", text: codeLines.join("\n") }],
       });
+      hasFormatting = true;
       continue;
     }
 
@@ -155,6 +166,7 @@ export function textToRichTextBlocks(text: string): RichTextBlock[] | null {
         type: "rich_text_quote",
         elements: parseInlineElements(quoteLines.join("\n")),
       });
+      hasFormatting = true;
       continue;
     }
 
@@ -189,18 +201,26 @@ export function textToRichTextBlocks(text: string): RichTextBlock[] | null {
     }
     const content = textLines.join("\n");
     if (content.trim()) {
+      const inlineElements = parseInlineElements(content.endsWith("\n") ? content : `${content}\n`);
+      if (hasRichInlineFormatting(inlineElements)) {
+        hasFormatting = true;
+      }
       elements.push({
         type: "rich_text_section",
-        elements: parseInlineElements(content.endsWith("\n") ? content : `${content}\n`),
+        elements: inlineElements,
       });
     }
   }
 
-  if (!hasLists) {
+  if (!hasLists && !(options.includeInlineFormatting && hasFormatting)) {
     return null;
   }
 
   return [{ type: "rich_text", elements }];
+}
+
+function hasRichInlineFormatting(elements: InlineElement[]): boolean {
+  return elements.some((element) => element.type !== "text" || Boolean(element.style));
 }
 
 function collectList(input: {

--- a/src/slack/rich-text.ts
+++ b/src/slack/rich-text.ts
@@ -4,6 +4,8 @@ type InlineElement =
   | { type: "text"; text: string; style?: InlineStyle }
   | { type: "link"; url: string; text?: string; style?: InlineStyle }
   | { type: "user"; user_id: string }
+  | { type: "channel"; channel_id: string }
+  | { type: "usergroup"; usergroup_id: string }
   | { type: "broadcast"; range: "here" | "channel" | "everyone" };
 
 type RichTextElement =
@@ -44,7 +46,7 @@ const BLOCKQUOTE_RE = /^> (.*)$/;
 export function parseInlineElements(text: string): InlineElement[] {
   const elements: InlineElement[] = [];
   const re =
-    /`([^`]+)`|\*([^*]+)\*|_([^_]+)_|~([^~]+)~|<@([UWB][A-Z0-9]+)(?:\|[^>]*)?>|<!(here|channel|everyone)(?:\|[^>]*)?>|<([^>|]+)\|([^>]+)>|<([^>|]+)>|(?:^|(?<=[^A-Za-z0-9_]))@([UWB][A-Z0-9]{6,})\b|(?:^|(?<=[^A-Za-z0-9_]))@(here|channel|everyone)\b/g;
+    /`([^`]+)`|\*([^*]+)\*|_([^_]+)_|~([^~]+)~|<@([UWB][A-Z0-9]+)(?:\|[^>]*)?>|<#([CG][A-Z0-9]+)(?:\|[^>]*)?>|<!subteam\^([A-Z0-9]+)(?:\|[^>]*)?>|<!(here|channel|everyone)(?:\|[^>]*)?>|<([^>|]+)\|([^>]+)>|<([^>|]+)>|(?:^|(?<=[^A-Za-z0-9_]))@([UWB][A-Z0-9]{6,})\b|(?:^|(?<=[^A-Za-z0-9_]))@(here|channel|everyone)\b/g;
   let lastIndex = 0;
   let match: RegExpExecArray | null;
 
@@ -66,6 +68,8 @@ export function parseInlineElements(text: string): InlineElement[] {
       italic,
       strike,
       userToken,
+      channelToken,
+      usergroupToken,
       broadcastToken,
       linkUrl,
       linkText,
@@ -83,14 +87,20 @@ export function parseInlineElements(text: string): InlineElement[] {
       elements.push({ type: "text", text: strike, style: { strike: true } });
     } else if (userToken != null) {
       elements.push({ type: "user", user_id: userToken });
+    } else if (channelToken != null) {
+      elements.push({ type: "channel", channel_id: channelToken });
+    } else if (usergroupToken != null) {
+      elements.push({ type: "usergroup", usergroup_id: usergroupToken });
     } else if (broadcastToken != null) {
       elements.push({
         type: "broadcast",
         range: broadcastToken as "here" | "channel" | "everyone",
       });
-    } else if (linkUrl != null && linkText != null) {
+    } else if (linkUrl != null && linkText != null && isSlackManualLinkUrl(linkUrl)) {
       elements.push({ type: "link", url: linkUrl, text: linkText });
-    } else if (bareUrl != null && /^https?:\/\//i.test(bareUrl)) {
+    } else if (linkUrl != null && linkText != null) {
+      elements.push({ type: "text", text: `<${linkUrl}|${linkText}>` });
+    } else if (bareUrl != null && isSlackManualLinkUrl(bareUrl)) {
       elements.push({ type: "link", url: bareUrl });
     } else if (bareUrl != null) {
       elements.push({ type: "text", text: `<${bareUrl}>` });
@@ -111,6 +121,10 @@ export function parseInlineElements(text: string): InlineElement[] {
   }
 
   return elements.length > 0 ? elements : [{ type: "text", text }];
+}
+
+function isSlackManualLinkUrl(value: string): boolean {
+  return /^(?:https?:\/\/|mailto:)/i.test(value);
 }
 
 /**

--- a/test/format-outbound.test.ts
+++ b/test/format-outbound.test.ts
@@ -14,6 +14,13 @@ describe("formatOutboundSlackText", () => {
     expect(formatOutboundSlackText("hi <@U123456A|nick>!")).toBe("hi <@U123456A|nick>!");
   });
 
+  test("leaves already-formatted usergroup mention tokens alone", () => {
+    expect(formatOutboundSlackText("ping <!subteam^S12345678|@team>")).toBe(
+      "ping <!subteam^S12345678|@team>",
+    );
+    expect(formatOutboundSlackText("ping <!subteam^S12345678>")).toBe("ping <!subteam^S12345678>");
+  });
+
   test("promotes broadcast mentions", () => {
     expect(formatOutboundSlackText("@here ping")).toBe("<!here> ping");
     expect(formatOutboundSlackText("cc @channel and @everyone")).toBe(
@@ -28,6 +35,9 @@ describe("formatOutboundSlackText", () => {
   test("does not escape inside already-formatted Slack tokens", () => {
     expect(formatOutboundSlackText("see <https://example.com|link>")).toBe(
       "see <https://example.com|link>",
+    );
+    expect(formatOutboundSlackText("mail <mailto:bob@example.com|Bob>")).toBe(
+      "mail <mailto:bob@example.com|Bob>",
     );
     expect(formatOutboundSlackText("see <https://a.test/?x=1&y=2>")).toBe(
       "see <https://a.test/?x=1&y=2>",

--- a/test/message-send.test.ts
+++ b/test/message-send.test.ts
@@ -539,7 +539,7 @@ describe("editMessage", () => {
     ]);
   });
 
-  test("edits a message URL with rich text blocks when text contains a link label", async () => {
+  test("edits a message URL with a link label without blocks", async () => {
     const calls: { method: string; params: Record<string, unknown> }[] = [];
     const ctx = createContext(calls);
 
@@ -555,24 +555,44 @@ describe("editMessage", () => {
     expect(calls[0]?.params.channel).toBe("C12345678");
     expect(calls[0]?.params.ts).toBe("1770165109.628379");
     expect(calls[0]?.params.text).toBe("Visit <https://example.com|Example>");
-    expect(calls[0]?.params.blocks).toEqual([
-      {
-        type: "rich_text",
-        elements: [
-          {
-            type: "rich_text_section",
-            elements: [
-              { type: "text", text: "Visit " },
-              { type: "link", url: "https://example.com", text: "Example" },
-              { type: "text", text: "\n" },
-            ],
-          },
-        ],
-      },
-    ]);
+    expect(calls[0]?.params.blocks).toBeUndefined();
   });
 
-  test("edits a channel target with rich text blocks when text contains formatting", async () => {
+  test("edits an inline mailto link without escaping it", async () => {
+    const calls: { method: string; params: Record<string, unknown> }[] = [];
+    const ctx = createContext(calls);
+
+    await editMessage({
+      ctx,
+      targetInput: "C12345678",
+      text: "Email <mailto:bob@example.com|Bob>",
+      options: { workspace: "https://workspace.slack.com", ts: "1770165109.628379" },
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.method).toBe("chat.update");
+    expect(calls[0]?.params.text).toBe("Email <mailto:bob@example.com|Bob>");
+    expect(calls[0]?.params.blocks).toBeUndefined();
+  });
+
+  test("edits an inline usergroup mention without escaping it", async () => {
+    const calls: { method: string; params: Record<string, unknown> }[] = [];
+    const ctx = createContext(calls);
+
+    await editMessage({
+      ctx,
+      targetInput: "C12345678",
+      text: "Ping <!subteam^S12345678|@team>",
+      options: { workspace: "https://workspace.slack.com", ts: "1770165109.628379" },
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.method).toBe("chat.update");
+    expect(calls[0]?.params.text).toBe("Ping <!subteam^S12345678|@team>");
+    expect(calls[0]?.params.blocks).toBeUndefined();
+  });
+
+  test("edits a channel target with inline formatting without blocks", async () => {
     const calls: { method: string; params: Record<string, unknown> }[] = [];
     const ctx = createContext(calls);
 
@@ -585,16 +605,45 @@ describe("editMessage", () => {
 
     expect(calls).toHaveLength(1);
     expect(calls[0]?.method).toBe("chat.update");
+    expect(calls[0]?.params.text).toBe("Update *now*");
+    expect(calls[0]?.params.blocks).toBeUndefined();
+  });
+
+  test("edits a channel target with rich text blocks when text contains a list", async () => {
+    const calls: { method: string; params: Record<string, unknown> }[] = [];
+    const ctx = createContext(calls);
+
+    await editMessage({
+      ctx,
+      targetInput: "C12345678",
+      text: "- Post in <#C87654321|general>\n- Update *now*",
+      options: { workspace: "https://workspace.slack.com", ts: "1770165109.628379" },
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.method).toBe("chat.update");
     expect(calls[0]?.params.blocks).toEqual([
       {
         type: "rich_text",
         elements: [
           {
-            type: "rich_text_section",
+            type: "rich_text_list",
+            style: "bullet",
             elements: [
-              { type: "text", text: "Update " },
-              { type: "text", text: "now", style: { bold: true } },
-              { type: "text", text: "\n" },
+              {
+                type: "rich_text_section",
+                elements: [
+                  { type: "text", text: "Post in " },
+                  { type: "channel", channel_id: "C87654321" },
+                ],
+              },
+              {
+                type: "rich_text_section",
+                elements: [
+                  { type: "text", text: "Update " },
+                  { type: "text", text: "now", style: { bold: true } },
+                ],
+              },
             ],
           },
         ],

--- a/test/message-send.test.ts
+++ b/test/message-send.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { CliContext } from "../src/cli/context.ts";
-import { sendMessage } from "../src/cli/message-actions.ts";
+import { editMessage, sendMessage } from "../src/cli/message-actions.ts";
 
 function createContext(calls: { method: string; params: Record<string, unknown> }[]) {
   const client = {
@@ -489,5 +489,116 @@ describe("sendMessage", () => {
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
+  });
+});
+
+describe("editMessage", () => {
+  test("edits a normal text message without blocks", async () => {
+    const calls: { method: string; params: Record<string, unknown> }[] = [];
+    const ctx = createContext(calls);
+
+    await editMessage({
+      ctx,
+      targetInput: "C12345678",
+      text: "hello",
+      options: { workspace: "https://workspace.slack.com", ts: "1770165109.628379" },
+    });
+
+    expect(calls).toEqual([
+      {
+        method: "chat.update",
+        params: {
+          channel: "C12345678",
+          ts: "1770165109.628379",
+          text: "hello",
+        },
+      },
+    ]);
+  });
+
+  test("edits literal angle bracket text without blocks", async () => {
+    const calls: { method: string; params: Record<string, unknown> }[] = [];
+    const ctx = createContext(calls);
+
+    await editMessage({
+      ctx,
+      targetInput: "C12345678",
+      text: "please use <fix>",
+      options: { workspace: "https://workspace.slack.com", ts: "1770165109.628379" },
+    });
+
+    expect(calls).toEqual([
+      {
+        method: "chat.update",
+        params: {
+          channel: "C12345678",
+          ts: "1770165109.628379",
+          text: "please use &lt;fix&gt;",
+        },
+      },
+    ]);
+  });
+
+  test("edits a message URL with rich text blocks when text contains a link label", async () => {
+    const calls: { method: string; params: Record<string, unknown> }[] = [];
+    const ctx = createContext(calls);
+
+    await editMessage({
+      ctx,
+      targetInput: "https://workspace.slack.com/archives/C12345678/p1770165109628379",
+      text: "Visit <https://example.com|Example>",
+      options: {},
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.method).toBe("chat.update");
+    expect(calls[0]?.params.channel).toBe("C12345678");
+    expect(calls[0]?.params.ts).toBe("1770165109.628379");
+    expect(calls[0]?.params.text).toBe("Visit <https://example.com|Example>");
+    expect(calls[0]?.params.blocks).toEqual([
+      {
+        type: "rich_text",
+        elements: [
+          {
+            type: "rich_text_section",
+            elements: [
+              { type: "text", text: "Visit " },
+              { type: "link", url: "https://example.com", text: "Example" },
+              { type: "text", text: "\n" },
+            ],
+          },
+        ],
+      },
+    ]);
+  });
+
+  test("edits a channel target with rich text blocks when text contains formatting", async () => {
+    const calls: { method: string; params: Record<string, unknown> }[] = [];
+    const ctx = createContext(calls);
+
+    await editMessage({
+      ctx,
+      targetInput: "C12345678",
+      text: "Update *now*",
+      options: { workspace: "https://workspace.slack.com", ts: "1770165109.628379" },
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.method).toBe("chat.update");
+    expect(calls[0]?.params.blocks).toEqual([
+      {
+        type: "rich_text",
+        elements: [
+          {
+            type: "rich_text_section",
+            elements: [
+              { type: "text", text: "Update " },
+              { type: "text", text: "now", style: { bold: true } },
+              { type: "text", text: "\n" },
+            ],
+          },
+        ],
+      },
+    ]);
   });
 });

--- a/test/rich-text.test.ts
+++ b/test/rich-text.test.ts
@@ -47,11 +47,61 @@ describe("parseInlineElements", () => {
       { type: "link", url: "https://example.com" },
     ]);
   });
+
+  test("non-url angle bracket text is preserved as text", () => {
+    expect(parseInlineElements("Use <fix>")).toEqual([
+      { type: "text", text: "Use " },
+      { type: "text", text: "<fix>" },
+    ]);
+  });
 });
 
 describe("textToRichTextBlocks", () => {
   test("plain text returns null", () => {
     expect(textToRichTextBlocks("Hello world")).toBeNull();
+  });
+
+  test("inline-only formatting returns null by default", () => {
+    expect(textToRichTextBlocks("Visit <https://example.com|Example>")).toBeNull();
+  });
+
+  test("non-url angle bracket text does not trigger rich text blocks", () => {
+    expect(textToRichTextBlocks("Use <fix>", { includeInlineFormatting: true })).toBeNull();
+  });
+
+  test("mixed non-url angle bracket text and formatting preserves brackets", () => {
+    const result = textToRichTextBlocks("Use <fix> and *bold*", {
+      includeInlineFormatting: true,
+    })!;
+    expect(result[0]!.elements).toEqual([
+      {
+        type: "rich_text_section",
+        elements: [
+          { type: "text", text: "Use " },
+          { type: "text", text: "<fix>" },
+          { type: "text", text: " and " },
+          { type: "text", text: "bold", style: { bold: true } },
+          { type: "text", text: "\n" },
+        ],
+      },
+    ]);
+  });
+
+  test("inline-only formatting can produce rich text blocks", () => {
+    const result = textToRichTextBlocks("Visit <https://example.com|Example>", {
+      includeInlineFormatting: true,
+    })!;
+    expect(result).not.toBeNull();
+    expect(result[0]!.elements).toEqual([
+      {
+        type: "rich_text_section",
+        elements: [
+          { type: "text", text: "Visit " },
+          { type: "link", url: "https://example.com", text: "Example" },
+          { type: "text", text: "\n" },
+        ],
+      },
+    ]);
   });
 
   test("bullet list with - prefix", () => {

--- a/test/rich-text.test.ts
+++ b/test/rich-text.test.ts
@@ -48,10 +48,38 @@ describe("parseInlineElements", () => {
     ]);
   });
 
+  test("<mailto|label> is parsed as link with text", () => {
+    expect(parseInlineElements("Email <mailto:bob@example.com|Bob>")).toEqual([
+      { type: "text", text: "Email " },
+      { type: "link", url: "mailto:bob@example.com", text: "Bob" },
+    ]);
+  });
+
   test("non-url angle bracket text is preserved as text", () => {
     expect(parseInlineElements("Use <fix>")).toEqual([
       { type: "text", text: "Use " },
       { type: "text", text: "<fix>" },
+    ]);
+  });
+
+  test("non-url labeled angle bracket text is preserved as text", () => {
+    expect(parseInlineElements("Use <fix|label>")).toEqual([
+      { type: "text", text: "Use " },
+      { type: "text", text: "<fix|label>" },
+    ]);
+  });
+
+  test("channel mention tokens are parsed as channel elements", () => {
+    expect(parseInlineElements("See <#C12345678|general>")).toEqual([
+      { type: "text", text: "See " },
+      { type: "channel", channel_id: "C12345678" },
+    ]);
+  });
+
+  test("usergroup mention tokens are parsed as usergroup elements", () => {
+    expect(parseInlineElements("Ping <!subteam^S12345678|@team>")).toEqual([
+      { type: "text", text: "Ping " },
+      { type: "usergroup", usergroup_id: "S12345678" },
     ]);
   });
 });
@@ -67,10 +95,11 @@ describe("textToRichTextBlocks", () => {
 
   test("non-url angle bracket text does not trigger rich text blocks", () => {
     expect(textToRichTextBlocks("Use <fix>", { includeInlineFormatting: true })).toBeNull();
+    expect(textToRichTextBlocks("Use <fix|label>", { includeInlineFormatting: true })).toBeNull();
   });
 
   test("mixed non-url angle bracket text and formatting preserves brackets", () => {
-    const result = textToRichTextBlocks("Use <fix> and *bold*", {
+    const result = textToRichTextBlocks("Use <fix|label> and *bold*", {
       includeInlineFormatting: true,
     })!;
     expect(result[0]!.elements).toEqual([
@@ -78,7 +107,7 @@ describe("textToRichTextBlocks", () => {
         type: "rich_text_section",
         elements: [
           { type: "text", text: "Use " },
-          { type: "text", text: "<fix>" },
+          { type: "text", text: "<fix|label>" },
           { type: "text", text: " and " },
           { type: "text", text: "bold", style: { bold: true } },
           { type: "text", text: "\n" },
@@ -98,6 +127,40 @@ describe("textToRichTextBlocks", () => {
         elements: [
           { type: "text", text: "Visit " },
           { type: "link", url: "https://example.com", text: "Example" },
+          { type: "text", text: "\n" },
+        ],
+      },
+    ]);
+  });
+
+  test("mailto links can produce rich text blocks when inline formatting is included", () => {
+    const result = textToRichTextBlocks("Email <mailto:bob@example.com|Bob>", {
+      includeInlineFormatting: true,
+    })!;
+    expect(result).not.toBeNull();
+    expect(result[0]!.elements).toEqual([
+      {
+        type: "rich_text_section",
+        elements: [
+          { type: "text", text: "Email " },
+          { type: "link", url: "mailto:bob@example.com", text: "Bob" },
+          { type: "text", text: "\n" },
+        ],
+      },
+    ]);
+  });
+
+  test("channel mentions can produce rich text blocks when inline formatting is included", () => {
+    const result = textToRichTextBlocks("See <#C12345678|general>", {
+      includeInlineFormatting: true,
+    })!;
+    expect(result).not.toBeNull();
+    expect(result[0]!.elements).toEqual([
+      {
+        type: "rich_text_section",
+        elements: [
+          { type: "text", text: "See " },
+          { type: "channel", channel_id: "C12345678" },
           { type: "text", text: "\n" },
         ],
       },


### PR DESCRIPTION
Replacement for #93 because maintainer pushes to the contributor fork were rejected with 403 despite maintainerCanModify=true.

This includes the original PR plus review fixes:
- Keep inline-only edits text-only so normal edited-marker behavior is preserved where blocks are not needed.
- Preserve Slack channel/usergroup/broadcast tokens in rich-text conversion.
- Preserve supported manual links, including http(s) and mailto.
- Keep non-URL angle-bracket tokens literal.
- Sync README and bundled agent-slack skill docs.

Validation:
- bun test
- bun run typecheck
- bun run format:check
- bun run lint
- Independent xhigh Codex review: no blocking findings.