### PR TITLE
refactor(channels): drop unused isUserId re-export

### DIFF
--- a/src/slack/channels.ts
+++ b/src/slack/channels.ts
@@ -1,8 +1,6 @@
 import type { SlackApiClient } from "./client.ts";
 import { asArray, getString, isRecord } from "../lib/object-type-guards.ts";
 
-export { isUserId } from "./user-id.ts";
-
 const DEFAULT_CONVERSATION_TYPES = "public_channel,private_channel,im,mpim";
 
 export type ConversationsPage = {


### PR DESCRIPTION
Follow-up cleanup from #114: the `isUserId` re-export in `src/slack/channels.ts` was kept for backward compatibility, but every consumer now imports from `src/slack/user-id.ts` directly, so it can go. Typecheck and all 248 tests pass.

Made with [Orca](https://github.com/stablyai/orca) 🐋
