### PR TITLE
fix(render): preserve usergroup and broadcast elements

### DIFF
--- a/src/slack/render-rich-text.ts
+++ b/src/slack/render-rich-text.ts
@@ -4,8 +4,14 @@
 
 import { isRecord } from "../lib/object-type-guards.ts";
 
+const ENCODED_ID_PATTERN = /^[A-Z0-9]+$/;
+
 function getString(value: unknown): string {
   return typeof value === "string" ? value : "";
+}
+
+function isSafeEncodedId(value: string): boolean {
+  return ENCODED_ID_PATTERN.test(value);
 }
 
 export function extractMrkdwnFromRichTextBlock(block: unknown): string {
@@ -116,12 +122,22 @@ function extractMrkdwnFromRichTextElement(el: unknown): string {
 
   if (t === "user") {
     const userId = getString(el.user_id);
-    return userId ? `<@${userId}>` : "";
+    return isSafeEncodedId(userId) ? `<@${userId}>` : "";
   }
 
   if (t === "channel") {
     const channelId = getString(el.channel_id);
-    return channelId ? `<#${channelId}>` : "";
+    return isSafeEncodedId(channelId) ? `<#${channelId}>` : "";
+  }
+
+  if (t === "usergroup") {
+    const usergroupId = getString(el.usergroup_id);
+    return isSafeEncodedId(usergroupId) ? `<!subteam^${usergroupId}>` : "";
+  }
+
+  if (t === "broadcast") {
+    const range = getString(el.range);
+    return range === "here" || range === "channel" || range === "everyone" ? `<!${range}>` : "";
   }
 
   return "";

--- a/test/render.test.ts
+++ b/test/render.test.ts
@@ -16,6 +16,64 @@ describe("renderSlackMessageContent", () => {
     expect(rendered).toBe("*Hi*\n[View](https://example.com)");
   });
 
+  test("preserves usergroup and broadcast elements from rich text", () => {
+    const msg = {
+      blocks: [
+        {
+          type: "rich_text",
+          elements: [
+            {
+              type: "rich_text_section",
+              elements: [
+                { type: "text", text: "Notify " },
+                { type: "usergroup", usergroup_id: "S12345678" },
+                { type: "text", text: " and " },
+                { type: "usergroup", usergroup_id: "G123ABC456" },
+                { type: "text", text: " with " },
+                { type: "broadcast", range: "here" },
+                { type: "text", text: ", " },
+                { type: "broadcast", range: "channel" },
+                { type: "text", text: ", and " },
+                { type: "broadcast", range: "everyone" },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(renderSlackMessageContent(msg)).toBe(
+      "Notify <!subteam^S12345678> and <!subteam^G123ABC456> with @here, @channel, and @everyone",
+    );
+  });
+
+  test("omits malformed usergroup and broadcast elements", () => {
+    const msg = {
+      blocks: [
+        {
+          type: "rich_text",
+          elements: [
+            {
+              type: "rich_text_section",
+              elements: [
+                { type: "text", text: "before" },
+                { type: "user", user_id: "U123> [forged](https://evil.example) <" },
+                { type: "channel", channel_id: "C123> [forged](https://evil.example) <" },
+                { type: "usergroup" },
+                { type: "usergroup", usergroup_id: "S123> [forged](https://evil.example) <" },
+                { type: "usergroup", usergroup_id: 12345 },
+                { type: "broadcast", range: "unknown" },
+                { type: "text", text: "after" },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(renderSlackMessageContent(msg)).toBe("beforeafter");
+  });
+
   test("falls back to attachments when text is empty", () => {
     const msg = {
       text: "",


### PR DESCRIPTION
Messages sent through agent-slack can include user-group mentions and broadcasts such as `@here`. Slack stores these as rich-text elements, but when the agent later reads the message back, agent-slack omits them from the returned `content`. The Slack message was delivered correctly, but the agent sees an incomplete version of what it sent. This change preserves those mentions when rendering messages back to the agent.

Co-authored by GPT 5.6-Sol.