### PR TITLE
feat(channel list): add --via-counts flag for Enterprise Grid

### DIFF
--- a/src/cli/channel-command.ts
+++ b/src/cli/channel-command.ts
@@ -3,6 +3,7 @@ import type { CliContext } from "./context.ts";
 import { pruneEmpty } from "../lib/compact-json.ts";
 import {
   listAllConversations,
+  listConversationsViaCounts,
   listUserConversations,
   markConversation,
   resolveChannelId,
@@ -21,6 +22,7 @@ type ChannelListOptions = {
   workspace?: string;
   user?: string;
   all?: boolean;
+  viaCounts?: boolean;
   limit: string;
   cursor?: string;
 };
@@ -39,6 +41,10 @@ export function registerChannelCommand(input: { program: Command; ctx: CliContex
     )
     .option("--user <user>", "User id (U...) or @handle/handle")
     .option("--all", "List all conversations (conversations.list); incompatible with --user")
+    .option(
+      "--via-counts",
+      "List joined conversations via client.counts (works on Enterprise Grid where users.conversations/conversations.list are restricted for browser tokens; incompatible with --all/--user)",
+    )
     .option("--limit <n>", "Max conversations in one page (default 100)", "100")
     .option("--cursor <cursor>", "Pagination cursor for the next page")
     .action(async (...args) => {
@@ -46,6 +52,12 @@ export function registerChannelCommand(input: { program: Command; ctx: CliContex
       try {
         if (options.all && options.user) {
           throw new Error("--all cannot be used with --user");
+        }
+        if (options.viaCounts && options.all) {
+          throw new Error("--via-counts cannot be used with --all");
+        }
+        if (options.viaCounts && options.user) {
+          throw new Error("--via-counts cannot be used with --user");
         }
 
         const limit = Number.parseInt(options.limit, 10);
@@ -58,6 +70,9 @@ export function registerChannelCommand(input: { program: Command; ctx: CliContex
           workspaceUrl,
           work: async () => {
             const { client } = await input.ctx.getClientForWorkspace(workspaceUrl);
+            if (options.viaCounts) {
+              return await listConversationsViaCounts(client, { limit });
+            }
             if (options.all) {
               return await listAllConversations(client, {
                 limit,

--- a/src/slack/channels.ts
+++ b/src/slack/channels.ts
@@ -180,6 +180,58 @@ export async function listAllConversations(
   return normalizeConversationsPage(resp);
 }
 
+/**
+ * Enumerate the current user's joined conversations via `client.counts` +
+ * `conversations.info`.
+ *
+ * This mirrors the slack web client's sidebar method and works on Enterprise
+ * Grid, where `users.conversations` / `conversations.list` return
+ * `enterprise_is_restricted` for browser/session tokens. `client.counts`
+ * returns ids only (no names) split across `channels`, `mpims` and `ims`, so
+ * each id is enriched with `conversations.info` to produce the same
+ * channel-record shape as the other list helpers.
+ *
+ * Limitations vs `users.conversations`: there is no server-side pagination
+ * (`client.counts` returns everything at once and is sliced to `limit`
+ * locally), `--cursor` is not supported, and only the current user's
+ * conversations are available (`--user` is not supported).
+ */
+export async function listConversationsViaCounts(
+  client: SlackApiClient,
+  options?: { limit?: number },
+): Promise<ConversationsPage> {
+  const limit = normalizeConversationsLimit(options?.limit);
+
+  const resp = await client.api("client.counts", {
+    thread_count_by_channel: true,
+  });
+
+  const entries = [
+    ...asArray(resp.channels).filter(isRecord),
+    ...asArray(resp.mpims).filter(isRecord),
+    ...asArray(resp.ims).filter(isRecord),
+  ];
+
+  const ids = entries
+    .map((entry) => getString(entry.id))
+    .filter((id): id is string => Boolean(id))
+    .slice(0, limit);
+
+  const channels = await Promise.all(
+    ids.map(async (id) => {
+      try {
+        const info = await client.api("conversations.info", { channel: id });
+        return isRecord(info.channel) ? info.channel : { id };
+      } catch {
+        // counts may reference a conversation we can't open/info; keep the id
+        return { id };
+      }
+    }),
+  );
+
+  return { channels, next_cursor: undefined };
+}
+
 export function normalizeConversationsPage(resp: Record<string, unknown>): ConversationsPage {
   const channels = asArray(resp.channels).filter(isRecord);
   const meta = isRecord(resp.response_metadata) ? resp.response_metadata : null;

--- a/test/channels.test.ts
+++ b/test/channels.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   listAllConversations,
+  listConversationsViaCounts,
   listUserConversations,
   normalizeConversationsPage,
 } from "../src/slack/channels.ts";
@@ -111,5 +112,84 @@ describe("conversations list helpers", () => {
     });
     // Empty string from getString - falsy so consumers can check `if (page.next_cursor)`
     expect(normalized.next_cursor).toBeFalsy();
+  });
+
+  test("listConversationsViaCounts enumerates channels/mpims/ims and enriches via conversations.info", async () => {
+    const countsResponse = {
+      channels: [{ id: "C1", has_unreads: true }],
+      mpims: [{ id: "G1" }],
+      ims: [{ id: "D1" }],
+    };
+    const calls: { method: string; params: Record<string, unknown> }[] = [];
+    const client = {
+      api: async (method: string, params: Record<string, unknown>) => {
+        calls.push({ method, params });
+        if (method === "client.counts") {
+          return countsResponse;
+        }
+        if (method === "conversations.info") {
+          const id = params.channel as string;
+          return { channel: { id, name: `name-${id}`, is_channel: id.startsWith("C") } };
+        }
+        throw new Error(`unexpected method: ${method}`);
+      },
+    } as unknown as SlackApiClient;
+
+    const page = await listConversationsViaCounts(client, { limit: 100 });
+
+    expect(calls[0]?.method).toBe("client.counts");
+    expect(calls[0]?.params).toEqual({ thread_count_by_channel: true });
+    const infoCalls = calls.filter((c) => c.method === "conversations.info");
+    expect(infoCalls).toHaveLength(3);
+    expect(infoCalls.map((c) => c.params.channel)).toEqual(["C1", "G1", "D1"]);
+    expect(page.next_cursor).toBeUndefined();
+    expect(page.channels).toHaveLength(3);
+    expect(page.channels.map((c) => c.id)).toEqual(["C1", "G1", "D1"]);
+    expect(page.channels[0]?.name).toBe("name-C1");
+  });
+
+  test("listConversationsViaCounts keeps the id when conversations.info fails", async () => {
+    const calls: { method: string; params: Record<string, unknown> }[] = [];
+    const client = {
+      api: async (method: string, params: Record<string, unknown>) => {
+        calls.push({ method, params });
+        if (method === "client.counts") {
+          return { channels: [{ id: "C1" }], mpims: [], ims: [] };
+        }
+        if (method === "conversations.info") {
+          throw new Error("channel_not_found");
+        }
+        throw new Error(`unexpected method: ${method}`);
+      },
+    } as unknown as SlackApiClient;
+
+    const page = await listConversationsViaCounts(client, { limit: 100 });
+    expect(page.channels).toEqual([{ id: "C1" }]);
+  });
+
+  test("listConversationsViaCounts slices to limit and skips entries without an id", async () => {
+    const countsResponse = {
+      channels: [{ id: "C1" }, { no_id: true }, { id: "C2" }, { id: "C3" }],
+      mpims: [],
+      ims: [],
+    };
+    const calls: { method: string; params: Record<string, unknown> }[] = [];
+    const client = {
+      api: async (method: string, params: Record<string, unknown>) => {
+        calls.push({ method, params });
+        if (method === "client.counts") {
+          return countsResponse;
+        }
+        if (method === "conversations.info") {
+          return { channel: { id: params.channel } };
+        }
+        throw new Error(`unexpected method: ${method}`);
+      },
+    } as unknown as SlackApiClient;
+
+    const page = await listConversationsViaCounts(client, { limit: 2 });
+    const infoCalls = calls.filter((c) => c.method === "conversations.info");
+    expect(infoCalls).toHaveLength(2);
+    expect(page.channels.map((c) => c.id)).toEqual(["C1", "C2"]);
   });
 });


### PR DESCRIPTION
## What

`channel list --via-counts` — lists the current user's joined conversations (channels, MPIMs, DMs) with names on Enterprise Grid workspaces, where browser/session tokens can't use `users.conversations`/`conversations.list` (Slack returns `enterprise_is_restricted`).

## Why

On Enterprise Grid, Slack restricts org-wide conversation enumeration (`conversations.list`, `users.conversations`) for browser/session (`xoxc`/`xoxd`) tokens — this is intentional on Slack's side and not something a CLI can route around. The web client builds its sidebar from `client.counts`, which is still permitted and returns every conversation the user has joined (split across `channels`/`mpims`/`ims`, ids only). This PR exposes that same path behind an explicit flag so Grid users can list their joined conversations from the CLI without an admin-approved app token.

`--all` (full workspace enumeration) remains inherently unavailable via browser tokens on Grid — only an app token (`xoxp`) with `conversations:read` can do that. `--via-counts` is therefore incompatible with `--all` and `--user` (`client.counts` is current-user, joined-only, and has no server-side pagination; `--limit` slices locally, `--cursor` is ignored).

## How

- `listConversationsViaCounts` (`src/slack/channels.ts`): calls `client.counts`, collects ids from `channels`/`mpims`/`ims`, enriches each via `conversations.info` (parallelised with `Promise.all`), and returns the same `ConversationsPage` shape as the other list helpers. Keeps `{ id }` if `conversations.info` fails for a given conversation.
- `channel list` (`src/cli/channel-command.ts`) gains `--via-counts`; mutually exclusive with `--all`/`--user`.

## Testing

- `bun run typecheck` — clean
- `bun run lint` — no new warnings/errors (10 pre-existing warnings unchanged)
- `bun run format:check` — clean
- `bun test` — 242 pass, 0 fail (3 new tests for `listConversationsViaCounts`: enumeration + enrichment, info-failure fallback, limit slicing / id-less entries)

## Example

```
$ agent-slack channel list --via-counts
{
  "channels": [
    { "id": "C…", "name": "general", "is_channel": true, … },
    { "id": "G…", "name": "group-dm-name", "is_mpim": true, … },
    { "id": "D…", "name": "alice", "is_im": true, … }
  ]
}
```