### PR TITLE
feat(message): compose editor + Slack-native drafts (#83)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Guiding principle:
 
 - **Token-efficient** — (compact JSON, minimal duplication, and empty/null fields pruned) so LLMs can consume results cheaply.
 - **Zero-config auth** — Auth just works if you have Slack Desktop (with fallbacks available). No Python dependency.
-- **Human-in-the-loop** — When appropriate (not in CI environments), loop humans in. Ex: `message draft`
+- **Human-in-the-loop** — When appropriate (not in CI environments), loop humans in. Ex: `message compose`
   <img width="1228" height="741" alt="image" src="https://github.com/user-attachments/assets/92ecbb71-18ca-4516-a874-c83c154b0709" />
 
 ## Getting started
@@ -35,6 +35,7 @@ nix run github:stablyai/agent-slack
 - **Search**: messages + files (with filters)
 - **Artifacts**: auto-download snippets/images/files to local paths for agents
 - **Write**: send now or schedule delivery, edit/delete messages, add reactions (bullet lists auto-render as native Slack rich text)
+- **Compose & drafts**: open a browser editor (`message compose`), or manage Slack-native drafts that show up in your Slack client (`message draft`)
 - **Channels**: list conversations, create channels, and invite users by id/handle/email
 - **Canvas**: create Slack canvases from Markdown and fetch them as Markdown
 
@@ -79,7 +80,12 @@ agent-slack
 │   ├── scheduled
 │   │   ├── list                   # list pending scheduled messages
 │   │   └── cancel <id>            # cancel a pending scheduled message
-│   ├── draft <target> [text]      # open Slack-like editor in browser
+│   ├── compose <target> [text]    # open Slack-like editor in browser
+│   ├── draft                      # Slack-native drafts (appear in your Slack client)
+│   │   ├── list                   # list Slack-native drafts
+│   │   ├── create <target> <text> # create a Slack-native draft
+│   │   ├── update <id> <text>     # replace a draft's text
+│   │   └── delete <id>            # delete a draft
 │   ├── edit  <target> <text>      # edit a message
 │   ├── delete <target>            # delete a message
 │   └── react
@@ -203,24 +209,46 @@ Optional:
 agent-slack message get "https://workspace.slack.com/archives/C123/p1700000000000000" --include-reactions
 ```
 
-### Draft a message (browser editor)
+### Compose a message (browser editor)
 
 Opens a Slack-like WYSIWYG editor in your browser for composing messages with full formatting support (bold, italic, strikethrough, links, lists, quotes, code, code blocks).
 
 ```bash
 # Open editor for a channel
-agent-slack message draft "#general"
+agent-slack message compose "#general"
 
 # Open editor with initial text
-agent-slack message draft "#general" "Here's my update"
+agent-slack message compose "#general" "Here's my update"
 
 # Reply in a thread
-agent-slack message draft "https://workspace.slack.com/archives/C123/p1700000000000000"
+agent-slack message compose "https://workspace.slack.com/archives/C123/p1700000000000000"
 ```
 
 After sending, the editor shows a "View in Slack" link to the posted message.
 
-`message draft` is send-capable. In CI, it skips the browser editor and immediately sends supplied text; do not use it for a compose-only request in a noninteractive environment.
+`message compose` is send-capable. In CI, it skips the browser editor and immediately sends supplied text; do not use it for a compose-only request in a noninteractive environment.
+
+### Slack-native drafts
+
+Manage drafts through Slack's own drafts API, so they show up natively in the user's Slack client (mobile and desktop) ready to review and send. Requires browser-style auth (xoxc/xoxd).
+
+> [!NOTE]
+> These commands use Slack's **undocumented** internal `drafts.*` client endpoints (the same ones the Slack app uses), authenticated with your own browser session. They act only as you, on your own drafts — nothing is exposed that you can't already see, and `create` posts nothing. But because the endpoints are unsupported: their behavior may change without notice, and on **Enterprise Grid** this style of session-token API use can be flagged by Slack's security/anomaly detection. This is the same auth model the rest of agent-slack already uses (`later`, `unreads`, `search`); use it where that's acceptable.
+
+```bash
+# List unsent drafts
+agent-slack message draft list
+
+# Draft a message to a channel (shows up in Slack's Drafts section)
+agent-slack message draft create "#general" "Here's my update"
+
+# Draft a thread reply
+agent-slack message draft create "https://workspace.slack.com/archives/C123/p1700000000000000" "Looking into it"
+
+# Replace a draft's text, or delete it
+agent-slack message draft update "DR_ID" "Here's my revised update"
+agent-slack message draft delete "DR_ID"
+```
 
 ### Reply, edit, delete, and react
 

--- a/llms.txt
+++ b/llms.txt
@@ -17,7 +17,8 @@
 - Token-efficient compact JSON output so LLMs can consume Slack data cheaply
 - Zero-config auth: auto-detects Slack Desktop credentials on macOS, Windows, and Linux — with Chrome, Brave, and Firefox fallbacks
 - Multi-workspace Slack management with automatic workspace resolution
-- Human-in-the-loop message drafting via browser-based WYSIWYG rich text editor
+- Human-in-the-loop message composing via browser-based WYSIWYG rich text editor (`message compose`)
+- Slack-native drafts that appear in the user's Slack client via `message draft` (list/create/update/delete)
 - Slack canvas creation from Markdown files or inline content, plus export to Markdown
 - Slack channel creation, user invites, and Slack Connect external invites
 

--- a/skills/agent-slack/SKILL.md
+++ b/skills/agent-slack/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-slack
-description: "Slack CLI for agents: read URLs/threads/history/unreads/later/canvases/workflows, create canvases from Markdown, search messages/files, download attachments, lookup users, list/create/invite channels, open DMs, draft messages, schedule sends, and explicit sends/edits/deletes/reactions/mark-read/uploads."
+description: "Slack CLI for agents: read URLs/threads/history/unreads/later/canvases/workflows, create canvases from Markdown, search messages/files, download attachments, lookup users, list/create/invite channels, open DMs, compose messages, manage Slack-native drafts, schedule sends, and explicit sends/edits/deletes/reactions/mark-read/uploads."
 ---
 
 # agent-slack
@@ -20,7 +20,7 @@ If a capability named here is absent from installed help, report version skew in
 
 - Read and search freely.
 - Perform write actions only when explicitly requested: sends, edits, deletes, reactions, invitations, channel or canvas creation, mark-read operations, scheduling or canceling delivery, uploads, Later state/reminder changes, DM/group-DM creation, and `workflow run`. Workflow runs can execute downstream actions.
-- For compose- or review-only requests, return proposed text without invoking Slack. `message draft` is send-capable; use it only when the user explicitly asks to open the interactive editor. In CI or another noninteractive environment, do not invoke it without separate authorization to send immediately: CI skips the editor and sends supplied text.
+- For compose- or review-only requests, return proposed text without invoking Slack, or use `message draft create` to add a Slack-native draft the user can review and send (nothing is posted). `message compose` is send-capable; use it only when the user explicitly asks to open the interactive editor. In CI or another noninteractive environment, do not invoke it without separate authorization to send immediately: CI skips the editor and sends supplied text.
 
 ## Workflow
 
@@ -35,6 +35,8 @@ For scheduled writes, prefer `--schedule` with an ISO 8601 timestamp and explici
 Named `later remind --in` values such as `tomorrow` or `monday` also use the executing environment's local timezone at 9:00. Confirm that timezone or pass an explicit Unix timestamp.
 
 Ordinary `message send` and `message edit` calls auto-convert lists. `message send --blocks` uses supplied blocks, while `message send --attach` sends its initial comment without automatic list conversion. Inside auto-converted lists, use Slack's `<URL|label>` syntax because CommonMark `[label](URL)` links are not converted into labeled link elements.
+
+Slack-native drafts (`message draft list|create|update|delete`) manage drafts that appear in the user's Slack client; `create` posts nothing. They use undocumented session endpoints and require browser-style auth (xoxc/xoxd).
 
 ## Conditional references
 

--- a/skills/agent-slack/references/targets.md
+++ b/skills/agent-slack/references/targets.md
@@ -10,7 +10,7 @@ A URL supplies the workspace, channel, and message timestamp. With a URL target:
 
 - `message get`, `edit`, `delete`, and `react` operate on that message.
 - `message list` returns the thread root and all replies.
-- `message send` replies in that message's thread. `message draft` does the same unless `--thread-ts` explicitly overrides the URL-derived thread.
+- `message send` replies in that message's thread. `message compose` and `message draft create` do the same unless `--thread-ts` explicitly overrides the URL-derived thread.
 - `channel mark` marks through that message timestamp; `--ts` explicitly overrides the timestamp. It rejects `--workspace` because the URL supplies it.
 
 Use a channel name or a `C...`, `G...`, or `D...` channel ID only when no URL is available:
@@ -19,7 +19,7 @@ Use a channel name or a `C...`, `G...`, or `D...` channel ID only when no URL is
 - `message list` reads channel history unless `--thread-ts` or `--ts` selects a thread.
 - `channel mark` requires `--ts`.
 
-Among `message` subcommands, only `message send` accepts a `U...` or `W...` user ID as a target; it opens or reuses that user's direct-message channel. Treat `U`- and `W`-prefixed user IDs equivalently.
+Among `message` subcommands, `message send` and `message draft create` accept a `U...` or `W...` user ID as a target; it opens or reuses that user's direct-message channel. `message draft update --channel` can likewise re-address a draft to a DM. Treat `U`- and `W`-prefixed user IDs equivalently.
 
 Use `user dm-open <users...>` with one to eight other user IDs or handles to get a DM or group-DM channel ID, then use that channel ID for message operations. The authenticated caller is implicit.
 

--- a/src/cli/compose-actions.ts
+++ b/src/cli/compose-actions.ts
@@ -5,7 +5,7 @@ import { resolveChannelId, resolveChannelName, normalizeChannelInput } from "../
 import { warnOnTruncatedSlackUrl } from "./message-url-warning.ts";
 import { openDraftEditor } from "./draft-server.ts";
 
-export async function draftMessage(input: {
+export async function composeMessage(input: {
   ctx: CliContext;
   targetInput: string;
   initialText?: string;
@@ -14,7 +14,7 @@ export async function draftMessage(input: {
   const target = parseMsgTarget(String(input.targetInput));
   if (target.kind === "user") {
     throw new Error(
-      "message draft does not support user ID targets. Use a channel name, channel ID, or message URL.",
+      "message compose does not support user ID targets. Use a channel name, channel ID, or message URL.",
     );
   }
 

--- a/src/cli/message-command.ts
+++ b/src/cli/message-command.ts
@@ -9,8 +9,9 @@ import {
   sendMessage,
   type MessageCommandOptions,
 } from "./message-actions.ts";
-import { draftMessage } from "./draft-actions.ts";
+import { composeMessage } from "./compose-actions.ts";
 import { registerScheduledMessageCommand } from "./message-scheduled-command.ts";
+import { registerMessageDraftCommand } from "./message-draft-command.ts";
 
 function collectOptionValue(value: string, previous: string[] = []): string[] {
   return [...previous, value];
@@ -253,14 +254,15 @@ export function registerMessageCommand(input: { program: Command; ctx: CliContex
     });
 
   registerScheduledMessageCommand({ messageCmd, ctx: input.ctx });
+  registerMessageDraftCommand({ messageCmd, ctx: input.ctx });
 
   messageCmd
-    .command("draft")
+    .command("compose")
     .description(
-      "Open a send-capable rich editor; CI skips the editor and immediately sends supplied text",
+      "Open a send-capable rich editor in the browser; CI skips the editor and immediately sends supplied text",
     )
     .argument("<target>", "Slack message URL, #name/name, or channel id")
-    .argument("[text]", "Initial draft text (sent immediately when CI skips the editor)")
+    .argument("[text]", "Initial message text (mrkdwn; sent immediately when CI skips the editor)")
     .option(
       "--workspace <url>",
       "Workspace selector (full URL or unique substring; needed when using #channel/channel id across multiple workspaces)",
@@ -276,7 +278,7 @@ export function registerMessageCommand(input: { program: Command; ctx: CliContex
         { workspace?: string; threadTs?: string },
       ];
       try {
-        const payload = await draftMessage({
+        const payload = await composeMessage({
           ctx: input.ctx,
           targetInput,
           initialText: text,

--- a/src/cli/message-draft-actions.ts
+++ b/src/cli/message-draft-actions.ts
@@ -1,0 +1,333 @@
+import type { CliContext } from "./context.ts";
+import { parseMsgTarget, type MsgTarget } from "./targets.ts";
+import { warnOnTruncatedSlackUrl } from "./message-url-warning.ts";
+import { normalizeChannelInput, openDmChannel, resolveChannelId } from "../slack/channels.ts";
+import type { SlackApiClient } from "../slack/client.ts";
+import {
+  createDraft,
+  deleteDraft,
+  findDraft,
+  listDrafts,
+  updateDraft,
+  type SlackDraft,
+} from "../slack/drafts.ts";
+import { fetchMessage } from "../slack/messages.ts";
+import { getString, isRecord } from "../lib/object-type-guards.ts";
+import { normalizeScheduleLimit } from "../slack/scheduled-messages.ts";
+
+export async function listDraftsAction(input: {
+  ctx: CliContext;
+  options: { workspace?: string; limit?: string; all?: boolean };
+}): Promise<Record<string, unknown>> {
+  const workspaceUrl = input.ctx.effectiveWorkspaceUrl(input.options.workspace);
+  return await input.ctx.withAutoRefresh({
+    workspaceUrl,
+    work: async () => {
+      const { client } = await input.ctx.getClientForWorkspace(workspaceUrl);
+      const { drafts } = await listDrafts(client, {
+        limit: normalizeScheduleLimit(input.options.limit),
+        activeOnly: !input.options.all,
+      });
+      const hydrated = await hydrateChannelNames(client, drafts);
+      return { ok: true, drafts: hydrated, count: hydrated.length };
+    },
+  });
+}
+
+export async function createDraftAction(input: {
+  ctx: CliContext;
+  targetInput: string;
+  text: string;
+  options: { workspace?: string; threadTs?: string; broadcast?: boolean };
+}): Promise<Record<string, unknown>> {
+  const target = parseMsgTarget(String(input.targetInput));
+  const workspaceUrl =
+    target.kind === "url"
+      ? target.ref.workspace_url
+      : input.ctx.effectiveWorkspaceUrl(input.options.workspace);
+  if (target.kind === "channel") {
+    await input.ctx.assertWorkspaceSpecifiedForChannelNames({
+      workspaceUrl,
+      channels: [target.channel],
+    });
+  }
+  // Validate --broadcast statically before any network round-trip, so an invalid
+  // combination fails fast with the real reason (matches updateDraftAction).
+  if (input.options.broadcast) {
+    assertBroadcastAllowedStatically(target, input.options.threadTs);
+  }
+
+  return await input.ctx.withAutoRefresh({
+    workspaceUrl,
+    work: async () => {
+      const { client } = await input.ctx.getClientForWorkspace(workspaceUrl);
+      const { channelId, threadTs } = await resolveDraftDestination(client, {
+        target,
+        threadTs: input.options.threadTs,
+      });
+      // Backstop for URL targets, whose channel/thread are only known here.
+      if (input.options.broadcast && isDmChannelId(channelId)) {
+        throw new Error("--broadcast is not supported for DM targets.");
+      }
+      if (input.options.broadcast && !threadTs) {
+        throw new Error("--broadcast requires a thread (use --thread-ts or a message URL target).");
+      }
+      const draft = await createDraft(client, {
+        channelId,
+        text: input.text,
+        threadTs,
+        broadcast: input.options.broadcast,
+      });
+      return { ok: true, draft };
+    },
+  });
+}
+
+export async function updateDraftAction(input: {
+  ctx: CliContext;
+  draftId: string;
+  text: string;
+  options: {
+    workspace?: string;
+    channel?: string;
+    threadTs?: string;
+    broadcast?: boolean;
+    lastUpdatedTs?: string;
+  };
+}): Promise<Record<string, unknown>> {
+  const channelTarget = input.options.channel
+    ? parseMsgTarget(String(input.options.channel))
+    : undefined;
+  const workspaceUrl =
+    channelTarget?.kind === "url"
+      ? channelTarget.ref.workspace_url
+      : input.ctx.effectiveWorkspaceUrl(input.options.workspace);
+  if (channelTarget?.kind === "channel") {
+    await input.ctx.assertWorkspaceSpecifiedForChannelNames({
+      workspaceUrl,
+      channels: [channelTarget.channel],
+    });
+  }
+  // Validate an explicit --channel re-address statically, before any network
+  // round-trip (findDraft / destination resolution), so an invalid --broadcast
+  // combination fails fast with the real reason.
+  if (input.options.broadcast && channelTarget) {
+    assertBroadcastAllowedStatically(channelTarget, input.options.threadTs);
+  }
+
+  return await input.ctx.withAutoRefresh({
+    workspaceUrl,
+    work: async () => {
+      const { client } = await input.ctx.getClientForWorkspace(workspaceUrl);
+      // drafts.update replaces the whole draft, so start from the existing
+      // one and override only what the caller passed.
+      const existing = await findDraft(client, input.draftId);
+      // The CLI rebuilds the draft from a single destination and no schedule, so
+      // refuse drafts it can't faithfully round-trip rather than silently drop a
+      // scheduled-send time or extra recipients (both are creatable in the Slack
+      // client). Deleting + recreating, or editing in Slack, is the safe path.
+      if (existing.date_scheduled) {
+        throw new Error(
+          `Draft ${input.draftId} has a scheduled send time; updating it here could clear the schedule. Edit it in the Slack client, or delete and recreate it.`,
+        );
+      }
+      if (!channelTarget && existing.destinations.length > 1) {
+        throw new Error(
+          `Draft ${input.draftId} targets multiple destinations; updating its text here would drop all but the first. Edit it in the Slack client, or re-address it with --channel.`,
+        );
+      }
+      const lastUpdatedTs = input.options.lastUpdatedTs ?? existing.last_updated_ts;
+      if (!lastUpdatedTs) {
+        throw new Error(`Draft ${input.draftId} has no last_updated_ts; pass --last-updated-ts.`);
+      }
+      const [destination] = existing.destinations;
+      const resolved = channelTarget
+        ? await resolveDraftDestination(client, {
+            target: channelTarget,
+            threadTs: input.options.threadTs,
+          })
+        : {
+            channelId: destination?.channel_id,
+            threadTs: input.options.threadTs ?? destination?.thread_ts,
+          };
+      if (!resolved.channelId) {
+        throw new Error(`Draft ${input.draftId} has no destination; pass --channel.`);
+      }
+      // Inherit the existing broadcast flag only when the destination is truly
+      // unchanged: same channel (no --channel) AND same thread. Changing the
+      // thread (via --thread-ts) or re-addressing resets broadcast to what was
+      // explicitly requested, so an inherited flag can never ratchet a reply
+      // into a different thread's channel. `??` preserves an explicit
+      // --no-broadcast.
+      const broadcast =
+        input.options.broadcast ??
+        (!channelTarget && resolved.threadTs === destination?.thread_ts
+          ? destination?.broadcast
+          : undefined);
+      // A DM (`D...`) destination — targeted directly, via URL, or an existing
+      // DM draft — has no channel to broadcast to.
+      if (broadcast && isDmChannelId(resolved.channelId)) {
+        throw new Error("--broadcast is not supported for DM targets.");
+      }
+      if (broadcast && !resolved.threadTs) {
+        throw new Error("--broadcast requires a thread (use --thread-ts).");
+      }
+      const draft = await updateDraft(client, {
+        draftId: input.draftId,
+        clientLastUpdatedTs: lastUpdatedTs,
+        channelId: resolved.channelId,
+        text: input.text,
+        threadTs: resolved.threadTs,
+        broadcast,
+        fileIds: existing.file_ids,
+      });
+      return { ok: true, draft };
+    },
+  });
+}
+
+export async function deleteDraftAction(input: {
+  ctx: CliContext;
+  draftId: string;
+  options: { workspace?: string; lastUpdatedTs?: string };
+}): Promise<Record<string, unknown>> {
+  const workspaceUrl = input.ctx.effectiveWorkspaceUrl(input.options.workspace);
+  return await input.ctx.withAutoRefresh({
+    workspaceUrl,
+    work: async () => {
+      const { client } = await input.ctx.getClientForWorkspace(workspaceUrl);
+      await deleteDraft(client, {
+        draftId: input.draftId,
+        clientLastUpdatedTs: input.options.lastUpdatedTs,
+      });
+      return { ok: true, draft_id: input.draftId };
+    },
+  });
+}
+
+/** Slack 1:1 DM channels are `D...`; broadcast has no channel to target there. */
+function isDmChannelId(channelId: string): boolean {
+  return channelId.startsWith("D");
+}
+
+/**
+ * Reject `--broadcast` combinations that are invalid regardless of what Slack
+ * returns, before any network round-trip, so the error names the real problem
+ * (a DM target, or a channel target with no thread) instead of an incidental
+ * channel-name or message lookup failure. A message-URL target to a channel
+ * derives its thread from the message, so it is validated after resolution.
+ */
+function assertBroadcastAllowedStatically(
+  target: MsgTarget,
+  threadTsOption: string | undefined,
+): void {
+  if (target.kind === "user") {
+    throw new Error("--broadcast is not supported for DM targets.");
+  }
+  if (target.kind === "url") {
+    if (isDmChannelId(target.ref.channel_id)) {
+      throw new Error("--broadcast is not supported for DM targets.");
+    }
+    return;
+  }
+  const normalized = normalizeChannelInput(target.channel);
+  if (normalized.kind === "id" && isDmChannelId(normalized.value)) {
+    throw new Error("--broadcast is not supported for DM targets.");
+  }
+  if (!threadTsOption) {
+    throw new Error("--broadcast requires a thread (use --thread-ts or a message URL target).");
+  }
+}
+
+/**
+ * Resolve a draft destination from a CLI target. Message-URL targets draft a
+ * reply into that message's thread (same behavior as `message send`).
+ */
+async function resolveDraftDestination(
+  client: SlackApiClient,
+  input: { target: MsgTarget; threadTs?: string },
+): Promise<{ channelId: string; threadTs?: string }> {
+  const { target } = input;
+  if (target.kind === "url") {
+    warnOnTruncatedSlackUrl(target.ref);
+    const msg = await fetchMessage(client, { ref: target.ref });
+    return {
+      channelId: target.ref.channel_id,
+      threadTs: input.threadTs ?? msg.thread_ts ?? msg.ts,
+    };
+  }
+  if (target.kind === "user") {
+    return {
+      channelId: await openDmChannel(client, target.userId),
+      threadTs: input.threadTs,
+    };
+  }
+  return {
+    channelId: await resolveChannelId(client, target.channel),
+    threadTs: input.threadTs,
+  };
+}
+
+type HydratedDraft = SlackDraft & {
+  destinations: (SlackDraft["destinations"][number] & { channel_name?: string })[];
+};
+
+/** Attach channel/DM display names to draft destinations (best-effort). */
+async function hydrateChannelNames(
+  client: SlackApiClient,
+  drafts: SlackDraft[],
+): Promise<HydratedDraft[]> {
+  const channelIds = [
+    ...new Set(drafts.flatMap((d) => d.destinations.map((dest) => dest.channel_id))),
+  ];
+  const names = new Map<string, string>();
+  await Promise.all(
+    channelIds.map(async (channelId) => {
+      const name = await resolveChannelDisplayName(client, channelId);
+      if (name) {
+        names.set(channelId, name);
+      }
+    }),
+  );
+  return drafts.map((draft) => ({
+    ...draft,
+    destinations: draft.destinations.map((dest) => ({
+      ...dest,
+      channel_name: names.get(dest.channel_id),
+    })),
+  }));
+}
+
+async function resolveChannelDisplayName(
+  client: SlackApiClient,
+  channelId: string,
+): Promise<string | undefined> {
+  try {
+    const info = await client.api("conversations.info", { channel: channelId });
+    const ch = isRecord(info.channel) ? info.channel : null;
+    if (!ch) {
+      return undefined;
+    }
+    const name = getString(ch.name) ?? getString(ch.name_normalized);
+    if (name) {
+      return name;
+    }
+    if (ch.is_im) {
+      const userId = getString(ch.user);
+      if (userId) {
+        const userInfo = await client.api("users.info", { user: userId });
+        const u = isRecord(userInfo.user) ? userInfo.user : null;
+        const profile = u && isRecord(u.profile) ? u.profile : null;
+        return (
+          getString(profile?.display_name) ||
+          getString(u?.real_name) ||
+          getString(u?.name) ||
+          undefined
+        );
+      }
+    }
+  } catch {
+    // best-effort — drafts still list without names
+  }
+  return undefined;
+}

--- a/src/cli/message-draft-command.ts
+++ b/src/cli/message-draft-command.ts
@@ -1,0 +1,146 @@
+import type { Command } from "commander";
+import type { CliContext } from "./context.ts";
+import {
+  createDraftAction,
+  deleteDraftAction,
+  listDraftsAction,
+  updateDraftAction,
+} from "./message-draft-actions.ts";
+
+export function registerMessageDraftCommand(input: { messageCmd: Command; ctx: CliContext }): void {
+  const draftCmd = input.messageCmd
+    .command("draft")
+    .description(
+      "Manage Slack-native message drafts (appear in the user's Slack client; requires browser auth)",
+    )
+    .addHelpText(
+      "after",
+      "\nNote: the browser compose editor moved to `agent-slack message compose <target> [text]`.",
+    );
+
+  draftCmd
+    .command("list")
+    .description("List unsent message drafts")
+    .option("--workspace <url>", "Workspace selector (full URL or unique substring)")
+    .option("--limit <n>", "Max drafts to return")
+    .option("--all", "Include sent/inactive drafts")
+    .action(async (options: { workspace?: string; limit?: string; all?: boolean }) => {
+      try {
+        const payload = await listDraftsAction({ ctx: input.ctx, options });
+        console.log(JSON.stringify(payload, null, 2));
+      } catch (err: unknown) {
+        console.error(input.ctx.errorMessage(err));
+        process.exitCode = 1;
+      }
+    });
+
+  draftCmd
+    .command("create")
+    .description("Create a Slack-native draft addressed to a channel, DM, or thread")
+    .argument(
+      "<target>",
+      "Slack message URL (drafts a thread reply), #name/name, channel id, or user id (DM)",
+    )
+    .argument("<text>", "Draft message text (mrkdwn format)")
+    .option(
+      "--workspace <url>",
+      "Workspace selector (full URL or unique substring; needed when using #channel/channel id across multiple workspaces)",
+    )
+    .option("--thread-ts <ts>", "Thread root ts to draft a reply into (optional)")
+    .option(
+      "--broadcast",
+      "Also send the thread reply to the channel when posted (requires thread context)",
+    )
+    .action(async (...args) => {
+      const [targetInput, text, options] = args as [
+        string,
+        string,
+        { workspace?: string; threadTs?: string; broadcast?: boolean },
+      ];
+      try {
+        const payload = await createDraftAction({ ctx: input.ctx, targetInput, text, options });
+        console.log(JSON.stringify(payload, null, 2));
+      } catch (err: unknown) {
+        console.error(input.ctx.errorMessage(err));
+        process.exitCode = 1;
+      }
+    });
+
+  draftCmd
+    .command("update")
+    .description("Replace a draft's text (and optionally re-address it)")
+    .argument("<draft-id>", "Draft id returned by draft list/create")
+    .argument("<text>", "New draft message text (replaces the existing body)")
+    .option(
+      "--workspace <url>",
+      "Workspace selector (full URL or unique substring; needed when using #channel/channel id across multiple workspaces)",
+    )
+    .option("--channel <target>", "Re-address the draft to a different channel/DM/message URL")
+    .option("--thread-ts <ts>", "Thread root ts to draft a reply into (optional)")
+    .option(
+      "--broadcast",
+      "Also send the thread reply to the channel when posted (requires thread context)",
+    )
+    .option("--no-broadcast", "Clear an inherited broadcast flag (keeps the thread)")
+    .option(
+      "--last-updated-ts <ts>",
+      "Draft last_updated_ts for conflict detection (auto-fetched when omitted)",
+    )
+    .action(async (...args) => {
+      const [draftId, text, options] = args as [
+        string,
+        string,
+        {
+          workspace?: string;
+          channel?: string;
+          threadTs?: string;
+          broadcast?: boolean;
+          lastUpdatedTs?: string;
+        },
+      ];
+      try {
+        const payload = await updateDraftAction({ ctx: input.ctx, draftId, text, options });
+        console.log(JSON.stringify(payload, null, 2));
+      } catch (err: unknown) {
+        console.error(input.ctx.errorMessage(err));
+        process.exitCode = 1;
+      }
+    });
+
+  draftCmd
+    .command("delete")
+    .description("Delete a draft")
+    .argument("<draft-id>", "Draft id returned by draft list/create")
+    .option("--workspace <url>", "Workspace selector (full URL or unique substring)")
+    .option(
+      "--last-updated-ts <ts>",
+      "Draft last_updated_ts for conflict detection (auto-fetched when omitted)",
+    )
+    .action(async (...args) => {
+      const [draftId, options] = args as [string, { workspace?: string; lastUpdatedTs?: string }];
+      try {
+        const payload = await deleteDraftAction({ ctx: input.ctx, draftId, options });
+        console.log(JSON.stringify(payload, null, 2));
+      } catch (err: unknown) {
+        console.error(input.ctx.errorMessage(err));
+        process.exitCode = 1;
+      }
+    });
+
+  // `message draft` is now a subcommand group, so an old-style
+  // `message draft <target> [text]` (the browser editor) lands here as an
+  // unknown subcommand. Point it straight at `message compose` instead of
+  // leaving a bare "unknown command" that only `--help` explains.
+  draftCmd.on("command:*", (operands: string[]) => {
+    const attempted = operands[0] ?? "";
+    console.error(
+      `error: '${attempted}' is not a 'message draft' subcommand (expected: list, create, update, delete).`,
+    );
+    console.error(
+      `The browser compose editor moved to \`message compose\`:\n  agent-slack message compose ${
+        attempted ? JSON.stringify(attempted) : "<target>"
+      } [text]`,
+    );
+    process.exitCode = 1;
+  });
+}

--- a/src/slack/drafts.ts
+++ b/src/slack/drafts.ts
@@ -1,0 +1,213 @@
+/**
+ * Slack-native message drafts via the undocumented `drafts.*` session
+ * endpoints (the same API the official Slack clients use). Drafts created
+ * here show up natively in the user's Slack client.
+ *
+ * Requires browser-style auth (xoxc/xoxd); bot/user tokens are rejected by
+ * Slack with `unknown_method` / `not_allowed_token_type`.
+ */
+
+import type { SlackApiClient } from "./client.ts";
+import { asArray, getNumber, getString, isRecord } from "../lib/object-type-guards.ts";
+import { extractMrkdwnFromRichTextBlock } from "./render-rich-text.ts";
+import { parseInlineElements, textToRichTextBlocks } from "./rich-text.ts";
+
+export type DraftDestination = {
+  channel_id: string;
+  thread_ts?: string;
+  broadcast?: boolean;
+};
+
+export type SlackDraft = {
+  id: string;
+  text?: string;
+  destinations: DraftDestination[];
+  last_updated_ts?: string;
+  date_created?: number;
+  date_scheduled?: number;
+  file_ids?: string[];
+};
+
+/**
+ * Pad a draft timestamp's fractional part to 7 digits.
+ * Slack rejects `client_last_updated_ts` values with fewer places
+ * (e.g. "1700000000.123" must be sent as "1700000000.1230000").
+ */
+export function padDraftTs(ts: string): string {
+  const dot = ts.indexOf(".");
+  if (dot === -1) {
+    return ts;
+  }
+  const frac = ts.slice(dot + 1);
+  return `${ts.slice(0, dot)}.${frac.padEnd(7, "0")}`;
+}
+
+/**
+ * Convert draft text to rich_text blocks. Drafts have no plain-text
+ * fallback param, so unformatted text is wrapped in a single section.
+ */
+export function draftTextToBlocks(text: string): unknown[] {
+  const rich = textToRichTextBlocks(text, { includeInlineFormatting: true });
+  if (rich) {
+    return rich;
+  }
+  return [
+    {
+      type: "rich_text",
+      elements: [{ type: "rich_text_section", elements: parseInlineElements(text) }],
+    },
+  ];
+}
+
+export function parseDraftRecord(raw: unknown): SlackDraft | null {
+  if (!isRecord(raw)) {
+    return null;
+  }
+  const id = getString(raw.id);
+  if (!id) {
+    return null;
+  }
+
+  const destinations = asArray(raw.destinations)
+    .filter(isRecord)
+    .flatMap((dest): DraftDestination[] => {
+      const channelId = getString(dest.channel_id);
+      if (!channelId) {
+        return [];
+      }
+      return [
+        {
+          channel_id: channelId,
+          thread_ts: getString(dest.thread_ts) || undefined,
+          broadcast: dest.broadcast === true ? true : undefined,
+        },
+      ];
+    });
+
+  const text = asArray(raw.blocks)
+    .map((block) => extractMrkdwnFromRichTextBlock(block))
+    .filter((t) => t.trim())
+    .join("\n\n")
+    .trim();
+
+  const fileIds = asArray(raw.file_ids).filter(
+    (fileId): fileId is string => typeof fileId === "string",
+  );
+  const dateScheduled = getNumber(raw.date_scheduled);
+
+  return {
+    id,
+    text: text || undefined,
+    destinations,
+    last_updated_ts: getString(raw.last_updated_ts),
+    date_created: getNumber(raw.date_created),
+    date_scheduled: dateScheduled && dateScheduled > 0 ? dateScheduled : undefined,
+    file_ids: fileIds.length > 0 ? fileIds : undefined,
+  };
+}
+
+export async function listDrafts(
+  client: SlackApiClient,
+  options?: { limit?: number; activeOnly?: boolean },
+): Promise<{ drafts: SlackDraft[] }> {
+  const resp = await client.api("drafts.list", {
+    is_active: options?.activeOnly === false ? undefined : true,
+    limit: options?.limit,
+  });
+  const drafts = asArray(resp.drafts)
+    .map(parseDraftRecord)
+    .filter((draft): draft is SlackDraft => draft !== null);
+  return { drafts };
+}
+
+export async function findDraft(client: SlackApiClient, draftId: string): Promise<SlackDraft> {
+  const { drafts } = await listDrafts(client, { activeOnly: false });
+  const matches = drafts.filter((d) => d.id === draftId);
+  // update/delete need last_updated_ts for conflict detection, so prefer a
+  // usable record if the response happens to include a malformed duplicate
+  // (e.g. a first entry missing last_updated_ts).
+  const draft = matches.find((d) => d.last_updated_ts) ?? matches[0];
+  if (!draft) {
+    throw new Error(`Draft not found: ${draftId}. Run "message draft list" to see draft ids.`);
+  }
+  return draft;
+}
+
+/**
+ * Shared wire payload for drafts.create / drafts.update: text wrapped as a
+ * rich_text block, addressed to one destination, with a fresh client_msg_id.
+ * `blocks`, `destinations` and `file_ids` are serialized to JSON strings by
+ * the form-encoding client, which is what these endpoints expect.
+ */
+function buildDraftBody(input: {
+  channelId: string;
+  text: string;
+  threadTs?: string;
+  broadcast?: boolean;
+  fileIds?: string[];
+}): Record<string, unknown> {
+  const destination: DraftDestination = { channel_id: input.channelId };
+  if (input.threadTs) {
+    destination.thread_ts = input.threadTs;
+    destination.broadcast = input.broadcast === true;
+  }
+  return {
+    blocks: draftTextToBlocks(input.text),
+    destinations: [destination],
+    client_msg_id: crypto.randomUUID(),
+    file_ids: input.fileIds ?? [],
+  };
+}
+
+export async function createDraft(
+  client: SlackApiClient,
+  input: {
+    channelId: string;
+    text: string;
+    threadTs?: string;
+    broadcast?: boolean;
+  },
+): Promise<SlackDraft | null> {
+  const resp = await client.api("drafts.create", {
+    ...buildDraftBody(input),
+    // Sent on create only, matching the official client's behavior.
+    is_from_composer: true,
+  });
+  return parseDraftRecord(resp.draft);
+}
+
+export async function updateDraft(
+  client: SlackApiClient,
+  input: {
+    draftId: string;
+    clientLastUpdatedTs: string;
+    channelId: string;
+    text: string;
+    threadTs?: string;
+    broadcast?: boolean;
+    fileIds?: string[];
+  },
+): Promise<SlackDraft | null> {
+  const resp = await client.api("drafts.update", {
+    ...buildDraftBody(input),
+    draft_id: input.draftId,
+    client_last_updated_ts: padDraftTs(input.clientLastUpdatedTs),
+  });
+  return parseDraftRecord(resp.draft);
+}
+
+export async function deleteDraft(
+  client: SlackApiClient,
+  input: { draftId: string; clientLastUpdatedTs?: string },
+): Promise<void> {
+  // Slack requires the draft's last-updated ts to detect conflicts; fetch it
+  // when the caller doesn't have one.
+  const ts = input.clientLastUpdatedTs ?? (await findDraft(client, input.draftId)).last_updated_ts;
+  if (!ts) {
+    throw new Error(`Draft ${input.draftId} has no last_updated_ts; cannot delete.`);
+  }
+  await client.api("drafts.delete", {
+    draft_id: input.draftId,
+    client_last_updated_ts: padDraftTs(ts),
+  });
+}

--- a/test/drafts.test.ts
+++ b/test/drafts.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, test } from "bun:test";
+import {
+  createDraft,
+  deleteDraft,
+  draftTextToBlocks,
+  findDraft,
+  listDrafts,
+  padDraftTs,
+  parseDraftRecord,
+  updateDraft,
+} from "../src/slack/drafts.ts";
+import type { SlackApiClient } from "../src/slack/client.ts";
+
+function createClient(responses: Record<string, Record<string, unknown>>) {
+  const calls: { method: string; params: Record<string, unknown> }[] = [];
+  const client = {
+    api: async (method: string, params: Record<string, unknown> = {}) => {
+      calls.push({ method, params });
+      return responses[method] ?? { ok: true };
+    },
+  } as unknown as SlackApiClient;
+  return { client, calls };
+}
+
+const rawDraft = {
+  id: "Dr123",
+  last_updated_ts: "1700000000.123",
+  date_created: 1700000000,
+  destinations: [{ channel_id: "C123", thread_ts: "1699.000100", broadcast: true }],
+  blocks: [
+    {
+      type: "rich_text",
+      elements: [{ type: "rich_text_section", elements: [{ type: "text", text: "hello world" }] }],
+    },
+  ],
+  file_ids: ["F1"],
+  date_scheduled: 0,
+};
+
+describe("padDraftTs", () => {
+  test("pads short fractional parts to 7 digits", () => {
+    expect(padDraftTs("1700000000.123")).toBe("1700000000.1230000");
+  });
+
+  test("leaves 7-digit fractional parts unchanged", () => {
+    expect(padDraftTs("1700000000.1234567")).toBe("1700000000.1234567");
+  });
+
+  test("leaves timestamps without a fractional part unchanged", () => {
+    expect(padDraftTs("1700000000")).toBe("1700000000");
+  });
+});
+
+describe("draftTextToBlocks", () => {
+  test("wraps plain text in a rich_text section", () => {
+    expect(draftTextToBlocks("hello world")).toEqual([
+      {
+        type: "rich_text",
+        elements: [
+          { type: "rich_text_section", elements: [{ type: "text", text: "hello world" }] },
+        ],
+      },
+    ]);
+  });
+
+  test("converts bullet lists to rich_text lists", () => {
+    const blocks = draftTextToBlocks("- one\n- two") as {
+      type: string;
+      elements: { type: string }[];
+    }[];
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]?.elements.some((el) => el.type === "rich_text_list")).toBe(true);
+  });
+});
+
+describe("parseDraftRecord", () => {
+  test("parses a raw draft into a compact shape", () => {
+    expect(parseDraftRecord(rawDraft)).toEqual({
+      id: "Dr123",
+      text: "hello world",
+      destinations: [{ channel_id: "C123", thread_ts: "1699.000100", broadcast: true }],
+      last_updated_ts: "1700000000.123",
+      date_created: 1700000000,
+      date_scheduled: undefined,
+      file_ids: ["F1"],
+    });
+  });
+
+  test("returns null for records without an id", () => {
+    expect(parseDraftRecord({ blocks: [] })).toBeNull();
+    expect(parseDraftRecord(null)).toBeNull();
+  });
+});
+
+describe("listDrafts", () => {
+  test("requests active drafts and parses the result", async () => {
+    const { client, calls } = createClient({
+      "drafts.list": { ok: true, drafts: [rawDraft, { not: "a draft" }] },
+    });
+
+    const result = await listDrafts(client, { limit: 10 });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.method).toBe("drafts.list");
+    expect(calls[0]?.params).toEqual({ is_active: true, limit: 10 });
+    expect(result.drafts).toHaveLength(1);
+    expect(result.drafts[0]?.id).toBe("Dr123");
+  });
+
+  test("omits is_active when activeOnly is false", async () => {
+    const { client, calls } = createClient({ "drafts.list": { ok: true, drafts: [] } });
+
+    await listDrafts(client, { activeOnly: false });
+
+    expect(calls[0]?.params.is_active).toBeUndefined();
+  });
+});
+
+describe("createDraft", () => {
+  test("sends blocks, destination, and composer flag", async () => {
+    const { client, calls } = createClient({
+      "drafts.create": { ok: true, draft: rawDraft },
+    });
+
+    const draft = await createDraft(client, {
+      channelId: "C123",
+      text: "hello",
+      threadTs: "1699.000100",
+      broadcast: true,
+    });
+
+    expect(calls).toHaveLength(1);
+    const { params } = calls[0]!;
+    expect(calls[0]?.method).toBe("drafts.create");
+    expect(params.destinations).toEqual([
+      { channel_id: "C123", thread_ts: "1699.000100", broadcast: true },
+    ]);
+    expect(params.blocks).toEqual([
+      {
+        type: "rich_text",
+        elements: [{ type: "rich_text_section", elements: [{ type: "text", text: "hello" }] }],
+      },
+    ]);
+    expect(params.file_ids).toEqual([]);
+    expect(params.is_from_composer).toBe(true);
+    expect(typeof params.client_msg_id).toBe("string");
+    expect(draft?.id).toBe("Dr123");
+  });
+
+  test("omits thread fields for channel drafts", async () => {
+    const { client, calls } = createClient({ "drafts.create": { ok: true } });
+
+    await createDraft(client, { channelId: "C123", text: "hello" });
+
+    expect(calls[0]?.params.destinations).toEqual([{ channel_id: "C123" }]);
+  });
+});
+
+describe("updateDraft", () => {
+  test("sends draft_id and a padded last-updated ts", async () => {
+    const { client, calls } = createClient({
+      "drafts.update": { ok: true, draft: rawDraft },
+    });
+
+    await updateDraft(client, {
+      draftId: "Dr123",
+      clientLastUpdatedTs: "1700000000.123",
+      channelId: "C123",
+      text: "updated",
+      fileIds: ["F1"],
+    });
+
+    expect(calls).toHaveLength(1);
+    const { params } = calls[0]!;
+    expect(calls[0]?.method).toBe("drafts.update");
+    expect(params.draft_id).toBe("Dr123");
+    expect(params.client_last_updated_ts).toBe("1700000000.1230000");
+    expect(params.file_ids).toEqual(["F1"]);
+    expect(params.is_from_composer).toBeUndefined();
+  });
+});
+
+describe("deleteDraft", () => {
+  test("deletes with an explicit last-updated ts", async () => {
+    const { client, calls } = createClient({ "drafts.delete": { ok: true } });
+
+    await deleteDraft(client, { draftId: "Dr123", clientLastUpdatedTs: "1700000000.123" });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.method).toBe("drafts.delete");
+    expect(calls[0]?.params).toEqual({
+      draft_id: "Dr123",
+      client_last_updated_ts: "1700000000.1230000",
+    });
+  });
+
+  test("fetches the last-updated ts from drafts.list when omitted", async () => {
+    const { client, calls } = createClient({
+      "drafts.list": { ok: true, drafts: [rawDraft] },
+      "drafts.delete": { ok: true },
+    });
+
+    await deleteDraft(client, { draftId: "Dr123" });
+
+    expect(calls.map((c) => c.method)).toEqual(["drafts.list", "drafts.delete"]);
+    expect(calls[1]?.params.client_last_updated_ts).toBe("1700000000.1230000");
+  });
+
+  test("throws when the draft does not exist", async () => {
+    const { client } = createClient({ "drafts.list": { ok: true, drafts: [] } });
+
+    expect(deleteDraft(client, { draftId: "DrMissing" })).rejects.toThrow(
+      "Draft not found: DrMissing",
+    );
+  });
+});
+
+describe("findDraft", () => {
+  test("lists all drafts (including inactive) and finds by id", async () => {
+    const { client, calls } = createClient({
+      "drafts.list": { ok: true, drafts: [rawDraft] },
+    });
+
+    const draft = await findDraft(client, "Dr123");
+
+    expect(draft.id).toBe("Dr123");
+    expect(calls[0]?.params.is_active).toBeUndefined();
+  });
+
+  test("prefers a matching record that has last_updated_ts over a malformed duplicate", async () => {
+    const { client } = createClient({
+      "drafts.list": {
+        ok: true,
+        // First entry lacks last_updated_ts; the usable one comes later.
+        drafts: [{ id: "Dr123", destinations: [] }, rawDraft],
+      },
+    });
+
+    const draft = await findDraft(client, "Dr123");
+
+    expect(draft.last_updated_ts).toBe("1700000000.123");
+  });
+});

--- a/test/help-contracts.test.ts
+++ b/test/help-contracts.test.ts
@@ -49,12 +49,20 @@ describe("agent-facing help contracts", () => {
     expect(optionDescription(send, "--reply-broadcast")).toContain("DM targets");
   });
 
-  test("message draft identifies its CI send behavior", () => {
-    const draft = findCommand(buildProgram(), "message", "draft");
+  test("message compose identifies its CI send behavior", () => {
+    const compose = findCommand(buildProgram(), "message", "compose");
 
-    expect(draft.description()).toContain("CI skips the editor");
-    expect(draft.registeredArguments[1]?.description).toContain("sent immediately");
-    expect(optionDescription(draft, "--thread-ts")).toContain("overrides the URL-derived thread");
+    expect(compose.description()).toContain("CI skips the editor");
+    expect(compose.registeredArguments[1]?.description).toContain("sent immediately");
+    expect(optionDescription(compose, "--thread-ts")).toContain("overrides the URL-derived thread");
+  });
+
+  test("Slack-native drafts document DM targeting and inherited-broadcast controls", () => {
+    const create = findCommand(buildProgram(), "message", "draft", "create");
+    expect(create.registeredArguments[0]?.description).toContain("user id");
+
+    const update = findCommand(buildProgram(), "message", "draft", "update");
+    expect(optionDescription(update, "--no-broadcast")).toContain("inherited");
   });
 
   test("scheduled cancellation identifies its required channel", () => {

--- a/test/message-draft-actions.test.ts
+++ b/test/message-draft-actions.test.ts
@@ -1,0 +1,589 @@
+import { describe, expect, spyOn, test } from "bun:test";
+import { Command } from "commander";
+import type { CliContext } from "../src/cli/context.ts";
+import {
+  createDraftAction,
+  deleteDraftAction,
+  listDraftsAction,
+  updateDraftAction,
+} from "../src/cli/message-draft-actions.ts";
+import { registerMessageDraftCommand } from "../src/cli/message-draft-command.ts";
+
+type Call = { method: string; params: Record<string, unknown> };
+
+/**
+ * Build a mock CliContext whose client records every api() call and answers
+ * drafts.* / conversations.info from the supplied fixtures. Mirrors the
+ * createContext helper in message-send.test.ts.
+ */
+function createContext(
+  calls: Call[],
+  fixtures: {
+    draftsList?: Record<string, unknown>[];
+    channelInfo?: Record<string, Record<string, unknown>>;
+  } = {},
+) {
+  const client = {
+    api: async (method: string, params: Record<string, unknown> = {}) => {
+      calls.push({ method, params });
+      switch (method) {
+        case "drafts.list":
+          return { ok: true, drafts: fixtures.draftsList ?? [] };
+        case "drafts.create":
+          return { ok: true, draft: { id: "DrNew", destinations: params.destinations } };
+        case "drafts.update":
+          return {
+            ok: true,
+            draft: { id: String(params.draft_id), destinations: params.destinations },
+          };
+        case "drafts.delete":
+          return { ok: true };
+        case "conversations.open":
+          return { ok: true, channel: { id: "D99999999" } };
+        case "conversations.info": {
+          const info = fixtures.channelInfo?.[String(params.channel)];
+          return info ? { ok: true, channel: info } : { ok: true };
+        }
+        default:
+          return { ok: true };
+      }
+    },
+  };
+
+  return {
+    effectiveWorkspaceUrl: (flag?: string) => flag,
+    assertWorkspaceSpecifiedForChannelNames: async () => {},
+    withAutoRefresh: async <T>(input: {
+      workspaceUrl: string | undefined;
+      work: () => Promise<T>;
+    }) => input.work(),
+    getClientForWorkspace: async () => ({
+      client: client as never,
+      auth: { auth_type: "standard", token: "x" as const },
+      workspace_url: "https://workspace.slack.com",
+    }),
+    normalizeUrl: (u: string) => u,
+    errorMessage: (err: unknown) => (err instanceof Error ? err.message : String(err)),
+    parseContentType: () => "any",
+    parseCurl: () => ({
+      workspace_url: "https://workspace.slack.com",
+      xoxc_token: "xoxc-1",
+      xoxd_cookie: "xoxd-1",
+    }),
+    importDesktop: async () => ({
+      cookie_d: "",
+      teams: [],
+      source: { leveldb_path: "", cookies_path: "" },
+    }),
+    importChrome: () => ({ cookie_d: "", teams: [] }),
+    importBrave: async () => null,
+    importFirefox: async () => null,
+  } satisfies CliContext;
+}
+
+function draftsUpdateCall(calls: Call[]): Call {
+  const call = calls.find((c) => c.method === "drafts.update");
+  if (!call) {
+    throw new Error("expected a drafts.update call");
+  }
+  return call;
+}
+
+describe("createDraftAction", () => {
+  test("creates a draft addressed to a channel id", async () => {
+    const calls: Call[] = [];
+    const ctx = createContext(calls);
+
+    const result = await createDraftAction({
+      ctx,
+      targetInput: "C11111111",
+      text: "hello",
+      options: { workspace: "https://workspace.slack.com" },
+    });
+
+    const create = calls.find((c) => c.method === "drafts.create");
+    expect(create).toBeDefined();
+    expect(create?.params.destinations).toEqual([{ channel_id: "C11111111" }]);
+    expect(Array.isArray(create?.params.blocks)).toBe(true);
+    expect(result).toEqual({
+      ok: true,
+      draft: { id: "DrNew", destinations: [{ channel_id: "C11111111" }] },
+    });
+  });
+
+  test("rejects --broadcast without a thread", async () => {
+    const calls: Call[] = [];
+    const ctx = createContext(calls);
+
+    await expect(
+      createDraftAction({
+        ctx,
+        targetInput: "C11111111",
+        text: "hello",
+        options: { workspace: "https://workspace.slack.com", broadcast: true },
+      }),
+    ).rejects.toThrow(/--broadcast requires a thread/);
+    expect(calls.some((c) => c.method === "drafts.create")).toBe(false);
+  });
+
+  test("rejects --broadcast for a DM (user) target", async () => {
+    const calls: Call[] = [];
+    const ctx = createContext(calls);
+
+    await expect(
+      createDraftAction({
+        ctx,
+        targetInput: "W12345678",
+        text: "hello",
+        options: {
+          workspace: "https://workspace.slack.com",
+          threadTs: "1700000000.100000",
+          broadcast: true,
+        },
+      }),
+    ).rejects.toThrow(/not supported for DM targets/);
+    expect(calls.some((c) => c.method === "drafts.create")).toBe(false);
+  });
+
+  test("rejects --broadcast for a D... channel-id (DM) target", async () => {
+    const calls: Call[] = [];
+    const ctx = createContext(calls);
+
+    await expect(
+      createDraftAction({
+        ctx,
+        targetInput: "D12345678",
+        text: "hello",
+        options: {
+          workspace: "https://workspace.slack.com",
+          threadTs: "1700000000.100000",
+          broadcast: true,
+        },
+      }),
+    ).rejects.toThrow(/not supported for DM targets/);
+    expect(calls.some((c) => c.method === "drafts.create")).toBe(false);
+  });
+
+  test("rejects --broadcast on a channel name with no thread before any network call", async () => {
+    const calls: Call[] = [];
+    const ctx = createContext(calls);
+
+    await expect(
+      createDraftAction({
+        ctx,
+        targetInput: "general",
+        text: "x",
+        options: { workspace: "https://workspace.slack.com", broadcast: true },
+      }),
+    ).rejects.toThrow(/--broadcast requires a thread/);
+    // The real problem (no thread) is reported without a channel-resolution round-trip.
+    expect(calls.length).toBe(0);
+  });
+
+  test("rejects --broadcast on a DM message URL before fetching the message", async () => {
+    const calls: Call[] = [];
+    const ctx = createContext(calls);
+
+    await expect(
+      createDraftAction({
+        ctx,
+        targetInput: "https://workspace.slack.com/archives/D12345678/p1700000000100000",
+        text: "x",
+        options: { broadcast: true },
+      }),
+    ).rejects.toThrow(/not supported for DM targets/);
+    expect(calls.length).toBe(0);
+  });
+});
+
+describe("updateDraftAction", () => {
+  const threadedBroadcastDraft = {
+    id: "Dr123",
+    blocks: [],
+    destinations: [{ channel_id: "C11111111", thread_ts: "1700000000.100000", broadcast: true }],
+    last_updated_ts: "1700000000.123",
+    file_ids: ["F1", "F2"],
+  };
+
+  test("text-only edit preserves destination, thread, broadcast, and file ids", async () => {
+    const calls: Call[] = [];
+    const ctx = createContext(calls, { draftsList: [threadedBroadcastDraft] });
+
+    await updateDraftAction({
+      ctx,
+      draftId: "Dr123",
+      text: "revised",
+      options: { workspace: "https://workspace.slack.com" },
+    });
+
+    const update = draftsUpdateCall(calls);
+    // conflict-detection ts is auto-fetched and padded to 7 fractional digits.
+    expect(update.params.client_last_updated_ts).toBe("1700000000.1230000");
+    expect(update.params.destinations).toEqual([
+      { channel_id: "C11111111", thread_ts: "1700000000.100000", broadcast: true },
+    ]);
+    expect(update.params.file_ids).toEqual(["F1", "F2"]);
+  });
+
+  test("re-addressing a broadcast thread draft to a non-thread channel clears broadcast instead of erroring", async () => {
+    const calls: Call[] = [];
+    const ctx = createContext(calls, { draftsList: [threadedBroadcastDraft] });
+
+    // Regression: an inherited broadcast flag must not become a one-way ratchet
+    // that fails the "broadcast requires a thread" guard on a non-thread target.
+    await updateDraftAction({
+      ctx,
+      draftId: "Dr123",
+      text: "revised",
+      options: { workspace: "https://workspace.slack.com", channel: "C99999999" },
+    });
+
+    const update = draftsUpdateCall(calls);
+    expect(update.params.destinations).toEqual([{ channel_id: "C99999999" }]);
+  });
+
+  test("explicit --broadcast on a non-thread draft still errors", async () => {
+    const calls: Call[] = [];
+    const ctx = createContext(calls, {
+      draftsList: [
+        {
+          id: "Dr123",
+          blocks: [],
+          destinations: [{ channel_id: "C11111111" }],
+          last_updated_ts: "1700000000.5",
+        },
+      ],
+    });
+
+    await expect(
+      updateDraftAction({
+        ctx,
+        draftId: "Dr123",
+        text: "revised",
+        options: { workspace: "https://workspace.slack.com", broadcast: true },
+      }),
+    ).rejects.toThrow(/--broadcast requires a thread/);
+    expect(calls.some((c) => c.method === "drafts.update")).toBe(false);
+  });
+
+  test("refuses to update a scheduled draft rather than clearing its schedule", async () => {
+    const calls: Call[] = [];
+    const ctx = createContext(calls, {
+      draftsList: [
+        {
+          id: "Dr123",
+          blocks: [],
+          destinations: [{ channel_id: "C11111111" }],
+          last_updated_ts: "1700000000.5",
+          date_scheduled: 1800000000,
+        },
+      ],
+    });
+
+    await expect(
+      updateDraftAction({
+        ctx,
+        draftId: "Dr123",
+        text: "revised",
+        options: { workspace: "https://workspace.slack.com" },
+      }),
+    ).rejects.toThrow(/scheduled send time/);
+    expect(calls.some((c) => c.method === "drafts.update")).toBe(false);
+  });
+
+  test("refuses a text-only update on a multi-destination draft, but allows re-addressing", async () => {
+    const multiDest = {
+      id: "Dr123",
+      blocks: [],
+      destinations: [{ channel_id: "C11111111" }, { channel_id: "C22222222" }],
+      last_updated_ts: "1700000000.5",
+    };
+
+    // Text-only: would drop the second recipient — must throw.
+    const calls1: Call[] = [];
+    await expect(
+      updateDraftAction({
+        ctx: createContext(calls1, { draftsList: [multiDest] }),
+        draftId: "Dr123",
+        text: "revised",
+        options: { workspace: "https://workspace.slack.com" },
+      }),
+    ).rejects.toThrow(/multiple destinations/);
+    expect(calls1.some((c) => c.method === "drafts.update")).toBe(false);
+
+    // Explicit re-address is an intentional single-destination move — allowed.
+    const calls2: Call[] = [];
+    await updateDraftAction({
+      ctx: createContext(calls2, { draftsList: [multiDest] }),
+      draftId: "Dr123",
+      text: "revised",
+      options: { workspace: "https://workspace.slack.com", channel: "C99999999" },
+    });
+    expect(draftsUpdateCall(calls2).params.destinations).toEqual([{ channel_id: "C99999999" }]);
+  });
+
+  test("re-addressing to a different thread does not inherit the old broadcast flag", async () => {
+    const calls: Call[] = [];
+    const ctx = createContext(calls, { draftsList: [threadedBroadcastDraft] });
+
+    await updateDraftAction({
+      ctx,
+      draftId: "Dr123",
+      text: "revised",
+      options: {
+        workspace: "https://workspace.slack.com",
+        channel: "C22222222",
+        threadTs: "1700000000.200000",
+      },
+    });
+
+    // Regression: --channel resets broadcast to explicit-only, so moving to a
+    // new thread must not carry broadcast:true from the old destination.
+    expect(draftsUpdateCall(calls).params.destinations).toEqual([
+      { channel_id: "C22222222", thread_ts: "1700000000.200000", broadcast: false },
+    ]);
+  });
+
+  test("--no-broadcast clears an inherited broadcast flag on a same-thread edit", async () => {
+    const calls: Call[] = [];
+    const ctx = createContext(calls, { draftsList: [threadedBroadcastDraft] });
+
+    await updateDraftAction({
+      ctx,
+      draftId: "Dr123",
+      text: "revised",
+      options: { workspace: "https://workspace.slack.com", broadcast: false },
+    });
+
+    expect(draftsUpdateCall(calls).params.destinations).toEqual([
+      { channel_id: "C11111111", thread_ts: "1700000000.100000", broadcast: false },
+    ]);
+  });
+
+  test("rejects --broadcast when re-addressing to a DM (user) target", async () => {
+    const calls: Call[] = [];
+    const ctx = createContext(calls, { draftsList: [threadedBroadcastDraft] });
+
+    await expect(
+      updateDraftAction({
+        ctx,
+        draftId: "Dr123",
+        text: "revised",
+        options: {
+          workspace: "https://workspace.slack.com",
+          channel: "W12345678",
+          broadcast: true,
+        },
+      }),
+    ).rejects.toThrow(/not supported for DM targets/);
+    // Fail-fast: the static re-address guard rejects before any network call
+    // (no findDraft / drafts.list), so nothing is sent to the client.
+    expect(calls).toEqual([]);
+  });
+
+  test("changing only --thread-ts (no --channel) does not inherit the old broadcast flag", async () => {
+    const calls: Call[] = [];
+    const ctx = createContext(calls, { draftsList: [threadedBroadcastDraft] });
+
+    await updateDraftAction({
+      ctx,
+      draftId: "Dr123",
+      text: "moved",
+      options: { workspace: "https://workspace.slack.com", threadTs: "1700000000.200000" },
+    });
+
+    // Moving to a different thread is a destination change, so broadcast resets
+    // to explicit-only (here: unset) rather than carrying broadcast:true over.
+    expect(draftsUpdateCall(calls).params.destinations).toEqual([
+      { channel_id: "C11111111", thread_ts: "1700000000.200000", broadcast: false },
+    ]);
+  });
+
+  test("rejects --broadcast on an existing DM-destination draft", async () => {
+    const calls: Call[] = [];
+    const ctx = createContext(calls, {
+      draftsList: [
+        {
+          id: "Dr123",
+          blocks: [],
+          destinations: [{ channel_id: "D12345678", thread_ts: "1700000000.100000" }],
+          last_updated_ts: "1700000000.5",
+        },
+      ],
+    });
+
+    await expect(
+      updateDraftAction({
+        ctx,
+        draftId: "Dr123",
+        text: "revised",
+        options: { workspace: "https://workspace.slack.com", broadcast: true },
+      }),
+    ).rejects.toThrow(/not supported for DM targets/);
+    expect(calls.some((c) => c.method === "drafts.update")).toBe(false);
+  });
+
+  test("rejects --broadcast when re-addressing to a channel name with no thread, before resolving it", async () => {
+    const calls: Call[] = [];
+    const ctx = createContext(calls, {
+      draftsList: [
+        {
+          id: "Dr123",
+          blocks: [],
+          destinations: [{ channel_id: "C11111111" }],
+          last_updated_ts: "1700000000.5",
+        },
+      ],
+    });
+
+    await expect(
+      updateDraftAction({
+        ctx,
+        draftId: "Dr123",
+        text: "x",
+        options: { workspace: "https://workspace.slack.com", channel: "general", broadcast: true },
+      }),
+    ).rejects.toThrow(/--broadcast requires a thread/);
+    // findDraft (drafts.list) runs, but no channel-name resolution round-trip.
+    expect(calls.some((c) => c.method === "search.messages")).toBe(false);
+  });
+});
+
+describe("deleteDraftAction", () => {
+  test("auto-fetches and pads last_updated_ts when omitted", async () => {
+    const calls: Call[] = [];
+    const ctx = createContext(calls, {
+      draftsList: [
+        {
+          id: "Dr123",
+          blocks: [],
+          destinations: [{ channel_id: "C11111111" }],
+          last_updated_ts: "1700000000.42",
+        },
+      ],
+    });
+
+    const result = await deleteDraftAction({
+      ctx,
+      draftId: "Dr123",
+      options: { workspace: "https://workspace.slack.com" },
+    });
+
+    const del = calls.find((c) => c.method === "drafts.delete");
+    expect(del?.params).toEqual({
+      draft_id: "Dr123",
+      client_last_updated_ts: "1700000000.4200000",
+    });
+    expect(result).toEqual({ ok: true, draft_id: "Dr123" });
+  });
+});
+
+describe("listDraftsAction", () => {
+  test("hydrates channel display names", async () => {
+    const calls: Call[] = [];
+    const ctx = createContext(calls, {
+      draftsList: [
+        {
+          id: "Dr123",
+          blocks: [],
+          destinations: [{ channel_id: "C11111111" }],
+          last_updated_ts: "1700000000.1",
+        },
+      ],
+      channelInfo: { C11111111: { id: "C11111111", name: "general" } },
+    });
+
+    const result = (await listDraftsAction({
+      ctx,
+      options: { workspace: "https://workspace.slack.com" },
+    })) as { ok: boolean; count: number; drafts: { destinations: { channel_name?: string }[] }[] };
+
+    expect(result.ok).toBe(true);
+    expect(result.count).toBe(1);
+    expect(result.drafts[0]?.destinations[0]?.channel_name).toBe("general");
+  });
+});
+
+describe("message draft update (commander --broadcast wiring)", () => {
+  const threadedBroadcast = {
+    id: "Dr123",
+    blocks: [],
+    destinations: [{ channel_id: "C11111111", thread_ts: "1700000000.100000", broadcast: true }],
+    last_updated_ts: "1700000000.5",
+  };
+  const threadedPlain = {
+    id: "Dr123",
+    blocks: [],
+    destinations: [{ channel_id: "C11111111", thread_ts: "1700000000.100000" }],
+    last_updated_ts: "1700000000.5",
+  };
+
+  async function runUpdate(flags: string[], draft: Record<string, unknown>): Promise<Call[]> {
+    const calls: Call[] = [];
+    const program = new Command();
+    program.exitOverride();
+    const messageCmd = program.command("message");
+    registerMessageDraftCommand({ ctx: createContext(calls, { draftsList: [draft] }), messageCmd });
+    await program.parseAsync([
+      "node",
+      "agent-slack",
+      "message",
+      "draft",
+      "update",
+      "Dr123",
+      "revised",
+      "--workspace",
+      "https://workspace.slack.com",
+      ...flags,
+    ]);
+    return calls;
+  }
+
+  test("omitting broadcast flags does not force broadcast on (no Commander default-true gotcha)", async () => {
+    const calls = await runUpdate([], threadedPlain);
+    // If defining --no-broadcast had made `broadcast` default to true, this
+    // non-broadcast draft would be silently promoted on a plain text edit.
+    expect(draftsUpdateCall(calls).params.destinations).toEqual([
+      { channel_id: "C11111111", thread_ts: "1700000000.100000", broadcast: false },
+    ]);
+  });
+
+  test("--broadcast sets broadcast true", async () => {
+    const calls = await runUpdate(["--broadcast"], threadedPlain);
+    expect(draftsUpdateCall(calls).params.destinations).toEqual([
+      { channel_id: "C11111111", thread_ts: "1700000000.100000", broadcast: true },
+    ]);
+  });
+
+  test("--no-broadcast clears an inherited broadcast flag", async () => {
+    const calls = await runUpdate(["--no-broadcast"], threadedBroadcast);
+    expect(draftsUpdateCall(calls).params.destinations).toEqual([
+      { channel_id: "C11111111", thread_ts: "1700000000.100000", broadcast: false },
+    ]);
+  });
+});
+
+describe("message draft unknown subcommand", () => {
+  test("old `message draft <target>` usage points to `message compose`", () => {
+    const errors: string[] = [];
+    const spy = spyOn(console, "error").mockImplementation((...a: unknown[]) => {
+      errors.push(a.map(String).join(" "));
+    });
+    const prevExit = process.exitCode;
+    try {
+      const program = new Command();
+      program.exitOverride();
+      const messageCmd = program.command("message");
+      registerMessageDraftCommand({ ctx: createContext([]), messageCmd });
+      program.parse(["node", "agent-slack", "message", "draft", "#general", "hi"]);
+    } finally {
+      spy.mockRestore();
+    }
+    const joined = errors.join("\n");
+    expect(joined).toMatch(/not a 'message draft' subcommand/);
+    expect(joined).toContain("message compose");
+    expect(process.exitCode).toBe(1);
+    // Don't leak a failing exit code into the test runner.
+    process.exitCode = prevExit;
+  });
+});


### PR DESCRIPTION
Implements #83. Supersedes #112 — reuses that PR's Slack `drafts.*` API layer, but takes the **"compose" direction (option 2)** from the issue instead of the plural `message drafts` subcommand.

## What & why

The issue flagged that adding Slack-native draft ops under the existing `draft` name would confuse an LLM. #112's answer was a near-homograph pair — `message draft` (browser editor) vs `message drafts` (native) — one letter apart, opposite meanings. This PR instead gives each concept a distinct verb/namespace:

- **`message compose <target> [text]`** — the human-in-the-loop browser editor (renamed from `message draft`; behavior identical). "Compose" matches what it does.
- **`message draft <list|create|update|delete>`** — Slack-native drafts via the undocumented `drafts.*` session endpoints, so drafts show up natively in the user's Slack client (desktop + mobile).

```bash
agent-slack message compose "#general" "Here's my update"      # opens browser editor

agent-slack message draft list
agent-slack message draft create "#general" "Here's my update"
agent-slack message draft create "<msg-url>" "Looking into it"    # thread reply
agent-slack message draft create "W0123456789" "hi"              # DM draft
agent-slack message draft update "<draft-id>" "Revised text"
agent-slack message draft delete "<draft-id>"
```

- `create` accepts the usual targets: `#channel`/name, channel id, user id (opens a DM), or a message URL (drafts a thread reply — same semantics as `message send`).
- Draft text runs through the existing mrkdwn → `rich_text` conversion, so lists/bold/code/mentions render natively.
- `update` replaces the body but preserves the draft's destination and attached files unless overridden; the conflict-detection `client_last_updated_ts` is auto-fetched for `update`/`delete` when omitted (incl. Slack's 7-digit fractional-padding quirk).
- Native drafts require browser-style auth (xoxc/xoxd), like `later`/`unreads`; noted in the docs.

### Broadcast semantics (thread replies)

`--broadcast` ("also send to channel") is handled carefully so it can't silently do the wrong thing:
- inherited on a text-only `update` (editing text keeps your broadcast choice), but **reset on any `--channel` re-address** so a reply is never ratcheted into a *different* thread's channel;
- clearable with a new `--no-broadcast` flag;
- rejected for DM targets (matching `message send`).

### Refuses unsafe updates

`update` fails loudly instead of corrupting drafts it can't faithfully round-trip: a **scheduled** draft (would drop the send time) or a **multi-destination** draft edited text-only (would drop recipients). It points the user to edit in Slack or delete + recreate.

## ⚠️ Breaking change (intentional, no compat shim)

`message draft <target> [text]` no longer opens the editor — use `message compose`. Old usage errors cleanly (`error: unknown command '#general'`), and `message draft --help` points to `message compose`. Deliberate clean break (pre-1.0, v0.9.x); the bundled agent skill is updated in the same PR, so agents pick up the new surface immediately. No magic dispatch / dual-meaning `draft`.

## Structure

- `src/slack/drafts.ts` — API layer (reused from #112).
- `src/cli/message-draft-command.ts` / `message-draft-actions.ts` — CLI layer (singular `draft` subcommand group).
- `src/cli/compose-actions.ts` — renamed from `draft-actions.ts`.
- Docs kept in sync: README, `skills/agent-slack/SKILL.md`, `references/commands.md`, `references/targets.md`, `llms.txt`.

## Testing

- `test/drafts.test.ts` (API layer, from #112) + new `test/message-draft-actions.test.ts` (CLI action layer + a commander-level test locking `--broadcast`/`--no-broadcast`/omitted parsing): create, update read-modify-write, scheduled/multi-destination guards, broadcast re-address + DM guards, `last_updated_ts` auto-fetch/pad, `findDraft` malformed-duplicate handling, channel-name hydration.
- Full suite (284), typecheck, lint (0 errors), format, and build all pass. Verified CLI wiring for `compose`/`draft`/all subcommands, and that old `message draft <target>` usage errors cleanly.

## Review

Reviewed by independent correctness + docs sub-agents, then an adversarial loop with GPT-5.6-Sol (xhigh) iterated to convergence. It surfaced and drove fixes for several real issues in the broadcast/thread/DM handling (broadcast one-way ratchets on re-address, DM broadcast via `D…` ids/URLs, and error-ordering that reported red-herring lookup failures). A couple of findings were pre-existing repo-wide concerns already owned by other PRs (rendered usergroup/broadcast text → #113) or resolved by rebasing onto current `main` (W-prefixed user IDs → #114).

Closes #83.

Credit: Slack `drafts.*` API layer originally by @mikaelq in #112.

🤖 Reviewed with GPT-5.6-Sol; generated with Claude Code.

Made with [Orca](https://github.com/stablyai/orca) 🐋
