### PR TITLE
feat(message): Slack-native drafts — message drafts list/create/update/delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ agent-slack
 │   │   ├── list                   # list pending scheduled messages
 │   │   └── cancel <id>            # cancel a pending scheduled message
 │   ├── draft <target> [text]      # open Slack-like editor in browser
+│   ├── drafts
+│   │   ├── list                   # list Slack-native drafts
+│   │   ├── create <target> <text> # create a Slack-native draft
+│   │   ├── update <id> <text>     # replace a draft's text
+│   │   └── delete <id>            # delete a draft
 │   ├── edit  <target> <text>      # edit a message
 │   ├── delete <target>            # delete a message
 │   └── react
@@ -216,6 +221,25 @@ agent-slack message draft "https://workspace.slack.com/archives/C123/p1700000000
 ```
 
 After sending, the editor shows a "View in Slack" link to the posted message.
+
+### Slack-native drafts
+
+Manage drafts through Slack's own drafts API, so they show up natively in the user's Slack client (mobile and desktop) ready to review and send. Requires browser-style auth (xoxc/xoxd).
+
+```bash
+# List unsent drafts
+agent-slack message drafts list
+
+# Draft a message to a channel (shows up in Slack's Drafts section)
+agent-slack message drafts create "#general" "Here's my update"
+
+# Draft a thread reply
+agent-slack message drafts create "https://workspace.slack.com/archives/C123/p1700000000000000" "Looking into it"
+
+# Replace a draft's text, or delete it
+agent-slack message drafts update "DR_ID" "Here's my revised update"
+agent-slack message drafts delete "DR_ID"
+```
 
 ### Reply, edit, delete, and react
 

--- a/skills/agent-slack/SKILL.md
+++ b/skills/agent-slack/SKILL.md
@@ -13,7 +13,7 @@ curl -fsSL https://raw.githubusercontent.com/stablyai/agent-slack/main/install.s
 
 Fallback: `npm i -g agent-slack` (Node >= 22.5).
 
-Safety: read/search freely. Do not send, edit, delete, react, invite, create channels, mark read, schedule, upload, or cancel scheduled messages unless explicitly asked. Prefer `message draft`.
+Safety: read/search freely. Do not send, edit, delete, react, invite, create channels, mark read, schedule, upload, or cancel scheduled messages unless explicitly asked. Prefer `message draft` (interactive editor) or `message drafts create` (Slack-native draft, nothing is posted).
 
 Auth: `agent-slack auth whoami`; if needed `auth import-desktop`, `auth import-brave`, `auth import-chrome`, or `auth import-firefox`, then `auth test`.
 
@@ -25,6 +25,8 @@ agent-slack message list "SLACK_URL"
 agent-slack message list "general" --limit 20
 agent-slack search messages "query" --channel "general"
 agent-slack message draft "general" "text"
+agent-slack message drafts list
+agent-slack message drafts create "general" "text"
 agent-slack message send "URL_OR_CHANNEL" "text" --attach ./file.md
 agent-slack message send "general" "text" --schedule-in "3h"
 agent-slack message scheduled list

--- a/skills/agent-slack/references/commands.md
+++ b/skills/agent-slack/references/commands.md
@@ -92,6 +92,36 @@ Run `agent-slack --help` (or `agent-slack <command> --help`) for the full option
     - `--channel <channel>` required channel/DM id or channel name for the scheduled message
     - `--workspace <url-or-unique-substring>` (needed for channel _names_ across multiple workspaces)
 
+- `agent-slack message drafts list`
+  - Lists Slack-native message drafts (the ones shown in the Slack client's Drafts section). Requires browser-style auth (xoxc/xoxd).
+  - Options:
+    - `--workspace <url-or-unique-substring>` (defaults to configured workspace)
+    - `--limit <n>` max drafts to return
+    - `--all` include sent/inactive drafts
+
+- `agent-slack message drafts create <target> <text>`
+  - Creates a Slack-native draft addressed to a channel, DM, or thread. The draft appears in the user's Slack client ready to review and send — nothing is posted.
+  - If `<target>` is a Slack message URL, the draft is a reply in that message's thread.
+  - Inline formatting and bullet/numbered lists are converted to Slack native rich text.
+  - Options:
+    - `--workspace <url-or-unique-substring>` (needed for channel _names_ across multiple workspaces)
+    - `--thread-ts <seconds>.<micros>` (optional, channel mode only)
+    - `--broadcast` also send the thread reply to the channel when posted (requires thread context)
+
+- `agent-slack message drafts update <draft-id> <text>`
+  - Replaces the draft's text (drafts are replaced whole; destination and attached files are preserved unless overridden).
+  - Options:
+    - `--channel <target>` re-address the draft to a different channel/DM/message URL
+    - `--thread-ts <seconds>.<micros>` (optional)
+    - `--broadcast` (requires thread context)
+    - `--last-updated-ts <ts>` conflict-detection ts (auto-fetched when omitted)
+    - `--workspace <url-or-unique-substring>`
+
+- `agent-slack message drafts delete <draft-id>`
+  - Options:
+    - `--last-updated-ts <ts>` conflict-detection ts (auto-fetched when omitted)
+    - `--workspace <url-or-unique-substring>`
+
 - `agent-slack message edit <target> <text>`
   - URL target edits that exact message.
   - Channel target requires `--ts`.

--- a/src/cli/message-command.ts
+++ b/src/cli/message-command.ts
@@ -11,6 +11,7 @@ import {
 } from "./message-actions.ts";
 import { draftMessage } from "./draft-actions.ts";
 import { registerScheduledMessageCommand } from "./message-scheduled-command.ts";
+import { registerMessageDraftsCommand } from "./message-drafts-command.ts";
 
 function collectOptionValue(value: string, previous: string[] = []): string[] {
   return [...previous, value];
@@ -242,6 +243,7 @@ export function registerMessageCommand(input: { program: Command; ctx: CliContex
     });
 
   registerScheduledMessageCommand({ messageCmd, ctx: input.ctx });
+  registerMessageDraftsCommand({ messageCmd, ctx: input.ctx });
 
   messageCmd
     .command("draft")

--- a/src/cli/message-drafts-actions.ts
+++ b/src/cli/message-drafts-actions.ts
@@ -1,0 +1,255 @@
+import type { CliContext } from "./context.ts";
+import { parseMsgTarget, type MsgTarget } from "./targets.ts";
+import { warnOnTruncatedSlackUrl } from "./message-url-warning.ts";
+import { openDmChannel, resolveChannelId } from "../slack/channels.ts";
+import type { SlackApiClient } from "../slack/client.ts";
+import {
+  createDraft,
+  deleteDraft,
+  findDraft,
+  listDrafts,
+  updateDraft,
+  type SlackDraft,
+} from "../slack/drafts.ts";
+import { fetchMessage } from "../slack/messages.ts";
+import { getString, isRecord } from "../lib/object-type-guards.ts";
+import { normalizeScheduleLimit } from "../slack/scheduled-messages.ts";
+
+export async function listDraftsAction(input: {
+  ctx: CliContext;
+  options: { workspace?: string; limit?: string; all?: boolean };
+}): Promise<Record<string, unknown>> {
+  const workspaceUrl = input.ctx.effectiveWorkspaceUrl(input.options.workspace);
+  return await input.ctx.withAutoRefresh({
+    workspaceUrl,
+    work: async () => {
+      const { client } = await input.ctx.getClientForWorkspace(workspaceUrl);
+      const { drafts } = await listDrafts(client, {
+        limit: normalizeScheduleLimit(input.options.limit),
+        activeOnly: !input.options.all,
+      });
+      const hydrated = await hydrateChannelNames(client, drafts);
+      return { ok: true, drafts: hydrated, count: hydrated.length };
+    },
+  });
+}
+
+export async function createDraftAction(input: {
+  ctx: CliContext;
+  targetInput: string;
+  text: string;
+  options: { workspace?: string; threadTs?: string; broadcast?: boolean };
+}): Promise<Record<string, unknown>> {
+  const target = parseMsgTarget(String(input.targetInput));
+  const workspaceUrl =
+    target.kind === "url"
+      ? target.ref.workspace_url
+      : input.ctx.effectiveWorkspaceUrl(input.options.workspace);
+  if (target.kind === "channel") {
+    await input.ctx.assertWorkspaceSpecifiedForChannelNames({
+      workspaceUrl,
+      channels: [target.channel],
+    });
+  }
+
+  return await input.ctx.withAutoRefresh({
+    workspaceUrl,
+    work: async () => {
+      const { client } = await input.ctx.getClientForWorkspace(workspaceUrl);
+      const { channelId, threadTs } = await resolveDraftDestination(client, {
+        target,
+        threadTs: input.options.threadTs,
+      });
+      if (input.options.broadcast && !threadTs) {
+        throw new Error("--broadcast requires a thread (use --thread-ts or a message URL target).");
+      }
+      const draft = await createDraft(client, {
+        channelId,
+        text: input.text,
+        threadTs,
+        broadcast: input.options.broadcast,
+      });
+      return { ok: true, draft };
+    },
+  });
+}
+
+export async function updateDraftAction(input: {
+  ctx: CliContext;
+  draftId: string;
+  text: string;
+  options: {
+    workspace?: string;
+    channel?: string;
+    threadTs?: string;
+    broadcast?: boolean;
+    lastUpdatedTs?: string;
+  };
+}): Promise<Record<string, unknown>> {
+  const channelTarget = input.options.channel
+    ? parseMsgTarget(String(input.options.channel))
+    : undefined;
+  const workspaceUrl =
+    channelTarget?.kind === "url"
+      ? channelTarget.ref.workspace_url
+      : input.ctx.effectiveWorkspaceUrl(input.options.workspace);
+  if (channelTarget?.kind === "channel") {
+    await input.ctx.assertWorkspaceSpecifiedForChannelNames({
+      workspaceUrl,
+      channels: [channelTarget.channel],
+    });
+  }
+
+  return await input.ctx.withAutoRefresh({
+    workspaceUrl,
+    work: async () => {
+      const { client } = await input.ctx.getClientForWorkspace(workspaceUrl);
+      // drafts.update replaces the whole draft, so start from the existing
+      // one and override only what the caller passed.
+      const existing = await findDraft(client, input.draftId);
+      const lastUpdatedTs = input.options.lastUpdatedTs ?? existing.last_updated_ts;
+      if (!lastUpdatedTs) {
+        throw new Error(`Draft ${input.draftId} has no last_updated_ts; pass --last-updated-ts.`);
+      }
+      const destination = existing.destinations[0];
+      const resolved = channelTarget
+        ? await resolveDraftDestination(client, {
+            target: channelTarget,
+            threadTs: input.options.threadTs,
+          })
+        : {
+            channelId: destination?.channel_id,
+            threadTs: input.options.threadTs ?? destination?.thread_ts,
+          };
+      if (!resolved.channelId) {
+        throw new Error(`Draft ${input.draftId} has no destination; pass --channel.`);
+      }
+      const broadcast = input.options.broadcast ?? destination?.broadcast;
+      if (broadcast && !resolved.threadTs) {
+        throw new Error("--broadcast requires a thread (use --thread-ts).");
+      }
+      const draft = await updateDraft(client, {
+        draftId: input.draftId,
+        clientLastUpdatedTs: lastUpdatedTs,
+        channelId: resolved.channelId,
+        text: input.text,
+        threadTs: resolved.threadTs,
+        broadcast,
+        fileIds: existing.file_ids,
+      });
+      return { ok: true, draft };
+    },
+  });
+}
+
+export async function deleteDraftAction(input: {
+  ctx: CliContext;
+  draftId: string;
+  options: { workspace?: string; lastUpdatedTs?: string };
+}): Promise<Record<string, unknown>> {
+  const workspaceUrl = input.ctx.effectiveWorkspaceUrl(input.options.workspace);
+  return await input.ctx.withAutoRefresh({
+    workspaceUrl,
+    work: async () => {
+      const { client } = await input.ctx.getClientForWorkspace(workspaceUrl);
+      await deleteDraft(client, {
+        draftId: input.draftId,
+        clientLastUpdatedTs: input.options.lastUpdatedTs,
+      });
+      return { ok: true, draft_id: input.draftId };
+    },
+  });
+}
+
+/**
+ * Resolve a draft destination from a CLI target. Message-URL targets draft a
+ * reply into that message's thread (same behavior as `message send`).
+ */
+async function resolveDraftDestination(
+  client: SlackApiClient,
+  input: { target: MsgTarget; threadTs?: string },
+): Promise<{ channelId: string; threadTs?: string }> {
+  const { target } = input;
+  if (target.kind === "url") {
+    warnOnTruncatedSlackUrl(target.ref);
+    const msg = await fetchMessage(client, { ref: target.ref });
+    return {
+      channelId: target.ref.channel_id,
+      threadTs: input.threadTs ?? msg.thread_ts ?? msg.ts,
+    };
+  }
+  if (target.kind === "user") {
+    return {
+      channelId: await openDmChannel(client, target.userId),
+      threadTs: input.threadTs,
+    };
+  }
+  return {
+    channelId: await resolveChannelId(client, target.channel),
+    threadTs: input.threadTs,
+  };
+}
+
+type HydratedDraft = SlackDraft & {
+  destinations: (SlackDraft["destinations"][number] & { channel_name?: string })[];
+};
+
+/** Attach channel/DM display names to draft destinations (best-effort). */
+async function hydrateChannelNames(
+  client: SlackApiClient,
+  drafts: SlackDraft[],
+): Promise<HydratedDraft[]> {
+  const channelIds = [
+    ...new Set(drafts.flatMap((d) => d.destinations.map((dest) => dest.channel_id))),
+  ];
+  const names = new Map<string, string>();
+  await Promise.all(
+    channelIds.map(async (channelId) => {
+      const name = await resolveChannelDisplayName(client, channelId);
+      if (name) {
+        names.set(channelId, name);
+      }
+    }),
+  );
+  return drafts.map((draft) => ({
+    ...draft,
+    destinations: draft.destinations.map((dest) => ({
+      ...dest,
+      channel_name: names.get(dest.channel_id),
+    })),
+  }));
+}
+
+async function resolveChannelDisplayName(
+  client: SlackApiClient,
+  channelId: string,
+): Promise<string | undefined> {
+  try {
+    const info = await client.api("conversations.info", { channel: channelId });
+    const ch = isRecord(info.channel) ? info.channel : null;
+    if (!ch) {
+      return undefined;
+    }
+    const name = getString(ch.name) ?? getString(ch.name_normalized);
+    if (name) {
+      return name;
+    }
+    if (ch.is_im) {
+      const userId = getString(ch.user);
+      if (userId) {
+        const userInfo = await client.api("users.info", { user: userId });
+        const u = isRecord(userInfo.user) ? userInfo.user : null;
+        const profile = u && isRecord(u.profile) ? u.profile : null;
+        return (
+          getString(profile?.display_name) ||
+          getString(u?.real_name) ||
+          getString(u?.name) ||
+          undefined
+        );
+      }
+    }
+  } catch {
+    // best-effort — drafts still list without names
+  }
+  return undefined;
+}

--- a/src/cli/message-drafts-command.ts
+++ b/src/cli/message-drafts-command.ts
@@ -1,0 +1,124 @@
+import type { Command } from "commander";
+import type { CliContext } from "./context.ts";
+import {
+  createDraftAction,
+  deleteDraftAction,
+  listDraftsAction,
+  updateDraftAction,
+} from "./message-drafts-actions.ts";
+
+export function registerMessageDraftsCommand(input: {
+  messageCmd: Command;
+  ctx: CliContext;
+}): void {
+  const draftsCmd = input.messageCmd
+    .command("drafts")
+    .description(
+      "Manage Slack-native message drafts (show up in the user's Slack client; requires browser auth)",
+    );
+
+  draftsCmd
+    .command("list", { isDefault: true })
+    .description("List unsent message drafts")
+    .option("--workspace <url>", "Workspace selector (full URL or unique substring)")
+    .option("--limit <n>", "Max drafts to return")
+    .option("--all", "Include sent/inactive drafts")
+    .action(async (options: { workspace?: string; limit?: string; all?: boolean }) => {
+      try {
+        const payload = await listDraftsAction({ ctx: input.ctx, options });
+        console.log(JSON.stringify(payload, null, 2));
+      } catch (err: unknown) {
+        console.error(input.ctx.errorMessage(err));
+        process.exitCode = 1;
+      }
+    });
+
+  draftsCmd
+    .command("create")
+    .description("Create a Slack-native draft addressed to a channel, DM, or thread")
+    .argument("<target>", "Slack message URL (drafts a thread reply), #name/name, or channel id")
+    .argument("<text>", "Draft message text (mrkdwn format)")
+    .option(
+      "--workspace <url>",
+      "Workspace selector (full URL or unique substring; needed when using #channel/channel id across multiple workspaces)",
+    )
+    .option("--thread-ts <ts>", "Thread root ts to draft a reply into (optional)")
+    .option(
+      "--broadcast",
+      "Also send the thread reply to the channel when posted (requires thread context)",
+    )
+    .action(async (...args) => {
+      const [targetInput, text, options] = args as [
+        string,
+        string,
+        { workspace?: string; threadTs?: string; broadcast?: boolean },
+      ];
+      try {
+        const payload = await createDraftAction({ ctx: input.ctx, targetInput, text, options });
+        console.log(JSON.stringify(payload, null, 2));
+      } catch (err: unknown) {
+        console.error(input.ctx.errorMessage(err));
+        process.exitCode = 1;
+      }
+    });
+
+  draftsCmd
+    .command("update")
+    .description("Replace a draft's text (and optionally re-address it)")
+    .argument("<draft-id>", "Draft id returned by drafts list/create")
+    .argument("<text>", "New draft message text (replaces the existing body)")
+    .option(
+      "--workspace <url>",
+      "Workspace selector (full URL or unique substring; needed when using #channel/channel id across multiple workspaces)",
+    )
+    .option("--channel <target>", "Re-address the draft to a different channel/DM/message URL")
+    .option("--thread-ts <ts>", "Thread root ts to draft a reply into (optional)")
+    .option(
+      "--broadcast",
+      "Also send the thread reply to the channel when posted (requires thread context)",
+    )
+    .option(
+      "--last-updated-ts <ts>",
+      "Draft last_updated_ts for conflict detection (auto-fetched when omitted)",
+    )
+    .action(async (...args) => {
+      const [draftId, text, options] = args as [
+        string,
+        string,
+        {
+          workspace?: string;
+          channel?: string;
+          threadTs?: string;
+          broadcast?: boolean;
+          lastUpdatedTs?: string;
+        },
+      ];
+      try {
+        const payload = await updateDraftAction({ ctx: input.ctx, draftId, text, options });
+        console.log(JSON.stringify(payload, null, 2));
+      } catch (err: unknown) {
+        console.error(input.ctx.errorMessage(err));
+        process.exitCode = 1;
+      }
+    });
+
+  draftsCmd
+    .command("delete")
+    .description("Delete a draft")
+    .argument("<draft-id>", "Draft id returned by drafts list/create")
+    .option("--workspace <url>", "Workspace selector (full URL or unique substring)")
+    .option(
+      "--last-updated-ts <ts>",
+      "Draft last_updated_ts for conflict detection (auto-fetched when omitted)",
+    )
+    .action(async (...args) => {
+      const [draftId, options] = args as [string, { workspace?: string; lastUpdatedTs?: string }];
+      try {
+        const payload = await deleteDraftAction({ ctx: input.ctx, draftId, options });
+        console.log(JSON.stringify(payload, null, 2));
+      } catch (err: unknown) {
+        console.error(input.ctx.errorMessage(err));
+        process.exitCode = 1;
+      }
+    });
+}

--- a/src/slack/drafts.ts
+++ b/src/slack/drafts.ts
@@ -1,0 +1,209 @@
+/**
+ * Slack-native message drafts via the undocumented `drafts.*` session
+ * endpoints (the same API the official Slack clients use). Drafts created
+ * here show up natively in the user's Slack client.
+ *
+ * Requires browser-style auth (xoxc/xoxd); bot/user tokens are rejected by
+ * Slack with `unknown_method` / `not_allowed_token_type`.
+ */
+
+import type { SlackApiClient } from "./client.ts";
+import { asArray, getNumber, getString, isRecord } from "../lib/object-type-guards.ts";
+import { extractMrkdwnFromRichTextBlock } from "./render-rich-text.ts";
+import { parseInlineElements, textToRichTextBlocks } from "./rich-text.ts";
+
+export type DraftDestination = {
+  channel_id: string;
+  thread_ts?: string;
+  broadcast?: boolean;
+};
+
+export type SlackDraft = {
+  id: string;
+  text?: string;
+  destinations: DraftDestination[];
+  last_updated_ts?: string;
+  date_created?: number;
+  date_scheduled?: number;
+  file_ids?: string[];
+};
+
+/**
+ * Pad a draft timestamp's fractional part to 7 digits.
+ * Slack rejects `client_last_updated_ts` values with fewer places
+ * (e.g. "1700000000.123" must be sent as "1700000000.1230000").
+ */
+export function padDraftTs(ts: string): string {
+  const dot = ts.indexOf(".");
+  if (dot === -1) {
+    return ts;
+  }
+  const frac = ts.slice(dot + 1);
+  return `${ts.slice(0, dot)}.${frac.padEnd(7, "0")}`;
+}
+
+/**
+ * Convert draft text to rich_text blocks. Drafts have no plain-text
+ * fallback param, so unformatted text is wrapped in a single section.
+ */
+export function draftTextToBlocks(text: string): unknown[] {
+  const rich = textToRichTextBlocks(text, { includeInlineFormatting: true });
+  if (rich) {
+    return rich;
+  }
+  return [
+    {
+      type: "rich_text",
+      elements: [{ type: "rich_text_section", elements: parseInlineElements(text) }],
+    },
+  ];
+}
+
+export function parseDraftRecord(raw: unknown): SlackDraft | null {
+  if (!isRecord(raw)) {
+    return null;
+  }
+  const id = getString(raw.id);
+  if (!id) {
+    return null;
+  }
+
+  const destinations = asArray(raw.destinations)
+    .filter(isRecord)
+    .flatMap((dest): DraftDestination[] => {
+      const channelId = getString(dest.channel_id);
+      if (!channelId) {
+        return [];
+      }
+      return [
+        {
+          channel_id: channelId,
+          thread_ts: getString(dest.thread_ts) || undefined,
+          broadcast: dest.broadcast === true ? true : undefined,
+        },
+      ];
+    });
+
+  const text = asArray(raw.blocks)
+    .map((block) => extractMrkdwnFromRichTextBlock(block))
+    .filter((t) => t.trim())
+    .join("\n\n")
+    .trim();
+
+  const fileIds = asArray(raw.file_ids).filter(
+    (fileId): fileId is string => typeof fileId === "string",
+  );
+  const dateScheduled = getNumber(raw.date_scheduled);
+
+  return {
+    id,
+    text: text || undefined,
+    destinations,
+    last_updated_ts: getString(raw.last_updated_ts),
+    date_created: getNumber(raw.date_created),
+    date_scheduled: dateScheduled && dateScheduled > 0 ? dateScheduled : undefined,
+    file_ids: fileIds.length > 0 ? fileIds : undefined,
+  };
+}
+
+export async function listDrafts(
+  client: SlackApiClient,
+  options?: { limit?: number; activeOnly?: boolean },
+): Promise<{ drafts: SlackDraft[] }> {
+  const resp = await client.api("drafts.list", {
+    is_active: options?.activeOnly === false ? undefined : true,
+    limit: options?.limit,
+  });
+  const drafts = asArray(resp.drafts)
+    .map(parseDraftRecord)
+    .filter((draft): draft is SlackDraft => draft !== null);
+  return { drafts };
+}
+
+export async function findDraft(client: SlackApiClient, draftId: string): Promise<SlackDraft> {
+  const { drafts } = await listDrafts(client, { activeOnly: false });
+  const draft = drafts.find((d) => d.id === draftId);
+  if (!draft) {
+    throw new Error(`Draft not found: ${draftId}. Run "message drafts list" to see draft ids.`);
+  }
+  return draft;
+}
+
+/**
+ * Shared wire payload for drafts.create / drafts.update: text wrapped as a
+ * rich_text block, addressed to one destination, with a fresh client_msg_id.
+ * `blocks`, `destinations` and `file_ids` are serialized to JSON strings by
+ * the form-encoding client, which is what these endpoints expect.
+ */
+function buildDraftBody(input: {
+  channelId: string;
+  text: string;
+  threadTs?: string;
+  broadcast?: boolean;
+  fileIds?: string[];
+}): Record<string, unknown> {
+  const destination: DraftDestination = { channel_id: input.channelId };
+  if (input.threadTs) {
+    destination.thread_ts = input.threadTs;
+    destination.broadcast = input.broadcast === true;
+  }
+  return {
+    blocks: draftTextToBlocks(input.text),
+    destinations: [destination],
+    client_msg_id: crypto.randomUUID(),
+    file_ids: input.fileIds ?? [],
+  };
+}
+
+export async function createDraft(
+  client: SlackApiClient,
+  input: {
+    channelId: string;
+    text: string;
+    threadTs?: string;
+    broadcast?: boolean;
+  },
+): Promise<SlackDraft | null> {
+  const resp = await client.api("drafts.create", {
+    ...buildDraftBody(input),
+    // Sent on create only, matching the official client's behavior.
+    is_from_composer: true,
+  });
+  return parseDraftRecord(resp.draft);
+}
+
+export async function updateDraft(
+  client: SlackApiClient,
+  input: {
+    draftId: string;
+    clientLastUpdatedTs: string;
+    channelId: string;
+    text: string;
+    threadTs?: string;
+    broadcast?: boolean;
+    fileIds?: string[];
+  },
+): Promise<SlackDraft | null> {
+  const resp = await client.api("drafts.update", {
+    ...buildDraftBody(input),
+    draft_id: input.draftId,
+    client_last_updated_ts: padDraftTs(input.clientLastUpdatedTs),
+  });
+  return parseDraftRecord(resp.draft);
+}
+
+export async function deleteDraft(
+  client: SlackApiClient,
+  input: { draftId: string; clientLastUpdatedTs?: string },
+): Promise<void> {
+  // Slack requires the draft's last-updated ts to detect conflicts; fetch it
+  // when the caller doesn't have one.
+  const ts = input.clientLastUpdatedTs ?? (await findDraft(client, input.draftId)).last_updated_ts;
+  if (!ts) {
+    throw new Error(`Draft ${input.draftId} has no last_updated_ts; cannot delete.`);
+  }
+  await client.api("drafts.delete", {
+    draft_id: input.draftId,
+    client_last_updated_ts: padDraftTs(ts),
+  });
+}

--- a/test/drafts.test.ts
+++ b/test/drafts.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, test } from "bun:test";
+import {
+  createDraft,
+  deleteDraft,
+  draftTextToBlocks,
+  findDraft,
+  listDrafts,
+  padDraftTs,
+  parseDraftRecord,
+  updateDraft,
+} from "../src/slack/drafts.ts";
+import type { SlackApiClient } from "../src/slack/client.ts";
+
+function createClient(responses: Record<string, Record<string, unknown>>) {
+  const calls: { method: string; params: Record<string, unknown> }[] = [];
+  const client = {
+    api: async (method: string, params: Record<string, unknown> = {}) => {
+      calls.push({ method, params });
+      return responses[method] ?? { ok: true };
+    },
+  } as unknown as SlackApiClient;
+  return { client, calls };
+}
+
+const rawDraft = {
+  id: "Dr123",
+  last_updated_ts: "1700000000.123",
+  date_created: 1700000000,
+  destinations: [{ channel_id: "C123", thread_ts: "1699.000100", broadcast: true }],
+  blocks: [
+    {
+      type: "rich_text",
+      elements: [{ type: "rich_text_section", elements: [{ type: "text", text: "hello world" }] }],
+    },
+  ],
+  file_ids: ["F1"],
+  date_scheduled: 0,
+};
+
+describe("padDraftTs", () => {
+  test("pads short fractional parts to 7 digits", () => {
+    expect(padDraftTs("1700000000.123")).toBe("1700000000.1230000");
+  });
+
+  test("leaves 7-digit fractional parts unchanged", () => {
+    expect(padDraftTs("1700000000.1234567")).toBe("1700000000.1234567");
+  });
+
+  test("leaves timestamps without a fractional part unchanged", () => {
+    expect(padDraftTs("1700000000")).toBe("1700000000");
+  });
+});
+
+describe("draftTextToBlocks", () => {
+  test("wraps plain text in a rich_text section", () => {
+    expect(draftTextToBlocks("hello world")).toEqual([
+      {
+        type: "rich_text",
+        elements: [
+          { type: "rich_text_section", elements: [{ type: "text", text: "hello world" }] },
+        ],
+      },
+    ]);
+  });
+
+  test("converts bullet lists to rich_text lists", () => {
+    const blocks = draftTextToBlocks("- one\n- two") as {
+      type: string;
+      elements: { type: string }[];
+    }[];
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]?.elements.some((el) => el.type === "rich_text_list")).toBe(true);
+  });
+});
+
+describe("parseDraftRecord", () => {
+  test("parses a raw draft into a compact shape", () => {
+    expect(parseDraftRecord(rawDraft)).toEqual({
+      id: "Dr123",
+      text: "hello world",
+      destinations: [{ channel_id: "C123", thread_ts: "1699.000100", broadcast: true }],
+      last_updated_ts: "1700000000.123",
+      date_created: 1700000000,
+      date_scheduled: undefined,
+      file_ids: ["F1"],
+    });
+  });
+
+  test("returns null for records without an id", () => {
+    expect(parseDraftRecord({ blocks: [] })).toBeNull();
+    expect(parseDraftRecord(null)).toBeNull();
+  });
+});
+
+describe("listDrafts", () => {
+  test("requests active drafts and parses the result", async () => {
+    const { client, calls } = createClient({
+      "drafts.list": { ok: true, drafts: [rawDraft, { not: "a draft" }] },
+    });
+
+    const result = await listDrafts(client, { limit: 10 });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.method).toBe("drafts.list");
+    expect(calls[0]?.params).toEqual({ is_active: true, limit: 10 });
+    expect(result.drafts).toHaveLength(1);
+    expect(result.drafts[0]?.id).toBe("Dr123");
+  });
+
+  test("omits is_active when activeOnly is false", async () => {
+    const { client, calls } = createClient({ "drafts.list": { ok: true, drafts: [] } });
+
+    await listDrafts(client, { activeOnly: false });
+
+    expect(calls[0]?.params.is_active).toBeUndefined();
+  });
+});
+
+describe("createDraft", () => {
+  test("sends blocks, destination, and composer flag", async () => {
+    const { client, calls } = createClient({
+      "drafts.create": { ok: true, draft: rawDraft },
+    });
+
+    const draft = await createDraft(client, {
+      channelId: "C123",
+      text: "hello",
+      threadTs: "1699.000100",
+      broadcast: true,
+    });
+
+    expect(calls).toHaveLength(1);
+    const { params } = calls[0]!;
+    expect(calls[0]?.method).toBe("drafts.create");
+    expect(params.destinations).toEqual([
+      { channel_id: "C123", thread_ts: "1699.000100", broadcast: true },
+    ]);
+    expect(params.blocks).toEqual([
+      {
+        type: "rich_text",
+        elements: [{ type: "rich_text_section", elements: [{ type: "text", text: "hello" }] }],
+      },
+    ]);
+    expect(params.file_ids).toEqual([]);
+    expect(params.is_from_composer).toBe(true);
+    expect(typeof params.client_msg_id).toBe("string");
+    expect(draft?.id).toBe("Dr123");
+  });
+
+  test("omits thread fields for channel drafts", async () => {
+    const { client, calls } = createClient({ "drafts.create": { ok: true } });
+
+    await createDraft(client, { channelId: "C123", text: "hello" });
+
+    expect(calls[0]?.params.destinations).toEqual([{ channel_id: "C123" }]);
+  });
+});
+
+describe("updateDraft", () => {
+  test("sends draft_id and a padded last-updated ts", async () => {
+    const { client, calls } = createClient({
+      "drafts.update": { ok: true, draft: rawDraft },
+    });
+
+    await updateDraft(client, {
+      draftId: "Dr123",
+      clientLastUpdatedTs: "1700000000.123",
+      channelId: "C123",
+      text: "updated",
+      fileIds: ["F1"],
+    });
+
+    expect(calls).toHaveLength(1);
+    const { params } = calls[0]!;
+    expect(calls[0]?.method).toBe("drafts.update");
+    expect(params.draft_id).toBe("Dr123");
+    expect(params.client_last_updated_ts).toBe("1700000000.1230000");
+    expect(params.file_ids).toEqual(["F1"]);
+    expect(params.is_from_composer).toBeUndefined();
+  });
+});
+
+describe("deleteDraft", () => {
+  test("deletes with an explicit last-updated ts", async () => {
+    const { client, calls } = createClient({ "drafts.delete": { ok: true } });
+
+    await deleteDraft(client, { draftId: "Dr123", clientLastUpdatedTs: "1700000000.123" });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.method).toBe("drafts.delete");
+    expect(calls[0]?.params).toEqual({
+      draft_id: "Dr123",
+      client_last_updated_ts: "1700000000.1230000",
+    });
+  });
+
+  test("fetches the last-updated ts from drafts.list when omitted", async () => {
+    const { client, calls } = createClient({
+      "drafts.list": { ok: true, drafts: [rawDraft] },
+      "drafts.delete": { ok: true },
+    });
+
+    await deleteDraft(client, { draftId: "Dr123" });
+
+    expect(calls.map((c) => c.method)).toEqual(["drafts.list", "drafts.delete"]);
+    expect(calls[1]?.params.client_last_updated_ts).toBe("1700000000.1230000");
+  });
+
+  test("throws when the draft does not exist", async () => {
+    const { client } = createClient({ "drafts.list": { ok: true, drafts: [] } });
+
+    expect(deleteDraft(client, { draftId: "DrMissing" })).rejects.toThrow(
+      "Draft not found: DrMissing",
+    );
+  });
+});
+
+describe("findDraft", () => {
+  test("lists all drafts (including inactive) and finds by id", async () => {
+    const { client, calls } = createClient({
+      "drafts.list": { ok: true, drafts: [rawDraft] },
+    });
+
+    const draft = await findDraft(client, "Dr123");
+
+    expect(draft.id).toBe("Dr123");
+    expect(calls[0]?.params.is_active).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Implements #83 (option 1: separate plural `drafts` subcommand, keeping the existing `message draft` browser editor unchanged).

## What

New `message drafts` subcommand group backed by Slack's undocumented `drafts.*` session endpoints (the same API the official clients use), so agents can read and write drafts that show up natively in the user's Slack client:

```bash
agent-slack message drafts list [--limit <n>] [--all]
agent-slack message drafts create <target> <text> [--thread-ts <ts>] [--broadcast]
agent-slack message drafts update <draft-id> <text> [--channel <target>] [--thread-ts <ts>] [--broadcast] [--last-updated-ts <ts>]
agent-slack message drafts delete <draft-id> [--last-updated-ts <ts>]
```

- `create` accepts the usual targets: `#channel`/name, channel id, user id (opens a DM), or a message URL (drafts a thread reply, same semantics as `message send`).
- Draft text goes through the existing mrkdwn → `rich_text` conversion (`textToRichTextBlocks`), so lists/bold/code/mentions render natively.
- `update` replaces the body but preserves the draft's destination and attached files unless overridden; the conflict-detection `client_last_updated_ts` is auto-fetched for `update`/`delete` when omitted (including Slack's 7-digit fractional-padding quirk).
- `list` resolves channel/DM display names best-effort.
- Requires browser-style auth (xoxc/xoxd), like the other session-endpoint features (`later`, `unreads`); noted in the docs.

## Structure

Follows the `message scheduled` pattern: `src/slack/drafts.ts` (API layer) + `src/cli/message-drafts-actions.ts` / `message-drafts-command.ts` (CLI layer). Docs updated in README, `skills/agent-slack/SKILL.md`, and `references/commands.md`.

## Testing

- 16 unit tests in `test/drafts.test.ts` (wire payloads, ts padding, parsing, auto-fetch/error paths); full suite, typecheck, lint, and format all pass.
- Verified live against a real workspace: create → appears in the Slack client's Drafts → list (with resolved names) → update → delete, including thread-reply drafts via message-URL targets.

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)