### PR TITLE
fix(rich_text): emit emoji elements in lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ agent-slack message edit "#general" "Updated text" --workspace "myteam" --ts "17
 agent-slack message delete "#general" --workspace "myteam" --ts "1770165109.628379"
 ```
 
-`message edit` keeps inline formatting text-only and converts bullet/numbered lists to Slack native rich text.
+`message send` and `message edit` convert bullet/numbered lists to Slack native rich text. Inline mentions, broadcasts, emoji shortcodes, and `<#C...>` channel references inside those lists are preserved as Slack elements.
 
 Send options for `message send`:
 

--- a/skills/agent-slack/SKILL.md
+++ b/skills/agent-slack/SKILL.md
@@ -166,7 +166,7 @@ agent-slack message edit "general" "Updated text" --workspace "myteam" --ts "177
 agent-slack message delete "general" --workspace "myteam" --ts "1770165109.628379"
 ```
 
-`message edit` keeps inline formatting text-only and converts bullet/numbered lists to Slack native rich text.
+`message send` and `message edit` convert bullet/numbered lists to Slack native rich text. Inline mentions, broadcasts, emoji shortcodes, and `<#C...>` channel references inside those lists are preserved as Slack elements.
 
 Send options for `message send`:
 
@@ -189,7 +189,7 @@ agent-slack message send "general" "Decision: shipping v2 today" \
 
 `message send` returns `channel_id` plus the posted `ts` and a `permalink` (for non-attachment sends). `thread_ts` appears only when replying in a thread.
 
-Mentions: just write `@U05BRPTKL6A`, `@here`, `@channel`, or `@everyone` — the CLI converts them to real Slack mention tokens and escapes literal `&`/`<`/`>` in your text. You don't need to wrap IDs yourself.
+Rich inline tokens in native rich-text output: when a message is converted to rich text, just write `@U05BRPTKL6A`, `@here`, `@channel`, `@everyone`, `:rocket:`, or `<#C12345678>` — the CLI converts supported tokens to real Slack elements and escapes literal `&`/`<`/`>` in your text. You don't need to wrap user IDs yourself.
 
 ## List channels + create/invite users
 

--- a/skills/agent-slack/references/commands.md
+++ b/skills/agent-slack/references/commands.md
@@ -64,7 +64,7 @@ Run `agent-slack --help` (or `agent-slack <command> --help`) for the full option
   - If `<target>` is a Slack message URL, replies in that message’s thread.
   - Otherwise posts to the channel/DM.
   - `[text]` is optional when uploading files with `--attach`; when present, it becomes the initial comment on the first uploaded file.
-  - Bullet lists (`- `, `* `, `• `, `1. `, etc.) are automatically converted to Slack’s native rich text format, so recipients see real editable bullets instead of plain-text dashes.
+  - Bullet lists (`- `, `* `, `• `, `1. `, etc.) are automatically converted to Slack’s native rich text format, so recipients see real editable bullets instead of plain-text dashes. Inline mentions, broadcasts, emoji shortcodes, and `<#C...>` channel references inside those lists are preserved as Slack elements.
   - Example: `agent-slack message send "general" "Coverage report" --attach ./report.md`
   - Options:
     - `--workspace <url-or-unique-substring>` (needed for channel _names_ across multiple workspaces)
@@ -76,7 +76,7 @@ Run `agent-slack --help` (or `agent-slack <command> --help`) for the full option
 - `agent-slack message edit <target> <text>`
   - URL target edits that exact message.
   - Channel target requires `--ts`.
-  - Inline formatting is sent as text; bullet/numbered lists are converted to Slack native rich text.
+  - Inline formatting is sent as text; bullet/numbered lists are converted to Slack native rich text. Inline mentions, broadcasts, emoji shortcodes, and `<#C...>` channel references inside those lists are preserved as Slack elements.
   - Options:
     - `--workspace <url-or-unique-substring>` (needed for channel _names_ across multiple workspaces)
     - `--ts <seconds>.<micros>` (required for channel targets)

--- a/src/slack/rich-text.ts
+++ b/src/slack/rich-text.ts
@@ -3,6 +3,7 @@ type InlineStyle = { bold?: true; italic?: true; strike?: true; code?: true };
 type InlineElement =
   | { type: "text"; text: string; style?: InlineStyle }
   | { type: "link"; url: string; text?: string; style?: InlineStyle }
+  | { type: "emoji"; name: string }
   | { type: "user"; user_id: string }
   | { type: "channel"; channel_id: string }
   | { type: "usergroup"; usergroup_id: string }
@@ -41,12 +42,12 @@ const BLOCKQUOTE_RE = /^> (.*)$/;
 /**
  * Parse mrkdwn inline formatting into Slack rich_text inline elements.
  *
- * Handles: *bold*, _italic_, ~strike~, `code`, <url|label>, <url>
+ * Handles: *bold*, _italic_, ~strike~, `code`, :emoji:, <url|label>, <url>
  */
 export function parseInlineElements(text: string): InlineElement[] {
   const elements: InlineElement[] = [];
   const re =
-    /`([^`]+)`|\*([^*]+)\*|_([^_]+)_|~([^~]+)~|<@([UWB][A-Z0-9]+)(?:\|[^>]*)?>|<#([CG][A-Z0-9]+)(?:\|[^>]*)?>|<!subteam\^([A-Z0-9]+)(?:\|[^>]*)?>|<!(here|channel|everyone)(?:\|[^>]*)?>|<([^>|]+)\|([^>]+)>|<([^>|]+)>|(?:^|(?<=[^A-Za-z0-9_]))@([UWB][A-Z0-9]{6,})\b|(?:^|(?<=[^A-Za-z0-9_]))@(here|channel|everyone)\b/g;
+    /`([^`]+)`|(?:^|(?<=[^A-Za-z0-9_])):([a-zA-Z0-9_+-]+):(?![A-Za-z0-9_+-])|\*([^*]+)\*|_([^_]+)_|~([^~]+)~|<@([UWB][A-Z0-9]+)(?:\|[^>]*)?>|<#([CG][A-Z0-9]+)(?:\|[^>]*)?>|<!subteam\^([A-Z0-9]+)(?:\|[^>]*)?>|<!(here|channel|everyone)(?:\|[^>]*)?>|<([^>|]+)\|([^>]+)>|<([^>|]+)>|(?:^|(?<=[^A-Za-z0-9_]))@([UWB][A-Z0-9]{6,})\b|(?:^|(?<=[^A-Za-z0-9_]))@(here|channel|everyone)\b/g;
   let lastIndex = 0;
   let match: RegExpExecArray | null;
 
@@ -64,6 +65,7 @@ export function parseInlineElements(text: string): InlineElement[] {
     const [
       ,
       code,
+      emojiName,
       bold,
       italic,
       strike,
@@ -79,6 +81,8 @@ export function parseInlineElements(text: string): InlineElement[] {
     ] = match;
     if (code != null) {
       elements.push({ type: "text", text: code, style: { code: true } });
+    } else if (emojiName != null) {
+      elements.push({ type: "emoji", name: emojiName });
     } else if (bold != null) {
       elements.push({ type: "text", text: bold, style: { bold: true } });
     } else if (italic != null) {

--- a/test/rich-text.test.ts
+++ b/test/rich-text.test.ts
@@ -34,6 +34,25 @@ describe("parseInlineElements", () => {
     ]);
   });
 
+  test(":emoji: shortcode is parsed as an emoji element", () => {
+    expect(parseInlineElements("Launch :rocket: now")).toEqual([
+      { type: "text", text: "Launch " },
+      { type: "emoji", name: "rocket" },
+      { type: "text", text: " now" },
+    ]);
+  });
+
+  test("emoji names with underscores are not parsed as italic text", () => {
+    expect(parseInlineElements(":white_check_mark: all clear")).toEqual([
+      { type: "emoji", name: "white_check_mark" },
+      { type: "text", text: " all clear" },
+    ]);
+  });
+
+  test("time-like colon text is not parsed as an emoji element", () => {
+    expect(parseInlineElements("Time 12:30:00")).toEqual([{ type: "text", text: "Time 12:30:00" }]);
+  });
+
   test("<url|label> is parsed as link with text", () => {
     expect(parseInlineElements("Visit <https://example.com|Example>")).toEqual([
       { type: "text", text: "Visit " },
@@ -71,6 +90,13 @@ describe("parseInlineElements", () => {
 
   test("channel mention tokens are parsed as channel elements", () => {
     expect(parseInlineElements("See <#C12345678|general>")).toEqual([
+      { type: "text", text: "See " },
+      { type: "channel", channel_id: "C12345678" },
+    ]);
+  });
+
+  test("bare channel mention tokens are parsed as channel elements", () => {
+    expect(parseInlineElements("See <#C12345678>")).toEqual([
       { type: "text", text: "See " },
       { type: "channel", channel_id: "C12345678" },
     ]);
@@ -218,6 +244,28 @@ describe("textToRichTextBlocks", () => {
     };
     expect(list.elements[0]!.elements).toEqual([
       { type: "text", text: "Bold item", style: { bold: true } },
+    ]);
+  });
+
+  test("emoji and channel references in list items are parsed", () => {
+    const result = textToRichTextBlocks(
+      "Header:\n- :rocket: launch sequence\n- discuss in <#C0AHR9XAT8B>\n- :white_check_mark: all clear",
+    )!;
+    expect(result).not.toBeNull();
+    const list = result[0]!.elements.find((e) => e.type === "rich_text_list") as {
+      elements: { elements: unknown[] }[];
+    };
+    expect(list.elements[0]!.elements).toEqual([
+      { type: "emoji", name: "rocket" },
+      { type: "text", text: " launch sequence" },
+    ]);
+    expect(list.elements[1]!.elements).toEqual([
+      { type: "text", text: "discuss in " },
+      { type: "channel", channel_id: "C0AHR9XAT8B" },
+    ]);
+    expect(list.elements[2]!.elements).toEqual([
+      { type: "emoji", name: "white_check_mark" },
+      { type: "text", text: " all clear" },
     ]);
   });
 


### PR DESCRIPTION
Refs #90

## Summary
- emit Slack `emoji` inline elements for `:shortcode:` tokens in rich_text conversion
- cover underscore emoji names, bare channel tokens, and list items containing emoji/channel references
- update README and bundled agent-slack skill docs for the preserved inline tokens

## Tests
- `bun test test/rich-text.test.ts`
- `bun test`
- `bun run typecheck`
- `bun run format:check`
- `git diff --check`

`bun run lint` passes with existing warnings outside this change.