### PR TITLE
fix(users): support W-prefixed Slack user IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ agent-slack channel new --name "incident-war-room"
 agent-slack channel new --name "incident-leads" --private
 
 # Invite users by id, handle, or email
-agent-slack channel invite --channel "incident-war-room" --users "U01AAAA,@alice,bob@example.com"
+agent-slack channel invite --channel "incident-war-room" --users "U01234567,@alice,bob@example.com"
 
 # Invite external Slack Connect users by email (restricted by default)
 agent-slack channel invite --channel "incident-war-room" --users "partner@vendor.com" --external
@@ -408,6 +408,8 @@ Tips:
 <!-- AI search (assistant.search.*) is described in design.doc but not currently implemented. -->
 
 ### Users
+
+Treat Slack user IDs beginning with `U` or `W` equivalently.
 
 ```bash
 # List users (email requires appropriate Slack scopes; fields are pruned if missing)

--- a/skills/agent-slack/SKILL.md
+++ b/skills/agent-slack/SKILL.md
@@ -39,9 +39,10 @@ agent-slack user dm-open @alice @bob
 ```
 
 With multiple workspaces, pass `--workspace "team"` or set `SLACK_WORKSPACE_URL`. Attachments include local `path` in JSON.
+Treat Slack user IDs beginning with `U` or `W` equivalently.
 
 For non-trivial usage, read the bundled references:
 
 - [references/commands.md](references/commands.md): command map and flags
-- [references/targets.md](references/targets.md): URL vs channel targeting rules
+- [references/targets.md](references/targets.md): URL, channel, and direct-message targeting rules
 - [references/output.md](references/output.md): JSON shapes and download paths

--- a/skills/agent-slack/references/commands.md
+++ b/skills/agent-slack/references/commands.md
@@ -62,6 +62,7 @@ Run `agent-slack --help` (or `agent-slack <command> --help`) for the full option
 
 - `agent-slack message send <target> [text]`
   - If `<target>` is a Slack message URL, replies in that message’s thread.
+  - A user ID target (`U...` or `W...`) opens or reuses that user's DM.
   - Otherwise posts to the channel/DM.
   - `[text]` is optional when uploading files with `--attach`; when present, it becomes the initial comment on the first uploaded file.
   - Bullet lists (`- `, `* `, `• `, `1. `, etc.) are automatically converted to Slack’s native rich text format, so recipients see real editable bullets instead of plain-text dashes. Inline mentions, broadcasts, emoji shortcodes, and `<#C...>` channel references inside those lists are preserved as Slack elements.
@@ -115,14 +116,14 @@ Run `agent-slack --help` (or `agent-slack <command> --help`) for the full option
 
 ## Channels
 
-- `agent-slack channel list [--workspace <url-or-unique-substring>] [--user <U...|@handle|handle> | --all] [--limit <n>] [--cursor <cursor>]`
+- `agent-slack channel list [--workspace <url-or-unique-substring>] [--user <U...|W...|@handle|handle> | --all] [--limit <n>] [--cursor <cursor>]`
   - Default mode calls `users.conversations` for the current user.
   - `--user` resolves handles/ids and lists conversations for that user.
   - `--all` switches to `conversations.list` (mutually exclusive with `--user`).
   - Returns one page and optional `next_cursor`; pass `--cursor` to continue.
 - `agent-slack channel new --name <name> [--private] [--workspace <url-or-unique-substring>]`
-- `agent-slack channel invite --channel <id|name> --users "<U...,@handle,email,...>" [--workspace <url-or-unique-substring>]`
-  - Internal invite (default): resolves users (`U...`, `@handle`, `handle`, `email`) and uses `conversations.invite`
+- `agent-slack channel invite --channel <id|name> --users "<user,...>" [--workspace <url-or-unique-substring>]`
+  - Internal invite (default): each `<user>` may be a `U...`/`W...` ID, `@handle`, handle, or email; uses `conversations.invite`
   - External invite: add `--external` (email targets only) to use `conversations.inviteShared`
   - Optional: `--allow-external-user-invites` sets `external_limited=false` for external invites
 - `agent-slack channel mark <target> [--ts <seconds>.<micros>] [--workspace <url-or-unique-substring>]`
@@ -172,7 +173,7 @@ Common options:
 
 - `--workspace <url-or-unique-substring>` (recommended when using channel names across multiple workspaces)
 - `--channel <channel...>` repeatable (`#name`, `name`, or id)
-- `--user <@name|name|U...>`
+- `--user <U...|W...|@name|name>`
 - `--after YYYY-MM-DD`
 - `--before YYYY-MM-DD`
 - `--content-type any|text|image|snippet|file`
@@ -198,5 +199,5 @@ Common options:
 ## Users
 
 - `agent-slack user list [--workspace <url-or-unique-substring>] [--limit <n>] [--cursor <cursor>] [--include-bots]`
-- `agent-slack user get <U...|@handle|handle> [--workspace <url-or-unique-substring>]`
-- `agent-slack user dm-open <users...> [--workspace <url-or-unique-substring>]` — get DM or group DM channel ID for one or more users (max 8)
+- `agent-slack user get <U...|W...|@handle|handle> [--workspace <url-or-unique-substring>]`
+- `agent-slack user dm-open <users...> [--workspace <url-or-unique-substring>]` — get a DM or group DM channel ID for one or more `U...`/`W...` IDs or handles (max 8)

--- a/skills/agent-slack/references/targets.md
+++ b/skills/agent-slack/references/targets.md
@@ -1,6 +1,7 @@
-# Targets: URL vs channel (reference)
+# Targets: URLs, channels, and users (reference)
 
-`agent-slack` accepts either a **Slack message URL** (preferred) or a **channel reference**.
+Message commands accept a **Slack message URL** (preferred) or a **channel reference**.
+`message send` also accepts a Slack user ID to open or reuse a direct message.
 
 ## Preferred: Slack message URL
 
@@ -19,6 +20,16 @@ Examples:
 - `agent-slack message delete "<url>"`
 - `agent-slack message react add "<url>" "eyes"`
 - `agent-slack channel mark "<url>"`
+
+## Direct-message target (`message send` only)
+
+Pass a `U...` or `W...` user ID to open or reuse that user's direct-message channel:
+
+```bash
+agent-slack message send "W12345678" "Hello"
+```
+
+Other message operations require a message URL or channel reference.
 
 ## Channel targets (when you don’t have a URL)
 

--- a/src/cli/channel-command.ts
+++ b/src/cli/channel-command.ts
@@ -37,7 +37,7 @@ export function registerChannelCommand(input: { program: Command; ctx: CliContex
       "--workspace <url>",
       "Workspace selector (full URL or unique substring; required if you have multiple workspaces)",
     )
-    .option("--user <user>", "User id (U...) or @handle/handle")
+    .option("--user <user>", "User ID (U.../W...) or @handle/handle")
     .option("--all", "List all conversations (conversations.list); incompatible with --user")
     .option("--limit <n>", "Max conversations in one page (default 100)", "100")
     .option("--cursor <cursor>", "Pagination cursor for the next page")
@@ -125,7 +125,10 @@ export function registerChannelCommand(input: { program: Command; ctx: CliContex
     .command("invite")
     .description("Invite users to a channel")
     .requiredOption("--channel <id-or-name>", "Channel id/name (#general, general, C...)")
-    .requiredOption("--users <users>", "Comma-separated users (U..., @handle, handle, email)")
+    .requiredOption(
+      "--users <users>",
+      "Comma-separated users (U.../W..., @handle, handle, or email)",
+    )
     .option("--external", "Send Slack Connect external invites (email targets only)")
     .option(
       "--allow-external-user-invites",
@@ -158,7 +161,7 @@ export function registerChannelCommand(input: { program: Command; ctx: CliContex
 
         const userInputs = parseInviteUsersCsv(options.users);
         if (userInputs.length === 0) {
-          throw new Error('No users provided. Pass --users "U01...,@alice,bob@example.com"');
+          throw new Error('No users provided. Pass --users "U01234567,@alice,bob@example.com"');
         }
 
         const payload = await input.ctx.withAutoRefresh({

--- a/src/cli/message-command.ts
+++ b/src/cli/message-command.ts
@@ -157,7 +157,7 @@ export function registerMessageCommand(input: { program: Command; ctx: CliContex
   messageCmd
     .command("send")
     .description("Send or schedule a message (optionally into a thread)")
-    .argument("<target>", "Slack message URL, #name/name, or channel id")
+    .argument("<target>", "Slack message URL, #name/name, channel ID, or user ID (U.../W...)")
     .argument("[text]", "Message text to post (optional when using --attach)")
     .option(
       "--workspace <url>",

--- a/src/cli/search-command.ts
+++ b/src/cli/search-command.ts
@@ -23,7 +23,7 @@ function addSearchOptions(cmd: Command): Command {
       "Workspace selector (full URL or unique substring; needed when searching across multiple workspaces)",
     )
     .option("--channel <channel...>", "Channel filter (#name, name, or id). Repeatable.")
-    .option("--user <user>", "User filter (@name, name, or user id U...)")
+    .option("--user <user>", "User filter (U.../W..., @handle, or handle)")
     .option("--after <date>", "Only results after YYYY-MM-DD")
     .option("--before <date>", "Only results before YYYY-MM-DD")
     .option(

--- a/src/cli/targets.ts
+++ b/src/cli/targets.ts
@@ -1,5 +1,6 @@
 import { parseSlackMessageUrl, type SlackMessageRef } from "../slack/url.ts";
-import { isChannelId, isUserId } from "../slack/channels.ts";
+import { isChannelId } from "../slack/channels.ts";
+import { isUserId } from "../slack/user-id.ts";
 
 export type MsgTarget =
   | { kind: "url"; ref: SlackMessageRef }

--- a/src/cli/user-command.ts
+++ b/src/cli/user-command.ts
@@ -43,8 +43,8 @@ export function registerUserCommand(input: { program: Command; ctx: CliContext }
 
   userCmd
     .command("get")
-    .description("Get a single user by id (U...) or handle (@name)")
-    .argument("<user>", "User id (U...) or @handle/handle")
+    .description("Get a single workspace user")
+    .argument("<user>", "User ID (U.../W...) or @handle/handle")
     .option(
       "--workspace <url>",
       "Workspace selector (full URL or unique substring; required if you have multiple workspaces)",
@@ -69,10 +69,8 @@ export function registerUserCommand(input: { program: Command; ctx: CliContext }
 
   userCmd
     .command("dm-open")
-    .description(
-      "Open or get a DM / group DM channel for one or more users by id (U...) or handle (@name)",
-    )
-    .argument("<users...>", "One or more user ids or @handles (space-separated)")
+    .description("Open or get a DM / group DM channel")
+    .argument("<users...>", "One or more user IDs (U.../W...) or @handles")
     .option("--workspace <url>", "Workspace URL (required if you have multiple workspaces)")
     .action(async (...args) => {
       const [users, options] = args as [string[], { workspace?: string }];

--- a/src/slack/channels.ts
+++ b/src/slack/channels.ts
@@ -1,6 +1,8 @@
 import type { SlackApiClient } from "./client.ts";
 import { asArray, getString, isRecord } from "../lib/object-type-guards.ts";
 
+export { isUserId } from "./user-id.ts";
+
 const DEFAULT_CONVERSATION_TYPES = "public_channel,private_channel,im,mpim";
 
 export type ConversationsPage = {
@@ -10,10 +12,6 @@ export type ConversationsPage = {
 
 export function isChannelId(input: string): boolean {
   return /^[CDG][A-Z0-9]{8,}$/.test(input);
-}
-
-export function isUserId(input: string): boolean {
-  return /^U[A-Z0-9]{8,}$/.test(input);
 }
 
 /**

--- a/src/slack/message-compact.ts
+++ b/src/slack/message-compact.ts
@@ -2,6 +2,7 @@ import type { SlackMessageSummary } from "./messages.ts";
 import type { DownloadResult } from "./files.ts";
 import { renderSlackMessageContent } from "./render.ts";
 import { getNumber, getString, isRecord } from "../lib/object-type-guards.ts";
+import { isUserId } from "./user-id.ts";
 
 export type CompactSlackMessage = {
   channel_id: string;
@@ -92,9 +93,7 @@ export function compactReactions(
     if (!name) {
       continue;
     }
-    const users = Array.isArray(r.users)
-      ? r.users.map((u) => String(u)).filter((u) => /^U[A-Z0-9]{8,}$/.test(u))
-      : [];
+    const users = Array.isArray(r.users) ? r.users.map((u) => String(u)).filter(isUserId) : [];
     const count = typeof r.count === "number" && r.count !== users.length ? r.count : undefined;
     out.push({ name, users, count });
   }

--- a/src/slack/search-query.ts
+++ b/src/slack/search-query.ts
@@ -1,6 +1,7 @@
 import type { SlackApiClient } from "./client.ts";
 import { normalizeChannelInput } from "./channels.ts";
 import { asArray, getString, isRecord } from "../lib/object-type-guards.ts";
+import { isUserId } from "./user-id.ts";
 
 export async function buildSlackSearchQuery(
   client: SlackApiClient,
@@ -68,7 +69,7 @@ async function userTokenForSearch(client: SlackApiClient, user: string): Promise
   if (trimmed.startsWith("@")) {
     return `from:@${trimmed.slice(1)}`;
   }
-  if (/^U[A-Z0-9]{8,}$/.test(trimmed)) {
+  if (isUserId(trimmed)) {
     try {
       const info = await client.api("users.info", { user: trimmed });
       const infoUser = isRecord(info) ? info.user : null;
@@ -118,7 +119,7 @@ export async function resolveUserId(
   if (!trimmed) {
     return undefined;
   }
-  if (/^U[A-Z0-9]{8,}$/.test(trimmed)) {
+  if (isUserId(trimmed)) {
     return trimmed;
   }
   const name = trimmed.startsWith("@") ? trimmed.slice(1) : trimmed;

--- a/src/slack/search.ts
+++ b/src/slack/search.ts
@@ -18,7 +18,7 @@ export type SearchOptions = {
   query: string;
   kind: SearchKind;
   channels?: string[];
-  user?: string; // @name, name, or U...
+  user?: string; // @name, name, or U.../W...
   after?: string; // YYYY-MM-DD
   before?: string; // YYYY-MM-DD
   content_type?: ContentType;

--- a/src/slack/user-cache.ts
+++ b/src/slack/user-cache.ts
@@ -6,11 +6,11 @@ import { asArray, getString, isRecord } from "../lib/object-type-guards.ts";
 import type { SlackApiClient } from "./client.ts";
 import type { SlackMessageSummary } from "./messages.ts";
 import { toCompactUser, type CompactSlackUser } from "./users.ts";
+import { isUserId } from "./user-id.ts";
 
 const CACHE_VERSION = 1;
 const USER_TTL_MS = 24 * 60 * 60 * 1000;
-const USER_ID_PATTERN = /^(U|W)[A-Z0-9]{8,}$/;
-const USER_MENTION_PATTERN = /<@((U|W)[A-Z0-9]{8,})(?:\|[^>]+)?>/g;
+const USER_MENTION_PATTERN = /<@([^>|]+)(?:\|[^>]*)?>/g;
 
 type UserCacheEntry = {
   fetched_at: number;
@@ -126,7 +126,7 @@ function dedupeUserIds(ids: string[]): string[] {
   const seen = new Set<string>();
   for (const raw of ids) {
     const userId = String(raw).trim();
-    if (!USER_ID_PATTERN.test(userId)) {
+    if (!isUserId(userId)) {
       continue;
     }
     seen.add(userId);
@@ -162,7 +162,7 @@ async function loadCache(path: string): Promise<UserCacheFile> {
 
   const entries: Record<string, UserCacheEntry> = {};
   for (const [userId, rawEntry] of Object.entries(file.entries)) {
-    if (!USER_ID_PATTERN.test(userId) || !isRecord(rawEntry)) {
+    if (!isUserId(userId) || !isRecord(rawEntry)) {
       continue;
     }
     const fetchedAt = typeof rawEntry.fetched_at === "number" ? rawEntry.fetched_at : undefined;
@@ -233,7 +233,7 @@ function collectUserIdsFromUnknown(value: unknown, out: Set<string>): void {
 
   for (const [key, child] of Object.entries(value)) {
     if ((key === "user" || key === "user_id") && typeof child === "string") {
-      if (USER_ID_PATTERN.test(child)) {
+      if (isUserId(child)) {
         out.add(child);
       }
       continue;
@@ -242,7 +242,7 @@ function collectUserIdsFromUnknown(value: unknown, out: Set<string>): void {
     if (key === "users") {
       for (const maybeUserId of asArray(child)) {
         const userId = String(maybeUserId);
-        if (USER_ID_PATTERN.test(userId)) {
+        if (isUserId(userId)) {
           out.add(userId);
         }
       }
@@ -258,7 +258,7 @@ function collectUserIdsFromMessage(
   out: Set<string>,
   options: { includeReactions: boolean },
 ): void {
-  if (message.user && USER_ID_PATTERN.test(message.user)) {
+  if (message.user && isUserId(message.user)) {
     out.add(message.user);
   }
 
@@ -282,7 +282,7 @@ function collectMentionUserIds(text: string, out: Set<string>): void {
       break;
     }
     const userId = match[1] ?? "";
-    if (USER_ID_PATTERN.test(userId)) {
+    if (isUserId(userId)) {
       out.add(userId);
     }
   }

--- a/src/slack/user-id.ts
+++ b/src/slack/user-id.ts
@@ -1,0 +1,9 @@
+const USER_ID_PATTERN = /^[UW][A-Z0-9]{8,}$/;
+
+/**
+ * Slack uses both U-prefixed and W-prefixed IDs for users. Treat them as
+ * equivalent while preserving the CLI's existing length and character rules.
+ */
+export function isUserId(input: string): boolean {
+  return USER_ID_PATTERN.test(input);
+}

--- a/src/slack/users.ts
+++ b/src/slack/users.ts
@@ -1,5 +1,6 @@
 import type { SlackApiClient } from "./client.ts";
 import { asArray, getString, isRecord } from "../lib/object-type-guards.ts";
+import { isUserId } from "./user-id.ts";
 
 export type CompactSlackUser = {
   id: string;
@@ -91,7 +92,7 @@ export async function getUser(client: SlackApiClient, input: string): Promise<Co
 
 export async function resolveUserId(client: SlackApiClient, input: string): Promise<string | null> {
   const trimmed = input.trim();
-  if (/^U[A-Z0-9]{8,}$/.test(trimmed)) {
+  if (isUserId(trimmed)) {
     return trimmed;
   }
 

--- a/test/message-send.test.ts
+++ b/test/message-send.test.ts
@@ -130,6 +130,33 @@ describe("sendMessage", () => {
     });
   });
 
+  test("opens and sends to a DM for a W-prefixed user target", async () => {
+    const calls: { method: string; params: Record<string, unknown> }[] = [];
+    const ctx = createContext(calls);
+
+    await sendMessage({
+      ctx,
+      targetInput: "W12345678",
+      text: "hello",
+      options: {},
+    });
+
+    expect(calls).toEqual([
+      {
+        method: "conversations.open",
+        params: { users: "W12345678" },
+      },
+      {
+        method: "chat.postMessage",
+        params: {
+          channel: "D12345678",
+          text: "hello",
+          thread_ts: undefined,
+        },
+      },
+    ]);
+  });
+
   test("returns a permalink when the workspace was resolved implicitly", async () => {
     const calls: { method: string; params: Record<string, unknown> }[] = [];
     const ctx = createContext(calls);

--- a/test/reactions.test.ts
+++ b/test/reactions.test.ts
@@ -20,6 +20,20 @@ describe("reactions compaction", () => {
     expect(b.reactions?.[0]?.count).toBeUndefined();
   });
 
+  test("preserves W-prefixed user IDs while compacting reactions", () => {
+    const msg: SlackMessageSummary = {
+      channel_id: "C1",
+      ts: "1.000001",
+      text: "hi",
+      markdown: "hi",
+      reactions: [{ name: "eyes", users: ["W12345678", "B12345678"], count: 2 }],
+    };
+
+    const compact = toCompactMessage(msg, { includeReactions: true });
+    expect(compact.reactions?.[0]?.users).toEqual(["W12345678"]);
+    expect(compact.reactions?.[0]?.count).toBe(2);
+  });
+
   test("adds forwarded thread metadata for shared messages with thread_ts", () => {
     const msg: SlackMessageSummary = {
       channel_id: "C1",

--- a/test/search-query.test.ts
+++ b/test/search-query.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { buildSlackSearchQuery, resolveUserId } from "../src/slack/search-query.ts";
+
+describe("W-prefixed user IDs in search", () => {
+  test("resolves a W-prefixed user ID to a from filter", async () => {
+    const client = {
+      api: async (method: string, params?: Record<string, unknown>) => {
+        expect(method).toBe("users.info");
+        expect(params).toEqual({ user: "W12345678" });
+        return { user: { id: "W12345678", name: "alice" } };
+      },
+    };
+
+    expect(
+      await buildSlackSearchQuery(client as never, {
+        query: "deployment",
+        user: "W12345678",
+      }),
+    ).toBe("deployment from:@alice");
+  });
+
+  test("returns a W-prefixed user ID without scanning users", async () => {
+    const client = {
+      api: async () => {
+        throw new Error("should not call api for user id");
+      },
+    };
+
+    expect(await resolveUserId(client as never, "W12345678")).toBe("W12345678");
+  });
+});

--- a/test/targets.test.ts
+++ b/test/targets.test.ts
@@ -50,6 +50,15 @@ describe("parseMsgTarget", () => {
     expect(t.userId).toBe("U12345ABCDE");
   });
 
+  test("accepts W-prefixed user IDs as DM targets", () => {
+    const t = parseMsgTarget("W12345ABCDE");
+    expect(t.kind).toBe("user");
+    if (t.kind !== "user") {
+      throw new Error("expected user");
+    }
+    expect(t.userId).toBe("W12345ABCDE");
+  });
+
   test("accepts user IDs with leading/trailing whitespace", () => {
     const t = parseMsgTarget("  U09GDJJKCCW  ");
     expect(t.kind).toBe("user");
@@ -61,6 +70,11 @@ describe("parseMsgTarget", () => {
 
   test("does not treat short U-prefixed strings as user IDs", () => {
     const t = parseMsgTarget("U1234");
+    expect(t.kind).toBe("channel");
+  });
+
+  test("does not treat short W-prefixed strings as user IDs", () => {
+    const t = parseMsgTarget("W1234");
     expect(t.kind).toBe("channel");
   });
 });

--- a/test/user-cache.test.ts
+++ b/test/user-cache.test.ts
@@ -35,17 +35,17 @@ describe("user-cache helpers", () => {
       {
         channel_id: "C1",
         ts: "1.000001",
-        text: "hey <@U22222222>",
-        markdown: "hey @U22222222",
-        user: "U11111111",
-        reactions: [{ name: "eyes", users: ["U11111111", "U44444444"] }],
+        text: "hey <@W22222222> and <@B22222222>",
+        markdown: "hey @W22222222",
+        user: "W11111111",
+        reactions: [{ name: "eyes", users: ["W11111111", "W44444444"] }],
       },
     ];
 
     expect(collectReferencedUserIds(messages, { includeReactions: true }).sort()).toEqual([
-      "U11111111",
-      "U22222222",
-      "U44444444",
+      "W11111111",
+      "W22222222",
+      "W44444444",
     ]);
   });
 

--- a/test/user-id.test.ts
+++ b/test/user-id.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test";
+import { isUserId } from "../src/slack/user-id.ts";
+
+describe("isUserId", () => {
+  test("accepts U-prefixed and W-prefixed Slack user IDs", () => {
+    expect(isUserId("U12345678")).toBe(true);
+    expect(isUserId("W12345678")).toBe(true);
+  });
+
+  test("preserves the existing length and character restrictions", () => {
+    expect(isUserId("U1234")).toBe(false);
+    expect(isUserId("W1234")).toBe(false);
+    expect(isUserId("B12345678")).toBe(false);
+    expect(isUserId("w12345678")).toBe(false);
+    expect(isUserId("W1234-678")).toBe(false);
+  });
+});

--- a/test/users.test.ts
+++ b/test/users.test.ts
@@ -11,6 +11,15 @@ describe("resolveUserId", () => {
     expect(await resolveUserId(client as never, "U01ABCDEFG")).toBe("U01ABCDEFG");
   });
 
+  test("returns W-prefixed user ids unchanged", async () => {
+    const client = {
+      api: async () => {
+        throw new Error("should not call api for user id");
+      },
+    };
+    expect(await resolveUserId(client as never, "W01ABCDEFG")).toBe("W01ABCDEFG");
+  });
+
   test("resolves @handle via users.list", async () => {
     const client = {
       api: async (method: string) => {


### PR DESCRIPTION
Slack treats `U`- and `W`-prefixed user IDs equivalently, but agent-slack recognizes `W` IDs only in some read paths. They already work in referenced-user caching but fail in direct-message targets, user lookup and resolution, search filters, and reaction compaction. This change makes one semantic user-ID validator authoritative across those paths and aligns the installed help and bundled skill with the resulting behavior.

Co-authored by GPT 5.6-Sol.