### PR TITLE
Fix Chrome import for HttpOnly Slack cookie

### DIFF
--- a/src/auth/chrome.ts
+++ b/src/auth/chrome.ts
@@ -1,5 +1,10 @@
-import { execSync } from "node:child_process";
-import { platform } from "node:os";
+import { execFileSync, execSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { readdir } from "node:fs/promises";
+import { homedir, platform } from "node:os";
+import { join } from "node:path";
+import { decryptChromiumCookieValue } from "./chromium-cookie.ts";
+import { copySqliteForRead, queryReadonlySqlite } from "./firefox-profile.ts";
 
 type ChromeExtractedTeam = { url: string; name?: string; token: string };
 
@@ -9,6 +14,7 @@ export type ChromeExtracted = {
 };
 
 const IS_MACOS = platform() === "darwin";
+const CHROME_SUPPORT_DIR = join(homedir(), "Library", "Application Support", "Google", "Chrome");
 
 function escapeOsaScript(script: string): string {
   // osascript -e '...'
@@ -36,6 +42,100 @@ function cookieScript(): string {
       return ""
     end tell
   `;
+}
+
+function getSafeStoragePasswords(): string[] {
+  const services = ["Chrome Safe Storage", "Chromium Safe Storage"];
+  const passwords: string[] = [];
+  for (const service of services) {
+    try {
+      const out = execFileSync("security", ["find-generic-password", "-w", "-s", service], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      }).trim();
+      if (out) {
+        passwords.push(out);
+      }
+    } catch {
+      // continue
+    }
+  }
+  return [...new Set(passwords)];
+}
+
+async function chromeCookieDbCandidates(): Promise<string[]> {
+  if (!existsSync(CHROME_SUPPORT_DIR)) {
+    return [];
+  }
+
+  const entries = await readdir(CHROME_SUPPORT_DIR, { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => join(CHROME_SUPPORT_DIR, entry.name, "Cookies"))
+    .filter((path) => existsSync(path))
+    .sort((a, b) => {
+      const aName = a.split("/").at(-2) ?? "";
+      const bName = b.split("/").at(-2) ?? "";
+      if (aName === "Default") {
+        return -1;
+      }
+      if (bName === "Default") {
+        return 1;
+      }
+      return aName.localeCompare(bName);
+    });
+}
+
+async function extractCookieDFromChromeDb(): Promise<string> {
+  const passwords = getSafeStoragePasswords();
+  if (passwords.length === 0) {
+    return "";
+  }
+
+  for (const dbPath of await chromeCookieDbCandidates()) {
+    const snapshot = await copySqliteForRead(dbPath);
+    try {
+      const rows = (await queryReadonlySqlite(
+        snapshot.copyPath,
+        "select host_key, name, value, encrypted_value from cookies where name = 'd' and host_key like '%slack.com' order by length(encrypted_value) desc",
+      )) as {
+        host_key: string;
+        name: string;
+        value: string;
+        encrypted_value: Uint8Array;
+      }[];
+
+      for (const row of rows) {
+        if (row.value && row.value.startsWith("xoxd-")) {
+          return row.value;
+        }
+
+        const encrypted = Buffer.from(row.encrypted_value || []);
+        if (encrypted.length === 0) {
+          continue;
+        }
+
+        const prefix = encrypted.subarray(0, 3).toString("utf8");
+        const data = prefix === "v10" || prefix === "v11" ? encrypted.subarray(3) : encrypted;
+
+        for (const password of passwords) {
+          try {
+            const decrypted = decryptChromiumCookieValue(data, { password, iterations: 1003 });
+            const match = decrypted.match(/xoxd-[A-Za-z0-9%/+_=.-]+/);
+            if (match) {
+              return match[0]!;
+            }
+          } catch {
+            // continue
+          }
+        }
+      }
+    } finally {
+      await snapshot.cleanup();
+    }
+  }
+
+  return "";
 }
 
 const TEAM_JSON_PATHS = [
@@ -81,12 +181,15 @@ function teamsScript(): string {
   `;
 }
 
-export function extractFromChrome(): ChromeExtracted | null {
+export async function extractFromChrome(): Promise<ChromeExtracted | null> {
   if (!IS_MACOS) {
     return null;
   }
   try {
-    const cookie = osascript(cookieScript());
+    let cookie = osascript(cookieScript());
+    if (!cookie || !cookie.startsWith("xoxd-")) {
+      cookie = await extractCookieDFromChromeDb();
+    }
     if (!cookie || !cookie.startsWith("xoxd-")) {
       return null;
     }

--- a/src/cli/auth-command.ts
+++ b/src/cli/auth-command.ts
@@ -78,7 +78,7 @@ export function registerAuthCommand(input: { program: Command; ctx: CliContext }
     .description("Import xoxc/xoxd from a logged-in Slack tab in Google Chrome (macOS)")
     .action(async () => {
       try {
-        const extracted = input.ctx.importChrome();
+        const extracted = await input.ctx.importChrome();
         if (!extracted) {
           throw new Error(
             "Could not extract tokens from Chrome. Open Slack in Chrome and ensure you're logged in.",

--- a/src/cli/context-client-resolver.ts
+++ b/src/cli/context-client-resolver.ts
@@ -140,7 +140,7 @@ export async function getClientForWorkspace(workspaceUrl?: string): Promise<{
     cookie_d: string;
     teams: { url: string; name?: string; token: string }[];
   }[] = [];
-  const chromeResult = extractFromChrome();
+  const chromeResult = await extractFromChrome();
   if (chromeResult && chromeResult.teams.length > 0) {
     browserSources.push(chromeResult);
   }

--- a/test/channel-command.test.ts
+++ b/test/channel-command.test.ts
@@ -55,7 +55,7 @@ function createContext() {
       teams: [],
       source: { leveldb_path: "", cookies_path: "" },
     }),
-    importChrome: () => ({ cookie_d: "", teams: [] }),
+    importChrome: async () => ({ cookie_d: "", teams: [] }),
     importBrave: async () => null,
     importFirefox: async () => null,
   };

--- a/test/message-send.test.ts
+++ b/test/message-send.test.ts
@@ -87,7 +87,7 @@ function createContext(calls: { method: string; params: Record<string, unknown> 
       teams: [],
       source: { leveldb_path: "", cookies_path: "" },
     }),
-    importChrome: () => ({ cookie_d: "", teams: [] }),
+    importChrome: async () => ({ cookie_d: "", teams: [] }),
     importBrave: async () => null,
     importFirefox: async () => null,
   } satisfies CliContext;

--- a/test/search-command.test.ts
+++ b/test/search-command.test.ts
@@ -100,7 +100,7 @@ function createContext(calls: ApiCall[]): CliContext {
       teams: [],
       source: { leveldb_path: "", cookies_path: "" },
     }),
-    importChrome: () => ({ cookie_d: "", teams: [] }),
+    importChrome: async () => ({ cookie_d: "", teams: [] }),
     importBrave: async () => null,
     importFirefox: async () => null,
   };


### PR DESCRIPTION
## Summary

- Keep the existing Chrome tab/localStorage extraction for `xoxc` team tokens.
- Fall back to Chrome profile cookie databases when the Slack `d` cookie is not visible to page JavaScript.
- Decrypt Chromium `v10`/`v11` cookie values with Chrome Safe Storage, matching the existing Brave importer approach.
- Await Chrome import at CLI call sites because cookie DB access uses the repo's async read-only SQLite helper.

Fixes the Chrome side of #13.

## Why

Recent/current Slack sessions may store `.slack.com` cookie `d` as `HttpOnly`. In that state, this existing Chrome importer path fails even though the user is logged in and AppleScript JavaScript execution works:

```js
document.cookie.split('; ').find(c => c.startsWith('d='))?.split('=')[1] || ''
```

I reproduced this on macOS with `agent-slack 0.9.3`: the Slack tab exposed `localConfig_v2` with an `xoxc-*` team token, while Chrome's Cookies DB contained `.slack.com` cookie `d` with `is_httponly = 1`.

## Verification

- `bun run typecheck`
- `bun test`
- `bun run lint` exits 0; existing warnings remain unrelated
- `bun run format:check`
- `bun run build:npm`
- `bun run src/index.ts auth import-chrome` imported 1 workspace token from my logged-in Chrome Slack session
