### PR TITLE
Add canvas creation from Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ nix run github:stablyai/agent-slack
 - **Artifacts**: auto-download snippets/images/files to local paths for agents
 - **Write**: send now or schedule delivery, edit/delete messages, add reactions (bullet lists auto-render as native Slack rich text)
 - **Channels**: list conversations, create channels, and invite users by id/handle/email
-- **Canvas**: fetch Slack canvases as Markdown
+- **Canvas**: create Slack canvases from Markdown and fetch them as Markdown
 
 ## Agent skill
 
@@ -100,6 +100,7 @@ agent-slack
 │   ├── get     <id>               # workflow definition + form fields
 │   └── run     <trigger-id>       # trip a workflow trigger
 └── canvas
+    ├── create                     # markdown file/blob → canvas
     └── get <canvas-url-or-id>     # canvas → markdown
 ```
 
@@ -493,12 +494,26 @@ agent-slack later remind "https://workspace.slack.com/archives/C123/p17000000000
 agent-slack later remind "https://workspace.slack.com/archives/C123/p1700000000000000" --in tomorrow
 ```
 
-### Fetch a Canvas as Markdown
+### Create or fetch a Canvas as Markdown
 
 ```bash
+# Create from a local Markdown file
+agent-slack canvas create --file ./launch-plan.md --title "Launch plan"
+
+# Create from an inline Markdown blob
+agent-slack canvas create --markdown $'# Launch plan\n\n- [ ] Ship it' --title "Launch plan"
+
+# Add the new canvas as a channel tab (required on free Slack plans)
+agent-slack canvas create --file ./launch-plan.md --channel "project-launch"
+
+# Fetch an existing canvas as Markdown
 agent-slack canvas get "https://workspace.slack.com/docs/T123/F456"
 agent-slack canvas get "F456" --workspace "https://workspace.slack.com"
 ```
+
+`canvas create` requires exactly one of `--file <path>` or `--markdown <text>`. Use
+`--workspace <url-or-unique-substring>` to select a workspace when needed. The command returns
+`canvas: { id, title?, channel_id? }`; creating canvases requires Slack's `canvases:write` scope.
 
 ## Developing / Contributing
 

--- a/README.md
+++ b/README.md
@@ -513,7 +513,8 @@ agent-slack canvas get "F456" --workspace "https://workspace.slack.com"
 
 `canvas create` requires exactly one of `--file <path>` or `--markdown <text>`. Use
 `--workspace <url-or-unique-substring>` to select a workspace when needed. The command returns
-`canvas: { id, title?, channel_id? }`; creating canvases requires Slack's `canvases:write` scope.
+`canvas: { id, title?, channel_id? }`. Imported browser credentials can create standalone
+canvases; `--channel` requires a standard Slack token with Slack's `canvases:write` scope.
 
 ## Developing / Contributing
 

--- a/llms.txt
+++ b/llms.txt
@@ -18,7 +18,7 @@
 - Zero-config auth: auto-detects Slack Desktop credentials on macOS, Windows, and Linux — with Chrome, Brave, and Firefox fallbacks
 - Multi-workspace Slack management with automatic workspace resolution
 - Human-in-the-loop message drafting via browser-based WYSIWYG rich text editor
-- Slack canvas export to Markdown
+- Slack canvas creation from Markdown files or inline content, plus export to Markdown
 - Slack channel creation, user invites, and Slack Connect external invites
 
 ## Optional

--- a/skills/agent-slack/SKILL.md
+++ b/skills/agent-slack/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-slack
-description: "Slack CLI for agents: read URLs/threads/history/unreads/later/canvases/workflows, search messages/files, download attachments, lookup users, list/create/invite channels, open DMs, draft messages, schedule sends, and explicit sends/edits/deletes/reactions/mark-read/uploads."
+description: "Slack CLI for agents: read URLs/threads/history/unreads/later/canvases/workflows, create canvases from Markdown, search messages/files, download attachments, lookup users, list/create/invite channels, open DMs, draft messages, schedule sends, and explicit sends/edits/deletes/reactions/mark-read/uploads."
 ---
 
 # agent-slack
@@ -13,7 +13,7 @@ curl -fsSL https://raw.githubusercontent.com/stablyai/agent-slack/main/install.s
 
 Fallback: `npm i -g agent-slack` (Node >= 22.5).
 
-Safety: read/search freely. Do not send, edit, delete, react, invite, create channels, mark read, schedule, upload, or cancel scheduled messages unless explicitly asked. Prefer `message draft`.
+Safety: read/search freely. Do not send, edit, delete, react, invite, create channels or canvases, mark read, schedule, upload, or cancel scheduled messages unless explicitly asked. Prefer `message draft`.
 
 Auth: `agent-slack auth whoami`; if needed `auth import-desktop`, `auth import-brave`, `auth import-chrome`, or `auth import-firefox`, then `auth test`.
 
@@ -31,6 +31,8 @@ agent-slack message scheduled list
 agent-slack message scheduled cancel "SCHEDULED_ID" --channel "CHANNEL_ID"
 agent-slack unreads
 agent-slack later list
+agent-slack canvas create --file ./plan.md --title "Plan"
+agent-slack canvas create --markdown $'# Plan\n\n- [ ] Ship it'
 agent-slack canvas get "CANVAS_URL"
 agent-slack workflow list "general"
 agent-slack user list

--- a/skills/agent-slack/references/commands.md
+++ b/skills/agent-slack/references/commands.md
@@ -183,6 +183,16 @@ Common options:
 
 ## Canvas
 
+- `agent-slack canvas create (--file <path> | --markdown <text>)`
+  - Creates a standalone canvas owned by the acting user from exactly one Markdown source.
+  - Markdown from either source is passed to Slack unchanged.
+  - Options:
+    - `--file <path>` read Markdown from a local file (mutually exclusive with `--markdown`)
+    - `--markdown <text>` use a Markdown string directly (mutually exclusive with `--file`)
+    - `--title <title>` set the canvas title
+    - `--channel <id-or-name>` add the canvas as a channel tab; required on free Slack plans
+    - `--workspace <url-or-unique-substring>` select the workspace; required for a channel name across multiple workspaces
+  - Requires Slack's `canvases:write` scope.
 - `agent-slack canvas get <canvas-url-or-id>`
   - Options:
     - `--workspace <url-or-unique-substring>` (required when passing an id and multiple workspaces)

--- a/skills/agent-slack/references/commands.md
+++ b/skills/agent-slack/references/commands.md
@@ -190,9 +190,9 @@ Common options:
     - `--file <path>` read Markdown from a local file (mutually exclusive with `--markdown`)
     - `--markdown <text>` use a Markdown string directly (mutually exclusive with `--file`)
     - `--title <title>` set the canvas title
-    - `--channel <id-or-name>` add the canvas as a channel tab; required on free Slack plans
+    - `--channel <id-or-name>` add the canvas as a channel tab; required on free Slack plans and requires a standard Slack token
     - `--workspace <url-or-unique-substring>` select the workspace; required for a channel name across multiple workspaces
-  - Requires Slack's `canvases:write` scope.
+  - Imported browser credentials support standalone canvases. Standard tokens require Slack's `canvases:write` scope and are required with `--channel`.
 - `agent-slack canvas get <canvas-url-or-id>`
   - Options:
     - `--workspace <url-or-unique-substring>` (required when passing an id and multiple workspaces)

--- a/skills/agent-slack/references/output.md
+++ b/skills/agent-slack/references/output.md
@@ -101,6 +101,13 @@ Use `--max-content-chars` (messages) and `--limit` to control size.
   - `channel: string` (resolved channel ID)
   - `ts: string`
 
+## Canvas shapes (high-level)
+
+- `canvas create` returns:
+  - `canvas: { id, title?, channel_id? }`
+- `canvas get` returns:
+  - `canvas: { id, title?, markdown }`
+
 ## File fields in compact messages
 
 When messages include file attachments, each file object contains:

--- a/src/cli/canvas-command.ts
+++ b/src/cli/canvas-command.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
 import type { CliContext } from "./context.ts";
 import {
+  BROWSER_AUTH_CANVAS_CHANNEL_ERROR,
   createCanvasFromMarkdown,
   fetchCanvasMarkdown,
   parseSlackCanvasUrl,
@@ -78,6 +79,9 @@ export function registerCanvasCommand(input: { program: Command; ctx: CliContext
           workspaceUrl,
           work: async () => {
             const { client, auth } = await input.ctx.getClientForWorkspace(workspaceUrl);
+            if (options.channel && auth.auth_type === "browser") {
+              throw new Error(BROWSER_AUTH_CANVAS_CHANNEL_ERROR);
+            }
             const channelId = options.channel
               ? await resolveChannelId(client, options.channel)
               : undefined;

--- a/src/cli/canvas-command.ts
+++ b/src/cli/canvas-command.ts
@@ -1,10 +1,100 @@
 import type { Command } from "commander";
 import type { CliContext } from "./context.ts";
-import { fetchCanvasMarkdown, parseSlackCanvasUrl } from "../slack/canvas.ts";
+import {
+  createCanvasFromMarkdown,
+  fetchCanvasMarkdown,
+  parseSlackCanvasUrl,
+} from "../slack/canvas.ts";
 import { pruneEmpty } from "../lib/compact-json.ts";
+import { resolveChannelId } from "../slack/channels.ts";
+import { readFile } from "node:fs/promises";
+
+type CanvasCreateOptions = {
+  file?: string;
+  markdown?: string;
+  title?: string;
+  channel?: string;
+  workspace?: string;
+};
+
+export async function readCanvasMarkdownInput(options: {
+  file?: string;
+  markdown?: string;
+}): Promise<string> {
+  const hasFile = options.file !== undefined;
+  const hasMarkdown = options.markdown !== undefined;
+  if (hasFile === hasMarkdown) {
+    throw new Error("Pass exactly one Markdown source: --file <path> or --markdown <text>");
+  }
+
+  let markdown: string;
+  if (hasFile) {
+    try {
+      markdown = await readFile(options.file!, "utf8");
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(`Could not read Markdown file "${options.file}": ${message}`);
+    }
+  } else {
+    markdown = options.markdown!;
+  }
+
+  if (!markdown.trim()) {
+    throw new Error("Canvas Markdown is empty");
+  }
+  return markdown;
+}
 
 export function registerCanvasCommand(input: { program: Command; ctx: CliContext }): void {
   const canvasCmd = input.program.command("canvas").description("Work with Slack canvases");
+
+  canvasCmd
+    .command("create")
+    .description("Create a Slack canvas from Markdown")
+    .option("--file <path>", "Read Markdown from a local file")
+    .option("--markdown <text>", "Use a Markdown string directly")
+    .option("--title <title>", "Canvas title")
+    .option(
+      "--channel <id-or-name>",
+      "Add the canvas as a channel tab (required on free Slack plans)",
+    )
+    .option(
+      "--workspace <url>",
+      "Workspace selector (full URL or unique substring; required if you have multiple workspaces)",
+    )
+    .action(async (...args) => {
+      const [options] = args as [CanvasCreateOptions];
+      try {
+        const markdown = await readCanvasMarkdownInput(options);
+        const workspaceUrl = input.ctx.effectiveWorkspaceUrl(options.workspace);
+        if (options.channel) {
+          await input.ctx.assertWorkspaceSpecifiedForChannelNames({
+            workspaceUrl,
+            channels: [options.channel],
+          });
+        }
+
+        const payload = await input.ctx.withAutoRefresh({
+          workspaceUrl,
+          work: async () => {
+            const { client } = await input.ctx.getClientForWorkspace(workspaceUrl);
+            const channelId = options.channel
+              ? await resolveChannelId(client, options.channel)
+              : undefined;
+            return await createCanvasFromMarkdown(client, {
+              markdown,
+              title: options.title,
+              channelId,
+            });
+          },
+        });
+
+        console.log(JSON.stringify(pruneEmpty(payload), null, 2));
+      } catch (err: unknown) {
+        console.error(input.ctx.errorMessage(err));
+        process.exitCode = 1;
+      }
+    });
 
   canvasCmd
     .command("get")

--- a/src/cli/canvas-command.ts
+++ b/src/cli/canvas-command.ts
@@ -77,11 +77,12 @@ export function registerCanvasCommand(input: { program: Command; ctx: CliContext
         const payload = await input.ctx.withAutoRefresh({
           workspaceUrl,
           work: async () => {
-            const { client } = await input.ctx.getClientForWorkspace(workspaceUrl);
+            const { client, auth } = await input.ctx.getClientForWorkspace(workspaceUrl);
             const channelId = options.channel
               ? await resolveChannelId(client, options.channel)
               : undefined;
             return await createCanvasFromMarkdown(client, {
+              auth,
               markdown,
               title: options.title,
               channelId,

--- a/src/slack/canvas.ts
+++ b/src/slack/canvas.ts
@@ -12,6 +12,41 @@ export type SlackCanvasRef = {
   raw: string;
 };
 
+export async function createCanvasFromMarkdown(
+  client: SlackApiClient,
+  input: {
+    markdown: string;
+    title?: string;
+    channelId?: string;
+  },
+): Promise<{ canvas: { id: string; title?: string; channel_id?: string } }> {
+  if (!input.markdown.trim()) {
+    throw new Error("Canvas Markdown is empty");
+  }
+
+  const title = input.title?.trim() || undefined;
+  const response = await client.api("canvases.create", {
+    title,
+    document_content: {
+      type: "markdown",
+      markdown: input.markdown,
+    },
+    channel_id: input.channelId,
+  });
+  const canvasId = getString(response.canvas_id);
+  if (!canvasId) {
+    throw new Error("canvases.create returned no canvas id");
+  }
+
+  return {
+    canvas: {
+      id: canvasId,
+      title,
+      channel_id: input.channelId,
+    },
+  };
+}
+
 export function parseSlackCanvasUrl(input: string): SlackCanvasRef {
   let url: URL;
   try {

--- a/src/slack/canvas.ts
+++ b/src/slack/canvas.ts
@@ -15,6 +15,7 @@ export type SlackCanvasRef = {
 export async function createCanvasFromMarkdown(
   client: SlackApiClient,
   input: {
+    auth: SlackAuth;
     markdown: string;
     title?: string;
     channelId?: string;
@@ -25,23 +26,41 @@ export async function createCanvasFromMarkdown(
   }
 
   const title = input.title?.trim() || undefined;
-  const response = await client.api("canvases.create", {
-    title,
-    document_content: {
-      type: "markdown",
+  let response: Record<string, unknown>;
+  let canvasId: string | undefined;
+
+  if (input.auth.auth_type === "browser") {
+    if (input.channelId) {
+      throw new Error(
+        "Adding a canvas as a channel tab requires a standard Slack token; imported browser credentials can create standalone canvases only",
+      );
+    }
+    response = await client.apiMultipart("files.createCanvas", {
+      title: title ?? "Untitled",
       markdown: input.markdown,
-    },
-    channel_id: input.channelId,
-  });
-  const canvasId = getString(response.canvas_id);
+      loosenValidation: true,
+    });
+    canvasId = getString(response.file_id);
+  } else {
+    response = await client.api("canvases.create", {
+      title,
+      document_content: {
+        type: "markdown",
+        markdown: input.markdown,
+      },
+      channel_id: input.channelId,
+    });
+    canvasId = getString(response.canvas_id);
+  }
+
   if (!canvasId) {
-    throw new Error("canvases.create returned no canvas id");
+    throw new Error("Slack returned no canvas id");
   }
 
   return {
     canvas: {
       id: canvasId,
-      title,
+      title: title ?? (input.auth.auth_type === "browser" ? "Untitled" : undefined),
       channel_id: input.channelId,
     },
   };

--- a/src/slack/canvas.ts
+++ b/src/slack/canvas.ts
@@ -12,6 +12,9 @@ export type SlackCanvasRef = {
   raw: string;
 };
 
+export const BROWSER_AUTH_CANVAS_CHANNEL_ERROR =
+  "Adding a canvas as a channel tab requires a standard Slack token; imported browser credentials can create standalone canvases only";
+
 export async function createCanvasFromMarkdown(
   client: SlackApiClient,
   input: {
@@ -31,9 +34,7 @@ export async function createCanvasFromMarkdown(
 
   if (input.auth.auth_type === "browser") {
     if (input.channelId) {
-      throw new Error(
-        "Adding a canvas as a channel tab requires a standard Slack token; imported browser credentials can create standalone canvases only",
-      );
+      throw new Error(BROWSER_AUTH_CANVAS_CHANNEL_ERROR);
     }
     response = await client.apiMultipart("files.createCanvas", {
       title: title ?? "Untitled",

--- a/src/slack/client.ts
+++ b/src/slack/client.ts
@@ -35,10 +35,26 @@ export class SlackApiClient {
       throw new Error("Browser auth requires workspace URL.");
     }
     const auth = this.auth as Extract<SlackAuth, { auth_type: "browser" }>;
-    const url = `${this.workspaceUrl.replace(/\/$/, "")}/api/${method}`;
+    return this.browserApiMultipart({
+      workspaceUrl: this.workspaceUrl,
+      auth,
+      method,
+      params,
+    });
+  }
+
+  private async browserApiMultipart(input: {
+    workspaceUrl: string;
+    auth: Extract<SlackAuth, { auth_type: "browser" }>;
+    method: string;
+    params: Record<string, unknown>;
+    attempt?: number;
+  }): Promise<Record<string, unknown>> {
+    const attempt = input.attempt ?? 0;
+    const url = `${input.workspaceUrl.replace(/\/$/, "")}/api/${input.method}`;
     const fd = new FormData();
-    fd.append("token", auth.xoxc_token);
-    for (const [k, v] of Object.entries(params)) {
+    fd.append("token", input.auth.xoxc_token);
+    for (const [k, v] of Object.entries(input.params)) {
       if (v !== undefined) {
         fd.append(k, typeof v === "object" ? JSON.stringify(v) : String(v));
       }
@@ -46,19 +62,30 @@ export class SlackApiClient {
     const response = await fetch(url, {
       method: "POST",
       headers: {
-        Cookie: `d=${encodeURIComponent(auth.xoxd_cookie)}`,
+        Cookie: `d=${encodeURIComponent(input.auth.xoxd_cookie)}`,
         Origin: "https://app.slack.com",
         "User-Agent": getUserAgent(),
       },
       body: fd,
     });
+
+    if (response.status === 429 && attempt < 3) {
+      const retryAfter = Number(response.headers.get("Retry-After") ?? "5");
+      const delayMs = Math.min(Math.max(retryAfter, 1) * 1000, 30000);
+      await new Promise((r) => setTimeout(r, delayMs));
+      return this.browserApiMultipart({
+        ...input,
+        attempt: attempt + 1,
+      });
+    }
+
     const data: unknown = await response.json().catch(() => ({}));
     if (!response.ok) {
-      throw new Error(`Slack HTTP ${response.status} calling ${method}`);
+      throw new Error(`Slack HTTP ${response.status} calling ${input.method}`);
     }
     if (!isRecord(data) || data.ok !== true) {
       const error = isRecord(data) && typeof data.error === "string" ? data.error : null;
-      throw new Error(error || `Slack API error calling ${method}`);
+      throw new Error(error || `Slack API error calling ${input.method}`);
     }
     return data;
   }

--- a/test/canvas-create.test.ts
+++ b/test/canvas-create.test.ts
@@ -1,0 +1,222 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Command } from "commander";
+import type { CliContext } from "../src/cli/context.ts";
+import { readCanvasMarkdownInput, registerCanvasCommand } from "../src/cli/canvas-command.ts";
+import { createCanvasFromMarkdown } from "../src/slack/canvas.ts";
+import type { SlackApiClient } from "../src/slack/client.ts";
+
+function createClient(response: Record<string, unknown> = { ok: true, canvas_id: "F12345678" }) {
+  const calls: { method: string; params: Record<string, unknown> }[] = [];
+  const client = {
+    api: async (method: string, params: Record<string, unknown>) => {
+      calls.push({ method, params });
+      return response;
+    },
+  } as unknown as SlackApiClient;
+  return { client, calls };
+}
+
+function createContext(client: SlackApiClient) {
+  const workspaceSelections: (string | undefined)[] = [];
+  const assertedChannels: string[][] = [];
+  const ctx: CliContext = {
+    effectiveWorkspaceUrl: (flag?: string) => flag,
+    assertWorkspaceSpecifiedForChannelNames: async ({ channels }) => {
+      assertedChannels.push(channels);
+    },
+    withAutoRefresh: async <T>(input: {
+      workspaceUrl: string | undefined;
+      work: () => Promise<T>;
+    }) => input.work(),
+    getClientForWorkspace: async (workspaceUrl?: string) => {
+      workspaceSelections.push(workspaceUrl);
+      return {
+        client,
+        auth: { auth_type: "standard" as const, token: "x" },
+        workspace_url: workspaceUrl,
+      };
+    },
+    normalizeUrl: (u: string) => u,
+    errorMessage: (err: unknown) => (err instanceof Error ? err.message : String(err)),
+    parseContentType: () => "any",
+    parseCurl: (_curl: string) => ({
+      workspace_url: "https://workspace.slack.com",
+      xoxc_token: "xoxc-1",
+      xoxd_cookie: "xoxd-1",
+    }),
+    importDesktop: async () => ({
+      cookie_d: "",
+      teams: [],
+      source: { leveldb_path: "", cookies_path: "" },
+    }),
+    importChrome: () => ({ cookie_d: "", teams: [] }),
+    importBrave: async () => null,
+    importFirefox: async () => null,
+  };
+  return { ctx, workspaceSelections, assertedChannels };
+}
+
+describe("createCanvasFromMarkdown", () => {
+  test("sends Markdown content, title, and channel to canvases.create", async () => {
+    const { client, calls } = createClient();
+
+    const result = await createCanvasFromMarkdown(client, {
+      markdown: "# Launch plan\n\n- Ship it\n",
+      title: "  Launch plan  ",
+      channelId: "C12345678",
+    });
+
+    expect(calls).toEqual([
+      {
+        method: "canvases.create",
+        params: {
+          title: "Launch plan",
+          document_content: {
+            type: "markdown",
+            markdown: "# Launch plan\n\n- Ship it\n",
+          },
+          channel_id: "C12345678",
+        },
+      },
+    ]);
+    expect(result).toEqual({
+      canvas: { id: "F12345678", title: "Launch plan", channel_id: "C12345678" },
+    });
+  });
+
+  test("rejects empty Markdown before calling Slack", async () => {
+    const { client, calls } = createClient();
+
+    await expect(createCanvasFromMarkdown(client, { markdown: "  \n" })).rejects.toThrow(
+      "Canvas Markdown is empty",
+    );
+    expect(calls).toHaveLength(0);
+  });
+
+  test("rejects a success response without a canvas id", async () => {
+    const { client } = createClient({ ok: true });
+
+    await expect(createCanvasFromMarkdown(client, { markdown: "Hello" })).rejects.toThrow(
+      "canvases.create returned no canvas id",
+    );
+  });
+});
+
+describe("readCanvasMarkdownInput", () => {
+  test("reads a Markdown file without changing its contents", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "agent-slack-canvas-"));
+    const path = join(dir, "plan.md");
+    try {
+      await writeFile(path, "# Plan\n\nBody\n", "utf8");
+      await expect(readCanvasMarkdownInput({ file: path })).resolves.toBe("# Plan\n\nBody\n");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("accepts a Markdown blob", async () => {
+    await expect(readCanvasMarkdownInput({ markdown: "# Inline\n" })).resolves.toBe("# Inline\n");
+  });
+
+  test("requires exactly one source", async () => {
+    await expect(readCanvasMarkdownInput({})).rejects.toThrow("Pass exactly one");
+    await expect(
+      readCanvasMarkdownInput({ file: "plan.md", markdown: "# Inline" }),
+    ).rejects.toThrow("Pass exactly one");
+  });
+
+  test("rejects an empty source", async () => {
+    await expect(readCanvasMarkdownInput({ markdown: "\n \t" })).rejects.toThrow(
+      "Canvas Markdown is empty",
+    );
+  });
+});
+
+describe("canvas create command", () => {
+  const originalLog = console.log;
+  const originalError = console.error;
+
+  beforeEach(() => {
+    process.exitCode = 0;
+  });
+
+  afterEach(() => {
+    process.exitCode = 0;
+    console.log = originalLog;
+    console.error = originalError;
+  });
+
+  test("creates from an inline blob in the selected workspace", async () => {
+    const { client, calls } = createClient();
+    const { ctx, workspaceSelections } = createContext(client);
+    const program = new Command();
+    registerCanvasCommand({ program, ctx });
+    const log = mock((_value?: unknown) => {});
+    console.log = log as typeof console.log;
+
+    await program.parseAsync(
+      ["canvas", "create", "--markdown", "# Inline\n", "--title", "Inline", "--workspace", "acme"],
+      { from: "user" },
+    );
+
+    expect(workspaceSelections).toEqual(["acme"]);
+    expect(calls[0]?.method).toBe("canvases.create");
+    expect(calls[0]?.params.document_content).toEqual({
+      type: "markdown",
+      markdown: "# Inline\n",
+    });
+    expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toEqual({
+      canvas: { id: "F12345678", title: "Inline" },
+    });
+    expect(process.exitCode).toBe(0);
+  });
+
+  test("creates from a file and resolves a channel tab", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "agent-slack-canvas-command-"));
+    const path = join(dir, "plan.md");
+    try {
+      await writeFile(path, "# Plan\n", "utf8");
+      const { client, calls } = createClient();
+      const { ctx, assertedChannels } = createContext(client);
+      const program = new Command();
+      registerCanvasCommand({ program, ctx });
+      console.log = mock(() => {}) as typeof console.log;
+
+      await program.parseAsync(["canvas", "create", "--file", path, "--channel", "C12345678"], {
+        from: "user",
+      });
+
+      expect(assertedChannels).toEqual([["C12345678"]]);
+      expect(calls[0]?.params.channel_id).toBe("C12345678");
+      expect(calls[0]?.params.document_content).toEqual({
+        type: "markdown",
+        markdown: "# Plan\n",
+      });
+      expect(process.exitCode).toBe(0);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects missing or conflicting sources before authenticating", async () => {
+    const { client, calls } = createClient();
+    const { ctx, workspaceSelections } = createContext(client);
+    const program = new Command();
+    registerCanvasCommand({ program, ctx });
+    const error = mock(() => {});
+    console.error = error as typeof console.error;
+
+    await program.parseAsync(["canvas", "create"], { from: "user" });
+    await program.parseAsync(["canvas", "create", "--file", "plan.md", "--markdown", "# Inline"], {
+      from: "user",
+    });
+
+    expect(error).toHaveBeenCalledTimes(2);
+    expect(workspaceSelections).toHaveLength(0);
+    expect(calls).toHaveLength(0);
+    expect(process.exitCode).toBe(1);
+  });
+});

--- a/test/canvas-create.test.ts
+++ b/test/canvas-create.test.ts
@@ -6,22 +6,31 @@ import { Command } from "commander";
 import type { CliContext } from "../src/cli/context.ts";
 import { readCanvasMarkdownInput, registerCanvasCommand } from "../src/cli/canvas-command.ts";
 import { createCanvasFromMarkdown } from "../src/slack/canvas.ts";
-import type { SlackApiClient } from "../src/slack/client.ts";
+import type { SlackApiClient, SlackAuth } from "../src/slack/client.ts";
 
 function createClient(response: Record<string, unknown> = { ok: true, canvas_id: "F12345678" }) {
-  const calls: { method: string; params: Record<string, unknown> }[] = [];
-  const api = async (method: string, params: Record<string, unknown>) => {
-    calls.push({ method, params });
-    return response;
+  const calls: {
+    transport: "json" | "multipart";
+    method: string;
+    params: Record<string, unknown>;
+  }[] = [];
+  const api = (transport: "json" | "multipart") => {
+    return async (method: string, params: Record<string, unknown>) => {
+      calls.push({ transport, method, params });
+      return response;
+    };
   };
   const client = {
-    api,
-    apiMultipart: api,
+    api: api("json"),
+    apiMultipart: api("multipart"),
   } as unknown as SlackApiClient;
   return { client, calls };
 }
 
-function createContext(client: SlackApiClient) {
+function createContext(
+  client: SlackApiClient,
+  auth: SlackAuth = { auth_type: "standard", token: "x" },
+) {
   const workspaceSelections: (string | undefined)[] = [];
   const assertedChannels: string[][] = [];
   const ctx: CliContext = {
@@ -37,7 +46,7 @@ function createContext(client: SlackApiClient) {
       workspaceSelections.push(workspaceUrl);
       return {
         client,
-        auth: { auth_type: "standard" as const, token: "x" },
+        auth,
         workspace_url: workspaceUrl,
       };
     },
@@ -74,6 +83,7 @@ describe("createCanvasFromMarkdown", () => {
 
     expect(calls).toEqual([
       {
+        transport: "json",
         method: "canvases.create",
         params: {
           title: "Launch plan",
@@ -127,6 +137,7 @@ describe("createCanvasFromMarkdown", () => {
 
     expect(calls).toEqual([
       {
+        transport: "multipart",
         method: "files.createCanvas",
         params: {
           title: "Untitled",
@@ -250,6 +261,28 @@ describe("canvas create command", () => {
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
+  });
+
+  test("rejects browser-auth channel tabs before resolving the channel", async () => {
+    const { client, calls } = createClient({ ok: true, file_id: "F87654321" });
+    const { ctx } = createContext(client, {
+      auth_type: "browser",
+      xoxc_token: "xoxc-test",
+      xoxd_cookie: "xoxd-test",
+    });
+    const program = new Command();
+    registerCanvasCommand({ program, ctx });
+    const error = mock((_value?: unknown) => {});
+    console.error = error as typeof console.error;
+
+    await program.parseAsync(
+      ["canvas", "create", "--markdown", "# Browser auth\n", "--channel", "project-launch"],
+      { from: "user" },
+    );
+
+    expect(calls).toHaveLength(0);
+    expect(String(error.mock.calls[0]?.[0])).toContain("requires a standard Slack token");
+    expect(process.exitCode).toBe(1);
   });
 
   test("rejects missing or conflicting sources before authenticating", async () => {

--- a/test/canvas-create.test.ts
+++ b/test/canvas-create.test.ts
@@ -10,11 +10,13 @@ import type { SlackApiClient } from "../src/slack/client.ts";
 
 function createClient(response: Record<string, unknown> = { ok: true, canvas_id: "F12345678" }) {
   const calls: { method: string; params: Record<string, unknown> }[] = [];
+  const api = async (method: string, params: Record<string, unknown>) => {
+    calls.push({ method, params });
+    return response;
+  };
   const client = {
-    api: async (method: string, params: Record<string, unknown>) => {
-      calls.push({ method, params });
-      return response;
-    },
+    api,
+    apiMultipart: api,
   } as unknown as SlackApiClient;
   return { client, calls };
 }
@@ -64,6 +66,7 @@ describe("createCanvasFromMarkdown", () => {
     const { client, calls } = createClient();
 
     const result = await createCanvasFromMarkdown(client, {
+      auth: { auth_type: "standard", token: "x" },
       markdown: "# Launch plan\n\n- Ship it\n",
       title: "  Launch plan  ",
       channelId: "C12345678",
@@ -90,18 +93,66 @@ describe("createCanvasFromMarkdown", () => {
   test("rejects empty Markdown before calling Slack", async () => {
     const { client, calls } = createClient();
 
-    await expect(createCanvasFromMarkdown(client, { markdown: "  \n" })).rejects.toThrow(
-      "Canvas Markdown is empty",
-    );
+    await expect(
+      createCanvasFromMarkdown(client, {
+        auth: { auth_type: "standard", token: "x" },
+        markdown: "  \n",
+      }),
+    ).rejects.toThrow("Canvas Markdown is empty");
     expect(calls).toHaveLength(0);
   });
 
   test("rejects a success response without a canvas id", async () => {
     const { client } = createClient({ ok: true });
 
-    await expect(createCanvasFromMarkdown(client, { markdown: "Hello" })).rejects.toThrow(
-      "canvases.create returned no canvas id",
-    );
+    await expect(
+      createCanvasFromMarkdown(client, {
+        auth: { auth_type: "standard", token: "x" },
+        markdown: "Hello",
+      }),
+    ).rejects.toThrow("Slack returned no canvas id");
+  });
+
+  test("uses Slack's Markdown canvas method with imported browser credentials", async () => {
+    const { client, calls } = createClient({ ok: true, file_id: "F87654321" });
+
+    const result = await createCanvasFromMarkdown(client, {
+      auth: {
+        auth_type: "browser",
+        xoxc_token: "xoxc-test",
+        xoxd_cookie: "xoxd-test",
+      },
+      markdown: "# Browser auth\n",
+    });
+
+    expect(calls).toEqual([
+      {
+        method: "files.createCanvas",
+        params: {
+          title: "Untitled",
+          markdown: "# Browser auth\n",
+          loosenValidation: true,
+        },
+      },
+    ]);
+    expect(result).toEqual({ canvas: { id: "F87654321", title: "Untitled" } });
+  });
+
+  test("rejects channel tabs with browser credentials before calling Slack", async () => {
+    const { client, calls } = createClient({ ok: true, file_id: "F87654321" });
+
+    await expect(
+      createCanvasFromMarkdown(client, {
+        auth: {
+          auth_type: "browser",
+          xoxc_token: "xoxc-test",
+          xoxd_cookie: "xoxd-test",
+        },
+        markdown: "# Browser auth\n",
+        channelId: "C12345678",
+      }),
+    ).rejects.toThrow("requires a standard Slack token");
+    expect(calls).toHaveLength(0);
   });
 });
 

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { SlackApiClient } from "../src/slack/client.ts";
+
+const originalFetch = globalThis.fetch;
+const originalSetTimeout = globalThis.setTimeout;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  globalThis.setTimeout = originalSetTimeout;
+});
+
+describe("SlackApiClient browser multipart transport", () => {
+  test("retries HTTP 429 responses using Retry-After", async () => {
+    const responses = [
+      new Response(JSON.stringify({ ok: false, error: "ratelimited" }), {
+        status: 429,
+        headers: { "Content-Type": "application/json", "Retry-After": "2" },
+      }),
+      new Response(JSON.stringify({ ok: true, file_id: "F12345678" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    ];
+    const fetchMock = mock(async (_input: string | URL | Request, _init?: RequestInit) => {
+      return responses.shift()!;
+    });
+    const delays: number[] = [];
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    globalThis.setTimeout = ((callback: () => void, delay?: number) => {
+      delays.push(delay ?? 0);
+      callback();
+      return 0;
+    }) as unknown as typeof setTimeout;
+
+    const client = new SlackApiClient(
+      {
+        auth_type: "browser",
+        xoxc_token: "xoxc-test",
+        xoxd_cookie: "xoxd-test",
+      },
+      { workspaceUrl: "https://workspace.slack.com" },
+    );
+
+    await expect(
+      client.apiMultipart("files.createCanvas", {
+        title: "Launch plan",
+        markdown: "# Launch plan\n",
+      }),
+    ).resolves.toEqual({ ok: true, file_id: "F12345678" });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(delays).toEqual([2000]);
+    for (const call of fetchMock.mock.calls) {
+      expect(call[1]?.body).toBeInstanceOf(FormData);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds `agent-slack canvas create`, giving agents a first-class way to create Slack canvases from either a local Markdown file or an inline Markdown blob.

- accepts exactly one of `--file <path>` or `--markdown <text>`
- supports an optional `--title`
- supports `--channel <id-or-name>` to add the canvas as a channel tab (and cover Slack free plans, where `channel_id` is required)
- uses the existing workspace selection, channel resolution, and auth auto-refresh paths
- returns compact JSON as `canvas: { id, title?, channel_id? }`
- rejects empty content and malformed success responses before presenting a false success

## Authentication paths

Live testing found that Slack's public `canvases.create` API rejects imported `xoxc` browser credentials with `not_allowed_token_type`. Canvas creation now selects the appropriate API automatically:

- standard Slack tokens use the official `canvases.create` API with Markdown `document_content`
- imported browser credentials use Slack's multipart `files.createCanvas` Markdown path
- `--channel` remains standard-token-only because the browser-auth path creates standalone canvases and cannot add a channel tab

Standard tokens require Slack's `canvases:write` scope.

## Usage

```bash
# Create from a file
agent-slack canvas create --file ./launch-plan.md --title "Launch plan"

# Create from an inline Markdown blob
agent-slack canvas create --markdown $'# Launch plan\n\n- [ ] Ship it' --title "Launch plan"

# Add the canvas as a channel tab (required on free Slack plans; standard tokens only)
agent-slack canvas create --file ./launch-plan.md --channel "project-launch"
```

When multiple workspaces are configured, callers can use the standard `--workspace <url-or-unique-substring>` selector. Channel names go through the same ambiguity checks and name-to-ID resolution used by the rest of the CLI.

## Validation and failure behavior

- missing `--file`/`--markdown` is rejected before authentication
- supplying both source options is rejected before authentication
- whitespace-only Markdown is rejected
- file read failures include the source path and underlying error
- the Markdown bytes read from a file or supplied inline are preserved in the API request
- a Slack success response without a canvas/file ID is treated as an error
- channel-tab creation with imported browser credentials fails locally with an actionable standard-token requirement

## Documentation

Kept all shipped agent guidance in sync with the implementation:

- updated the README feature list, command map, usage examples, output shape, auth requirements, and free-plan note
- updated `skills/agent-slack/SKILL.md` common commands and mutation safety guidance
- updated the bundled command and output references
- updated `llms.txt` feature metadata

## Testing

Live acceptance testing in `stablygroup` passed for both supported sources using imported browser credentials:

- created a canvas from a Markdown file and read it back successfully
- created a canvas from an inline Markdown blob and read it back successfully
- sent both canvas links to the requested self-DM and verified delivery

Automated verification:

- `bun test` — 265 passed, 0 failed
- focused canvas/client regression suite — 14 passed, 0 failed
- `bun run typecheck`
- `bun run build`
- `bun run build:npm`
- `bun run lint` — 0 errors (10 existing warnings in unrelated files)
- `bun run format:check`
- `git diff --check`
