### PR TITLE
docs(skill): clarify rich-text links and thread behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ nix run github:stablyai/agent-slack
 
 This repo ships an agent skill at `skills/agent-slack/` compatible with Claude Code, Codex, Cursor, etc
 
+Treat the installed CLI's `agent-slack --help` and `agent-slack <command> --help` output as authoritative for supported commands and flags.
+
 **Install via [skills.sh](https://skills.sh)** (recommended):
 
 ```bash
@@ -237,7 +239,7 @@ agent-slack message edit "#general" "Updated text" --workspace "myteam" --ts "17
 agent-slack message delete "#general" --workspace "myteam" --ts "1770165109.628379"
 ```
 
-`message send` and `message edit` convert bullet/numbered lists to Slack native rich text. Inline mentions, broadcasts, emoji shortcodes, and `<#C...>` channel references inside those lists are preserved as Slack elements.
+`message edit` and ordinary `message send` calls convert bullet/numbered lists to Slack native rich text. `message send --blocks` uses the supplied blocks instead, while `message send --attach` sends its initial comment as plain text without automatic list conversion. Inside auto-converted lists, inline mentions, broadcasts, emoji shortcodes, `<#C...>` channel references, and Slack manual links such as `<https://example.com/pull/42|PR #42>` are preserved as Slack elements. CommonMark links such as `[PR #42](https://example.com/pull/42)` are not converted into labeled link elements.
 
 Send options for `message send`:
 
@@ -361,7 +363,7 @@ Notes:
 }
 ```
 
-**`message list`** fetches all replies in a thread, or recent channel messages when no thread is specified. Use this when you need the full conversation:
+**`message list`** fetches the thread root plus all replies, or recent channel messages when no thread is specified. Use this when you need the full conversation:
 
 ```json
 {

--- a/skills/agent-slack/SKILL.md
+++ b/skills/agent-slack/SKILL.md
@@ -13,9 +13,13 @@ curl -fsSL https://raw.githubusercontent.com/stablyai/agent-slack/main/install.s
 
 Fallback: `npm i -g agent-slack` (Node >= 22.5).
 
-Safety: read/search freely. Do not send, edit, delete, react, invite, create channels, mark read, schedule, upload, or cancel scheduled messages unless explicitly asked. Prefer `message draft`.
+Treat the installed CLI's `agent-slack --help` and `agent-slack <command> --help` output as authoritative for supported commands and flags.
+
+Safety: read/search freely. Treat sends, edits, deletes, reactions, invitations, channel creation, mark-read operations, schedules, uploads, scheduled-message cancellation, and `workflow run` as write actions; perform them only when explicitly requested. Workflow runs can execute downstream actions. Prefer `message draft`.
 
 Auth: `agent-slack auth whoami`; if needed `auth import-desktop`, `auth import-brave`, `auth import-chrome`, or `auth import-firefox`, then `auth test`.
+
+For labeled links inside bullet or numbered lists, use Slack's `<URL|label>` syntax. Auto-converted lists do not convert CommonMark `[label](URL)` links into labeled link elements.
 
 Common commands:
 

--- a/skills/agent-slack/references/commands.md
+++ b/skills/agent-slack/references/commands.md
@@ -1,6 +1,18 @@
 # `agent-slack` command map (reference)
 
-Run `agent-slack --help` (or `agent-slack <command> --help`) for the full option list.
+## Contents
+
+- [Auth](#auth)
+- [Messages / threads](#messages--threads)
+- [Channels](#channels)
+- [Later](#later)
+- [Unreads](#unreads)
+- [Search](#search)
+- [Canvas](#canvas)
+- [Workflows](#workflows)
+- [Users](#users)
+
+Treat the installed CLI's `agent-slack --help` and `agent-slack <command> --help` output as authoritative for supported commands and flags.
 
 ## Auth
 
@@ -17,6 +29,10 @@ Run `agent-slack --help` (or `agent-slack <command> --help`) for the full option
 
 ## Messages / threads
 
+### Automatic rich-text formatting
+
+`message edit` and `message send` without `--attach` convert bullet and numbered lists to Slack native rich text. `message send --blocks` bypasses automatic conversion, while `message send --attach` sends its initial comment as plain text without automatic list conversion. Inside auto-converted lists, use `<URL|label>` for labeled links; CommonMark `[label](URL)` links are not converted into labeled link elements.
+
 - `agent-slack message get <target>`
   - `<target>`: Slack message URL OR `#channel`/`channel`/channel id (`C...`) (see `targets.md`)
   - Options:
@@ -29,16 +45,16 @@ Run `agent-slack --help` (or `agent-slack <command> --help`) for the full option
     - `--refresh-users` (implies `--resolve-users` and forces a cache refresh)
 
 - `agent-slack message list <target>`
-  - Lists recent channel messages (channel history), or fetches all thread replies
+  - Uses channel-history mode by default. A message URL, `--thread-ts`, or `--ts` selects thread mode, which returns the root plus all replies.
   - **Channel history** (default when targeting a channel without `--thread-ts`):
     - `agent-slack message list "general"` — latest 25 messages
     - `agent-slack message list "general" --limit 50` — latest 50 messages
-  - **Thread mode** (when `--thread-ts` or `--ts` is provided, or target is a message URL):
-    - `agent-slack message list "<url>"` — all replies in that thread
-    - `agent-slack message list "general" --thread-ts "1770165109.000001"` — thread replies
+  - **Thread mode**:
+    - `agent-slack message list "<url>"` — full thread
+    - `agent-slack message list "general" --thread-ts "1770165109.000001"` — full thread
   - Options:
     - `--workspace <url-or-unique-substring>` (same rules as above)
-    - `--thread-ts <seconds>.<micros>` (switches to thread mode; fetches replies)
+    - `--thread-ts <seconds>.<micros>` (switches to thread mode)
     - `--ts <seconds>.<micros>` (resolve a message to its thread)
     - `--limit <n>` (default `25`, max `200`; channel history mode only)
     - `--oldest <ts>` (only messages after this ts; channel history mode)
@@ -65,7 +81,6 @@ Run `agent-slack --help` (or `agent-slack <command> --help`) for the full option
   - A user ID target (`U...` or `W...`) opens or reuses that user's DM.
   - Otherwise posts to the channel/DM.
   - `[text]` is optional when uploading files with `--attach`; when present, it becomes the initial comment on the first uploaded file.
-  - Bullet lists (`- `, `* `, `• `, `1. `, etc.) are automatically converted to Slack’s native rich text format, so recipients see real editable bullets instead of plain-text dashes. Inline mentions, broadcasts, emoji shortcodes, and `<#C...>` channel references inside those lists are preserved as Slack elements.
   - Example: `agent-slack message send "general" "Coverage report" --attach ./report.md`
   - Example: `agent-slack message send "general" "Monday launch checklist" --schedule-in "monday 9am"`
   - Options:
@@ -96,7 +111,6 @@ Run `agent-slack --help` (or `agent-slack <command> --help`) for the full option
 - `agent-slack message edit <target> <text>`
   - URL target edits that exact message.
   - Channel target requires `--ts`.
-  - Inline formatting is sent as text; bullet/numbered lists are converted to Slack native rich text. Inline mentions, broadcasts, emoji shortcodes, and `<#C...>` channel references inside those lists are preserved as Slack elements.
   - Options:
     - `--workspace <url-or-unique-substring>` (needed for channel _names_ across multiple workspaces)
     - `--ts <seconds>.<micros>` (required for channel targets)
@@ -133,7 +147,7 @@ Run `agent-slack --help` (or `agent-slack <command> --help`) for the full option
 
 ## Later
 
-- `agent-slack later list` â€” list saved-for-later messages (default: in-progress)
+- `agent-slack later list` — list saved-for-later messages (default: in-progress)
   - Options:
     - `--workspace <url-or-unique-substring>` (defaults to configured workspace)
     - `--state <state>` (filter: `in_progress` (default), `archived`, `completed`, `all`)
@@ -141,15 +155,15 @@ Run `agent-slack --help` (or `agent-slack <command> --help`) for the full option
     - `--max-body-chars <n>` (max content chars per message, default `4000`, `-1` unlimited)
     - `--counts-only` (only show counts per state)
 
-- `agent-slack later complete <target>` â€” mark a saved message as completed
-- `agent-slack later archive <target>` â€” archive a saved message
-- `agent-slack later reopen <target>` â€” move back to in-progress (from completed or archived)
-- `agent-slack later save <target>` â€” save a message for later
-- `agent-slack later remove <target>` â€” remove from Later entirely
+- `agent-slack later complete <target>` — mark a saved message as completed
+- `agent-slack later archive <target>` — archive a saved message
+- `agent-slack later reopen <target>` — move back to in-progress (from completed or archived)
+- `agent-slack later save <target>` — save a message for later
+- `agent-slack later remove <target>` — remove from Later entirely
   - All accept Slack message URL or channel ID with `--ts`
   - Options: `--workspace <url-or-unique-substring>`, `--ts <seconds>.<micros>`
 
-- `agent-slack later remind <target> --in <duration>` â€” set a reminder on a saved item
+- `agent-slack later remind <target> --in <duration>` — set a reminder on a saved item
   - `--in` accepts: `30m`, `1h`, `3h`, `2d`, `tomorrow`, `monday`, or a unix timestamp
   - Options: `--workspace <url-or-unique-substring>`, `--ts <seconds>.<micros>`
 
@@ -194,7 +208,7 @@ Common options:
 - `agent-slack workflow list <channel> [--workspace <url-or-unique-substring>]` — list workflows bookmarked or featured in a channel
 - `agent-slack workflow preview <trigger-id> [--workspace <url-or-unique-substring>]` — get workflow metadata from a trigger ID (no side effects)
 - `agent-slack workflow get <id> [--workspace <url-or-unique-substring>]` — get workflow definition including form fields and steps (accepts `Ft...` or `Wf...`)
-- `agent-slack workflow run <trigger-id> --channel <id-or-name> [--workspace <url-or-unique-substring>]` — trip a workflow trigger
+- `agent-slack workflow run <trigger-id> --channel <id-or-name> [--workspace <url-or-unique-substring>]` — execute a workflow trigger. This is a write action that can perform downstream actions; run it only when explicitly requested.
 
 ## Users
 

--- a/skills/agent-slack/references/output.md
+++ b/skills/agent-slack/references/output.md
@@ -1,5 +1,16 @@
 # Output + downloads (reference)
 
+## Contents
+
+- [Output format](#output-format)
+- [Message shapes](#message-shapes-high-level)
+- [Later shape](#later-shape-high-level)
+- [Unreads shape](#unreads-shape-high-level)
+- [Search shapes](#search-shapes-high-level)
+- [Channel shapes](#channel-shapes-high-level)
+- [File fields in compact messages](#file-fields-in-compact-messages)
+- [Attachment downloads](#attachment-downloads)
+
 ## Output format
 
 All commands print JSON to stdout.
@@ -37,7 +48,7 @@ All commands print JSON to stdout.
   - `channel_id: "C..." | "D..."`
   - `scheduled_message_id: "Q..."`
 
-Message payload fields keep canonical user IDs (for example `author.user_id`, reaction `users[]`, and `@U...` mentions in rendered content).
+Message payload fields keep canonical user IDs (for example `author.user_id`, reaction `users[]`, and `@U...` or `@W...` mentions in rendered content).
 `referenced_users` provides display metadata for those IDs. The cache is per-workspace with a 24-hour per-entry TTL.
 This behavior is opt-in and requires passing the `--resolve-users` flag (or `--refresh-users` to bypass the cache).
 

--- a/src/cli/message-command.ts
+++ b/src/cli/message-command.ts
@@ -61,7 +61,10 @@ export function registerMessageCommand(input: { program: Command; ctx: CliContex
       "--workspace <url>",
       "Workspace selector (full URL or unique substring; needed when using #channel/channel id across multiple workspaces)",
     )
-    .option("--thread-ts <ts>", "Thread root ts (lists thread replies instead of channel history)")
+    .option(
+      "--thread-ts <ts>",
+      "Thread root ts (lists the thread root and replies instead of channel history)",
+    )
     .option("--ts <ts>", "Message ts (resolve message to its thread)")
     .option("--limit <n>", "Max messages to return for channel history (default 25, max 200)")
     .option("--oldest <ts>", "Only messages after this ts (channel history mode)")

--- a/test/message-send.test.ts
+++ b/test/message-send.test.ts
@@ -540,6 +540,40 @@ describe("sendMessage", () => {
     expect(calls[0]?.params.blocks).toEqual(blocks);
   });
 
+  test("sends Slack manual links in lists as rich-text link blocks", async () => {
+    const calls: { method: string; params: Record<string, unknown> }[] = [];
+    const ctx = createContext(calls);
+
+    await sendMessage({
+      ctx,
+      targetInput: "C12345678",
+      text: "- Review <https://example.com/pull/42|PR #42>",
+      options: {},
+    });
+
+    expect(calls[0]?.method).toBe("chat.postMessage");
+    expect(calls[0]?.params.blocks).toEqual([
+      {
+        type: "rich_text",
+        elements: [
+          {
+            type: "rich_text_list",
+            style: "bullet",
+            elements: [
+              {
+                type: "rich_text_section",
+                elements: [
+                  { type: "text", text: "Review " },
+                  { type: "link", url: "https://example.com/pull/42", text: "PR #42" },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+  });
+
   test("--blocks: errors when an array element is not an object", async () => {
     const calls: { method: string; params: Record<string, unknown> }[] = [];
     const ctx = createContext(calls);

--- a/test/messages.test.ts
+++ b/test/messages.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import { fetchThread } from "../src/slack/messages.ts";
+
+describe("fetchThread", () => {
+  test("returns the thread root and replies in chronological order", async () => {
+    const calls: { method: string; params: Record<string, unknown> }[] = [];
+    const client = {
+      api: async (method: string, params: Record<string, unknown>) => {
+        calls.push({ method, params });
+        return {
+          messages: [
+            { ts: "2.000002", thread_ts: "1.000001", text: "reply", user: "U22222222" },
+            { ts: "1.000001", text: "root", user: "U11111111" },
+          ],
+        };
+      },
+    };
+
+    const messages = await fetchThread(client as never, {
+      channelId: "C12345678",
+      threadTs: "1.000001",
+    });
+
+    expect(calls).toEqual([
+      {
+        method: "conversations.replies",
+        params: {
+          channel: "C12345678",
+          ts: "1.000001",
+          limit: 200,
+          cursor: undefined,
+          include_all_metadata: undefined,
+        },
+      },
+    ]);
+    expect(messages.map(({ ts, text }) => ({ ts, text }))).toEqual([
+      { ts: "1.000001", text: "root" },
+      { ts: "2.000002", text: "reply" },
+    ]);
+  });
+});

--- a/test/rich-text.test.ts
+++ b/test/rich-text.test.ts
@@ -269,6 +269,22 @@ describe("textToRichTextBlocks", () => {
     ]);
   });
 
+  test("Slack manual links and CommonMark links remain distinct in list items", () => {
+    const result = textToRichTextBlocks(
+      "- Review <https://example.com/pull/42|PR #42>\n- Review [PR #43](https://example.com/pull/43)",
+    )!;
+    const list = result[0]!.elements.find((e) => e.type === "rich_text_list") as {
+      elements: { elements: unknown[] }[];
+    };
+    expect(list.elements[0]!.elements).toEqual([
+      { type: "text", text: "Review " },
+      { type: "link", url: "https://example.com/pull/42", text: "PR #42" },
+    ]);
+    expect(list.elements[1]!.elements).toEqual([
+      { type: "text", text: "Review [PR #43](https://example.com/pull/43)" },
+    ]);
+  });
+
   test("code block is preserved", () => {
     const result = textToRichTextBlocks("- Item\n```\ncode here\n```")!;
     expect(result).not.toBeNull();


### PR DESCRIPTION
Agents can produce unlabeled links in lists because agent-slack automatic list conversion recognizes Slack `<URL|label>` syntax but does not convert CommonMark `[label](URL)` into labeled link elements.

This change consolidates send/edit formatting guidance, documents link and attachment behavior, clarifies that thread listings include the root plus replies, points agents to installed CLI help as the command/flag authority, and classifies `workflow run` as a write action. Regression tests cover list-link blocks, the send path, and chronological full-thread output.

Maintainer takeover: rebased onto current `main` and kept rendered-output documentation limited to behavior present in the merged codebase.

Co-authored by GPT 5.6-Sol.