### PR TITLE
Support current Windows Store Slack package ID

### DIFF
--- a/src/auth/desktop.ts
+++ b/src/auth/desktop.ts
@@ -55,6 +55,15 @@ const SLACK_SUPPORT_DIR_WIN_APPDATA = join(
   "Slack",
 );
 
+const WINDOWS_STORE_SLACK_PACKAGE_PREFIXES = [
+  "com.tinyspeck.slackdesktop_",
+  "91750D7E.Slack_",
+] as const;
+
+export function isWindowsStoreSlackPackageName(entry: string): boolean {
+  return WINDOWS_STORE_SLACK_PACKAGE_PREFIXES.some((prefix) => entry.startsWith(prefix));
+}
+
 /**
  * Find the Microsoft Store Slack app data directory.
  * The package folder name includes a publisher hash suffix that varies per machine,
@@ -64,7 +73,7 @@ function getWindowsStoreSlackPath(): string | null {
   const pkgBase = join(process.env.LOCALAPPDATA || join(homedir(), "AppData", "Local"), "Packages");
   try {
     const entries = readdirSync(pkgBase);
-    const slackPkg = entries.find((e) => e.startsWith("com.tinyspeck.slackdesktop_"));
+    const slackPkg = entries.find(isWindowsStoreSlackPackageName);
     if (slackPkg) {
       return join(pkgBase, slackPkg, "LocalCache", "Roaming", "Slack");
     }

--- a/test/desktop-auth-paths.test.ts
+++ b/test/desktop-auth-paths.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "bun:test";
+import { isWindowsStoreSlackPackageName } from "../src/auth/desktop.ts";
+
+describe("Windows Store Slack package detection", () => {
+  test("matches known Microsoft Store package identifiers", () => {
+    expect(isWindowsStoreSlackPackageName("com.tinyspeck.slackdesktop_8wekyb3d8bbwe")).toBe(true);
+    expect(isWindowsStoreSlackPackageName("91750D7E.Slack_8she8kybcnzg4")).toBe(true);
+  });
+
+  test("does not match unrelated packages", () => {
+    expect(isWindowsStoreSlackPackageName("com.example.SlackNotes_123")).toBe(false);
+    expect(isWindowsStoreSlackPackageName("91750D7E.SlackBackup_123")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- recognize the current Microsoft Store Slack package prefix (`91750D7E.Slack_`) during desktop auth discovery
- keep support for the existing `com.tinyspeck.slackdesktop_` prefix
- add focused coverage for both known Store package identifiers

## Verification
- `pnpm exec tsc --noEmit`
- `pnpm exec oxlint src/auth/desktop.ts test/desktop-auth-paths.test.ts`

## Notes
This fixes discovery for the Windows Store build observed at `AppData\\Local\\Packages\\91750D7E.Slack_8she8kybcnzg4\\LocalCache\\Roaming\\Slack`.