### PR TITLE
Fail fast on Slack auth hangs

### DIFF
--- a/src/auth/brave.ts
+++ b/src/auth/brave.ts
@@ -4,6 +4,7 @@ import { homedir, platform } from "node:os";
 import { join } from "node:path";
 import { queryReadonlySqlite } from "./firefox-profile.ts";
 import { decryptChromiumCookieValue } from "./chromium-cookie.ts";
+import { getKeychainTimeoutMs } from "./keychain.ts";
 import { isRecord } from "../lib/object-type-guards.ts";
 
 type BraveExtractedTeam = { url: string; name?: string; token: string };
@@ -136,6 +137,7 @@ function getSafeStoragePasswords(): string[] {
       const out = execFileSync("security", ["find-generic-password", "-w", "-s", service], {
         encoding: "utf8",
         stdio: ["ignore", "pipe", "ignore"],
+        timeout: getKeychainTimeoutMs(),
       }).trim();
       if (out) {
         passwords.push(out);

--- a/src/auth/desktop-crypto.ts
+++ b/src/auth/desktop-crypto.ts
@@ -4,6 +4,7 @@ import { createDecipheriv, randomUUID } from "node:crypto";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { isRecord } from "../lib/object-type-guards.ts";
+import { getKeychainTimeoutMs } from "./keychain.ts";
 
 const IS_MACOS = process.platform === "darwin";
 const IS_LINUX = process.platform === "linux";
@@ -31,6 +32,7 @@ export function getSafeStoragePasswords(prefix: string): string[] {
         const out = execFileSync("security", ["find-generic-password", ...args], {
           encoding: "utf8",
           stdio: ["ignore", "pipe", "ignore"],
+          timeout: getKeychainTimeoutMs(),
         }).trim();
         if (out) {
           passwords.push(out);
@@ -57,6 +59,7 @@ export function getSafeStoragePasswords(prefix: string): string[] {
         const out = execFileSync("secret-tool", ["lookup", ...pair], {
           encoding: "utf8",
           stdio: ["ignore", "pipe", "ignore"],
+          timeout: getKeychainTimeoutMs(),
         }).trim();
         if (out) {
           passwords.push(out);

--- a/src/auth/keychain.ts
+++ b/src/auth/keychain.ts
@@ -2,6 +2,19 @@ import { platform } from "node:os";
 import { execFileSync } from "node:child_process";
 
 const IS_MACOS = platform() === "darwin";
+const DEFAULT_KEYCHAIN_TIMEOUT_MS = 3_000;
+
+export function getKeychainTimeoutMs(): number {
+  const raw = process.env.AGENT_SLACK_KEYCHAIN_TIMEOUT_MS?.trim();
+  if (!raw) {
+    return DEFAULT_KEYCHAIN_TIMEOUT_MS;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_KEYCHAIN_TIMEOUT_MS;
+  }
+  return Math.floor(parsed);
+}
 
 export function keychainGet(account: string, service: string): string | null {
   if (!IS_MACOS) {
@@ -11,7 +24,11 @@ export function keychainGet(account: string, service: string): string | null {
     const result = execFileSync(
       "security",
       ["find-generic-password", "-s", service, "-a", account, "-w"],
-      { encoding: "utf8", stdio: ["pipe", "pipe", "ignore"] },
+      {
+        encoding: "utf8",
+        stdio: ["pipe", "pipe", "ignore"],
+        timeout: getKeychainTimeoutMs(),
+      },
     );
     return result.trim() || null;
   } catch {
@@ -28,12 +45,14 @@ export function keychainSet(input: { account: string; value: string; service: st
     try {
       execFileSync("security", ["delete-generic-password", "-s", service, "-a", account], {
         stdio: ["pipe", "pipe", "ignore"],
+        timeout: getKeychainTimeoutMs(),
       });
     } catch {
       // ignore
     }
     execFileSync("security", ["add-generic-password", "-s", service, "-a", account, "-w", value], {
       stdio: "pipe",
+      timeout: getKeychainTimeoutMs(),
     });
     return true;
   } catch {

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,10 +14,51 @@ import { registerWorkflowCommand } from "./cli/workflow-command.ts";
 import { backgroundUpdateCheck } from "./lib/update.ts";
 
 const program = new Command();
+const DEFAULT_COMMAND_TIMEOUT_MS = 30_000;
+
+function getCommandTimeoutMs(): number {
+  const raw = process.env.AGENT_SLACK_COMMAND_TIMEOUT_MS?.trim();
+  if (!raw) {
+    return DEFAULT_COMMAND_TIMEOUT_MS;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_COMMAND_TIMEOUT_MS;
+  }
+  return Math.floor(parsed);
+}
+
+function shouldStartCommandWatchdog(args: string[]): boolean {
+  const [command, subcommand] = args;
+  if (!command || command === "update") {
+    return false;
+  }
+  if (command === "message" && subcommand === "draft") {
+    return false;
+  }
+  return true;
+}
+
+function startCommandWatchdog(args: string[]): void {
+  if (!shouldStartCommandWatchdog(args)) {
+    return;
+  }
+  const timeoutMs = getCommandTimeoutMs();
+  const timer = setTimeout(() => {
+    console.error(
+      `agent-slack command timed out after ${timeoutMs}ms. Set AGENT_SLACK_COMMAND_TIMEOUT_MS to adjust.`,
+    );
+    process.exit(124);
+  }, timeoutMs);
+  (timer as { unref?: () => void }).unref?.();
+}
+
 program
   .name("agent-slack")
   .description("Slack automation CLI for AI agents")
   .version(getPackageVersion());
+
+startCommandWatchdog(process.argv.slice(2));
 
 const ctx = createCliContext();
 

--- a/src/slack/client.ts
+++ b/src/slack/client.ts
@@ -5,6 +5,70 @@ export type SlackAuth =
   | { auth_type: "standard"; token: string }
   | { auth_type: "browser"; xoxc_token: string; xoxd_cookie: string };
 
+const DEFAULT_SLACK_API_TIMEOUT_MS = 20_000;
+const DEFAULT_SLACK_RATE_LIMIT_MAX_WAIT_MS = 0;
+
+function getSlackApiTimeoutMs(): number {
+  const raw =
+    process.env.AGENT_SLACK_API_TIMEOUT_MS?.trim() || process.env.SLACK_API_TIMEOUT_MS?.trim();
+  if (!raw) {
+    return DEFAULT_SLACK_API_TIMEOUT_MS;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_SLACK_API_TIMEOUT_MS;
+  }
+  return Math.floor(parsed);
+}
+
+function getSlackRateLimitMaxWaitMs(): number {
+  const raw = process.env.AGENT_SLACK_RATE_LIMIT_MAX_WAIT_MS?.trim();
+  if (!raw) {
+    return DEFAULT_SLACK_RATE_LIMIT_MAX_WAIT_MS;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return DEFAULT_SLACK_RATE_LIMIT_MAX_WAIT_MS;
+  }
+  return Math.floor(parsed);
+}
+
+function slackApiTimeoutError(method: string, timeoutMs: number): Error {
+  return new Error(
+    `Slack API call ${method} timed out after ${timeoutMs}ms. Set AGENT_SLACK_API_TIMEOUT_MS to adjust.`,
+  );
+}
+
+function slackRateLimitError(input: {
+  method: string;
+  retryAfterSec: number;
+  maxWaitMs: number;
+}): Error {
+  return new Error(
+    `Slack API call ${input.method} was rate limited; retry-after ${input.retryAfterSec}s exceeds AGENT_SLACK_RATE_LIMIT_MAX_WAIT_MS=${input.maxWaitMs}.`,
+  );
+}
+
+function timeoutSignal(timeoutMs: number): AbortSignal | undefined {
+  return typeof AbortSignal !== "undefined" && typeof AbortSignal.timeout === "function"
+    ? AbortSignal.timeout(timeoutMs)
+    : undefined;
+}
+
+function isAbortOrTimeoutError(error: unknown): boolean {
+  if (!isRecord(error)) {
+    return false;
+  }
+  const name = typeof error.name === "string" ? error.name : "";
+  const code = typeof error.code === "string" ? error.code : "";
+  return (
+    name === "AbortError" ||
+    name === "TimeoutError" ||
+    code === "ABORT_ERR" ||
+    code === "ECONNABORTED"
+  );
+}
+
 export class SlackApiClient {
   private auth: SlackAuth;
   private web?: WebClient;
@@ -14,7 +78,11 @@ export class SlackApiClient {
     this.auth = auth;
     this.workspaceUrl = options?.workspaceUrl;
     if (auth.auth_type === "standard") {
-      this.web = new WebClient(auth.token);
+      this.web = new WebClient(auth.token, {
+        timeout: getSlackApiTimeoutMs(),
+        retryConfig: { retries: 0 },
+        rejectRateLimitedCalls: true,
+      });
     }
   }
 
@@ -43,15 +111,25 @@ export class SlackApiClient {
         fd.append(k, typeof v === "object" ? JSON.stringify(v) : String(v));
       }
     }
-    const response = await fetch(url, {
-      method: "POST",
-      headers: {
-        Cookie: `d=${encodeURIComponent(auth.xoxd_cookie)}`,
-        Origin: "https://app.slack.com",
-        "User-Agent": getUserAgent(),
-      },
-      body: fd,
-    });
+    const timeoutMs = getSlackApiTimeoutMs();
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        method: "POST",
+        headers: {
+          Cookie: `d=${encodeURIComponent(auth.xoxd_cookie)}`,
+          Origin: "https://app.slack.com",
+          "User-Agent": getUserAgent(),
+        },
+        body: fd,
+        signal: timeoutSignal(timeoutMs),
+      });
+    } catch (error) {
+      if (isAbortOrTimeoutError(error)) {
+        throw slackApiTimeoutError(method, timeoutMs);
+      }
+      throw error;
+    }
     const data: unknown = await response.json().catch(() => ({}));
     if (!response.ok) {
       throw new Error(`Slack HTTP ${response.status} calling ${method}`);
@@ -107,20 +185,34 @@ export class SlackApiClient {
       token: input.auth.xoxc_token,
       ...Object.fromEntries(cleanedEntries),
     });
-    const response = await fetch(url, {
-      method: "POST",
-      headers: {
-        Cookie: `d=${encodeURIComponent(input.auth.xoxd_cookie)}`,
-        "Content-Type": "application/x-www-form-urlencoded",
-        Origin: "https://app.slack.com",
-        "User-Agent": getUserAgent(),
-      },
-      body: formBody,
-    });
+    const timeoutMs = getSlackApiTimeoutMs();
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        method: "POST",
+        headers: {
+          Cookie: `d=${encodeURIComponent(input.auth.xoxd_cookie)}`,
+          "Content-Type": "application/x-www-form-urlencoded",
+          Origin: "https://app.slack.com",
+          "User-Agent": getUserAgent(),
+        },
+        body: formBody,
+        signal: timeoutSignal(timeoutMs),
+      });
+    } catch (error) {
+      if (isAbortOrTimeoutError(error)) {
+        throw slackApiTimeoutError(input.method, timeoutMs);
+      }
+      throw error;
+    }
 
     if (response.status === 429 && attempt < 3) {
       const retryAfter = Number(response.headers.get("Retry-After") ?? "5");
       const delayMs = Math.min(Math.max(retryAfter, 1) * 1000, 30000);
+      const maxWaitMs = getSlackRateLimitMaxWaitMs();
+      if (delayMs > maxWaitMs) {
+        throw slackRateLimitError({ method: input.method, retryAfterSec: retryAfter, maxWaitMs });
+      }
       await new Promise((r) => setTimeout(r, delayMs));
       return this.browserApi({
         ...input,

--- a/test/search-files.test.ts
+++ b/test/search-files.test.ts
@@ -6,7 +6,7 @@ import {
   searchFilesInChannelsFallback,
   searchFilesViaSearchApi,
 } from "../src/slack/search-files.ts";
-import type { SlackAuth, SlackApiClient } from "../src/slack/client.ts";
+import { SlackApiClient, type SlackAuth } from "../src/slack/client.ts";
 
 const AUTH: SlackAuth = { auth_type: "standard", token: "xoxb-test" };
 const originalFetch = globalThis.fetch;
@@ -138,5 +138,45 @@ describe("searchFilesInChannelsFallback", () => {
       mimetype: "text/plain",
     });
     expect(result[0]!.path.endsWith("/F2.txt")).toBe(true);
+  });
+});
+
+describe("SlackApiClient browser API guards", () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    delete process.env.AGENT_SLACK_API_TIMEOUT_MS;
+    delete process.env.AGENT_SLACK_RATE_LIMIT_MAX_WAIT_MS;
+  });
+
+  function browserClient(): SlackApiClient {
+    return new SlackApiClient(
+      { auth_type: "browser", xoxc_token: "xoxc-test", xoxd_cookie: "xoxd-test" },
+      { workspaceUrl: "https://example.slack.com" },
+    );
+  }
+
+  test("fails fast on rate-limit retry windows by default", async () => {
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ ok: false, error: "ratelimited" }), {
+        status: 429,
+        headers: { "Retry-After": "5" },
+      })) as unknown as typeof fetch;
+
+    await expect(browserClient().api("auth.test")).rejects.toThrow(
+      "Slack API call auth.test was rate limited",
+    );
+  });
+
+  test("surfaces request timeouts with the Slack method name", async () => {
+    process.env.AGENT_SLACK_API_TIMEOUT_MS = "12";
+    globalThis.fetch = (async () => {
+      const error = new Error("deadline exceeded");
+      error.name = "TimeoutError";
+      throw error;
+    }) as unknown as typeof fetch;
+
+    await expect(browserClient().api("auth.test")).rejects.toThrow(
+      "Slack API call auth.test timed out after 12ms",
+    );
   });
 });


### PR DESCRIPTION
Adds bounded timeouts for agent-facing Slack commands so CLI calls do not hang silently when keychain, Slack API, or rate-limit retry paths stall.

Changes:
- Add Slack API request timeout env override via AGENT_SLACK_API_TIMEOUT_MS.
- Fail fast on browser-auth 429 retry windows by default, with opt-in wait via AGENT_SLACK_RATE_LIMIT_MAX_WAIT_MS.
- Bound macOS keychain / safe-storage subprocess calls via AGENT_SLACK_KEYCHAIN_TIMEOUT_MS.
- Add a non-interactive command watchdog via AGENT_SLACK_COMMAND_TIMEOUT_MS.
- Add regression coverage for browser API timeout and 429 fail-fast behavior.

Validation:
- bun run typecheck
- bun test (241 pass)
- bun run lint (0 errors; existing warnings only)
- bun run format:check
- bun run build:npm
- node --check dist/index.js
- Built CLI smoke against brain-grf4627 auth test/message list now exits quickly with invalid_auth instead of hanging.