### PR TITLE
feat: include status fields in compact user output

### DIFF
--- a/src/slack/users.ts
+++ b/src/slack/users.ts
@@ -12,6 +12,9 @@ export type CompactSlackUser = {
   is_bot?: boolean;
   deleted?: boolean;
   dm_id?: string;
+  status_text?: string;
+  status_emoji?: string;
+  status_expiration?: number;
 };
 
 export async function listUsers(
@@ -231,5 +234,8 @@ export function toCompactUser(u: Record<string, unknown>): CompactSlackUser {
     tz: getString(u.tz) ?? undefined,
     is_bot: typeof u.is_bot === "boolean" ? u.is_bot : undefined,
     deleted: typeof u.deleted === "boolean" ? u.deleted : undefined,
+    status_text: getString(profile.status_text) ?? undefined,
+    status_emoji: getString(profile.status_emoji) ?? undefined,
+    status_expiration: typeof profile.status_expiration === "number" ? profile.status_expiration : undefined,
   };
 }

--- a/src/slack/users.ts
+++ b/src/slack/users.ts
@@ -236,6 +236,7 @@ export function toCompactUser(u: Record<string, unknown>): CompactSlackUser {
     deleted: typeof u.deleted === "boolean" ? u.deleted : undefined,
     status_text: getString(profile.status_text) ?? undefined,
     status_emoji: getString(profile.status_emoji) ?? undefined,
-    status_expiration: typeof profile.status_expiration === "number" ? profile.status_expiration : undefined,
+    status_expiration:
+      typeof profile.status_expiration === "number" ? profile.status_expiration : undefined,
   };
 }


### PR DESCRIPTION
Adds status_text, status_emoji, and status_expiration to CompactSlackUser and toCompactUser() so callers can detect OOO/vacation status.