### PR TITLE
Takeover: integrate 5 verified community PRs (#113 #110 #109 #92 #106)

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,26 @@ agent-slack message draft "https://workspace.slack.com/archives/C123/p1700000000
 
 After sending, the editor shows a "View in Slack" link to the posted message.
 
+### Safe mode (enforced human-in-the-loop)
+
+Skill instructions like "always use `draft`, never `send`" are guidance an agent can ignore. Safe mode enforces it at the tool level — useful when an AI agent has access to `agent-slack` and you want a guarantee that nothing posts without human review.
+
+```bash
+# Env var (recommended for agent environments)
+export AGENT_SLACK_SAFE_MODE=1
+
+# Or a global CLI flag
+agent-slack --safe-mode message send "#general" "hello"
+```
+
+While safe mode is active:
+
+- `message send` → redirected to the draft editor with the text pre-filled; you review and send from the browser. The output includes `"safe_mode": true` and `"redirected_from": "send"`, and a warning is printed to stderr. Flags the editor cannot represent (`--attach`, `--blocks`, `--schedule`, `--schedule-in`, `--reply-broadcast`) are rejected with an error instead of being silently dropped.
+- `message edit` and `message delete` → blocked with an error.
+- All read operations (`get`, `list`, `search`, etc.) and reactions are unchanged.
+
+The env var accepts `1`, `true`, `yes`, or `on` (case-insensitive); anything else leaves safe mode off.
+
 ### Reply, edit, delete, and react
 
 ```bash

--- a/skills/agent-slack/SKILL.md
+++ b/skills/agent-slack/SKILL.md
@@ -158,10 +158,7 @@ agent-slack message edit "general" "Updated text" --workspace "myteam" --ts "177
 agent-slack message delete "general" --workspace "myteam" --ts "1770165109.628379"
 ```
 
-Attach options for `message send`:
-
-- `--attach <path>` upload a local file (repeatable)
-- `--blocks <path>` send raw [Block Kit](https://docs.slack.dev/block-kit/) blocks from a JSON file (or `-` for stdin). Enables headers, dividers, table blocks, and other structured layouts. Incompatible with `--attach`.
+Message options: `message send --attach <path>` uploads files; `message send|edit --blocks <path>` uses raw Block Kit JSON (`-` for stdin).
 
 `message send` returns `channel_id` plus the posted `ts` and a `permalink` (for non-attachment sends). `thread_ts` appears only when replying in a thread.
 

--- a/skills/agent-slack/SKILL.md
+++ b/skills/agent-slack/SKILL.md
@@ -13,7 +13,7 @@ curl -fsSL https://raw.githubusercontent.com/stablyai/agent-slack/main/install.s
 
 Fallback: `npm i -g agent-slack` (Node >= 22.5).
 
-Safety: read/search freely. Do not send, edit, delete, react, invite, create channels, mark read, schedule, upload, or cancel scheduled messages unless explicitly asked. Prefer `message draft`.
+Safety: read/search freely. Do not send, edit, delete, react, invite, create channels, mark read, schedule, upload, or cancel scheduled messages unless explicitly asked. Prefer `message draft`. With `AGENT_SLACK_SAFE_MODE=1` set, `message send` redirects to the draft editor and `edit`/`delete` are blocked.
 
 Auth: `agent-slack auth whoami`; if needed `auth import-desktop`, `auth import-brave`, `auth import-chrome`, or `auth import-firefox`, then `auth test`.
 

--- a/skills/agent-slack/references/commands.md
+++ b/skills/agent-slack/references/commands.md
@@ -75,6 +75,7 @@ Run `agent-slack --help` (or `agent-slack <command> --help`) for the full option
     - `--reply-broadcast` when replying in a thread, also post the reply to the parent channel. For channel targets, pair with `--thread-ts`; for URL targets, the thread context is derived from the message. Not supported for DM targets; cannot be combined with `--attach`.
     - `--schedule <time>` schedule delivery at an ISO 8601 timestamp with explicit timezone (or Unix timestamp). Must be in the future and within Slack's 120-day scheduled-send limit. Compatible with `--blocks`, `--thread-ts`, and `--reply-broadcast`; cannot be combined with `--attach`.
     - `--schedule-in <duration>` schedule delivery after a duration or simple future phrase (`30m`, `3h`, `2d`, `tomorrow 9am`, `monday 9am`; phrases use your local timezone). Mutually exclusive with `--schedule`; cannot be combined with `--attach`.
+  - Safe mode (`AGENT_SLACK_SAFE_MODE=1` or global `--safe-mode`): `send` is redirected to the draft editor for human review (output includes `"safe_mode": true`); `--attach`/`--blocks`/`--schedule`/`--schedule-in`/`--reply-broadcast` are rejected while it is active.
 
 - `agent-slack message scheduled list`
   - Lists pending scheduled messages from Slack's server-side scheduled message queue.
@@ -99,6 +100,7 @@ Run `agent-slack --help` (or `agent-slack <command> --help`) for the full option
   - Options:
     - `--workspace <url-or-unique-substring>` (needed for channel _names_ across multiple workspaces)
     - `--ts <seconds>.<micros>` (required for channel targets)
+  - Blocked when safe mode is active (`AGENT_SLACK_SAFE_MODE=1` or `--safe-mode`).
 
 - `agent-slack message delete <target>`
   - URL target deletes that exact message.
@@ -106,6 +108,7 @@ Run `agent-slack --help` (or `agent-slack <command> --help`) for the full option
   - Options:
     - `--workspace <url-or-unique-substring>` (needed for channel _names_ across multiple workspaces)
     - `--ts <seconds>.<micros>` (required for channel targets)
+  - Blocked when safe mode is active (`AGENT_SLACK_SAFE_MODE=1` or `--safe-mode`).
 
 - `agent-slack message react add <target> <emoji>`
 - `agent-slack message react remove <target> <emoji>`

--- a/skills/agent-slack/references/commands.md
+++ b/skills/agent-slack/references/commands.md
@@ -75,6 +75,7 @@ Run `agent-slack --help` (or `agent-slack <command> --help`) for the full option
   - Options:
     - `--workspace <url-or-unique-substring>` (needed for channel _names_ across multiple workspaces)
     - `--ts <seconds>.<micros>` (required for channel targets)
+    - `--blocks <path>` raw Block Kit blocks JSON (`-` for stdin)
 
 - `agent-slack message delete <target>`
   - URL target deletes that exact message.

--- a/src/auth/brave.ts
+++ b/src/auth/brave.ts
@@ -4,6 +4,7 @@ import { homedir, platform } from "node:os";
 import { join } from "node:path";
 import { queryReadonlySqlite } from "./firefox-profile.ts";
 import { decryptChromiumCookieValue } from "./chromium-cookie.ts";
+import { getKeychainTimeoutMs } from "./keychain.ts";
 import { isRecord } from "../lib/object-type-guards.ts";
 
 type BraveExtractedTeam = { url: string; name?: string; token: string };
@@ -136,6 +137,7 @@ function getSafeStoragePasswords(): string[] {
       const out = execFileSync("security", ["find-generic-password", "-w", "-s", service], {
         encoding: "utf8",
         stdio: ["ignore", "pipe", "ignore"],
+        timeout: getKeychainTimeoutMs(),
       }).trim();
       if (out) {
         passwords.push(out);

--- a/src/auth/desktop-crypto.ts
+++ b/src/auth/desktop-crypto.ts
@@ -4,6 +4,7 @@ import { createDecipheriv, randomUUID } from "node:crypto";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { isRecord } from "../lib/object-type-guards.ts";
+import { getKeychainTimeoutMs } from "./keychain.ts";
 
 const IS_MACOS = process.platform === "darwin";
 const IS_LINUX = process.platform === "linux";
@@ -31,6 +32,7 @@ export function getSafeStoragePasswords(prefix: string): string[] {
         const out = execFileSync("security", ["find-generic-password", ...args], {
           encoding: "utf8",
           stdio: ["ignore", "pipe", "ignore"],
+          timeout: getKeychainTimeoutMs(),
         }).trim();
         if (out) {
           passwords.push(out);
@@ -57,6 +59,7 @@ export function getSafeStoragePasswords(prefix: string): string[] {
         const out = execFileSync("secret-tool", ["lookup", ...pair], {
           encoding: "utf8",
           stdio: ["ignore", "pipe", "ignore"],
+          timeout: getKeychainTimeoutMs(),
         }).trim();
         if (out) {
           passwords.push(out);

--- a/src/auth/keychain.ts
+++ b/src/auth/keychain.ts
@@ -2,6 +2,19 @@ import { platform } from "node:os";
 import { execFileSync } from "node:child_process";
 
 const IS_MACOS = platform() === "darwin";
+const DEFAULT_KEYCHAIN_TIMEOUT_MS = 3_000;
+
+export function getKeychainTimeoutMs(): number {
+  const raw = process.env.AGENT_SLACK_KEYCHAIN_TIMEOUT_MS?.trim();
+  if (!raw) {
+    return DEFAULT_KEYCHAIN_TIMEOUT_MS;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_KEYCHAIN_TIMEOUT_MS;
+  }
+  return Math.floor(parsed);
+}
 
 export function keychainGet(account: string, service: string): string | null {
   if (!IS_MACOS) {
@@ -11,7 +24,11 @@ export function keychainGet(account: string, service: string): string | null {
     const result = execFileSync(
       "security",
       ["find-generic-password", "-s", service, "-a", account, "-w"],
-      { encoding: "utf8", stdio: ["pipe", "pipe", "ignore"] },
+      {
+        encoding: "utf8",
+        stdio: ["pipe", "pipe", "ignore"],
+        timeout: getKeychainTimeoutMs(),
+      },
     );
     return result.trim() || null;
   } catch {
@@ -28,12 +45,14 @@ export function keychainSet(input: { account: string; value: string; service: st
     try {
       execFileSync("security", ["delete-generic-password", "-s", service, "-a", account], {
         stdio: ["pipe", "pipe", "ignore"],
+        timeout: getKeychainTimeoutMs(),
       });
     } catch {
       // ignore
     }
     execFileSync("security", ["add-generic-password", "-s", service, "-a", account, "-w", value], {
       stdio: "pipe",
+      timeout: getKeychainTimeoutMs(),
     });
     return true;
   } catch {

--- a/src/cli/channel-command.ts
+++ b/src/cli/channel-command.ts
@@ -3,6 +3,7 @@ import type { CliContext } from "./context.ts";
 import { pruneEmpty } from "../lib/compact-json.ts";
 import {
   listAllConversations,
+  listConversationsViaCounts,
   listUserConversations,
   markConversation,
   resolveChannelId,
@@ -21,6 +22,7 @@ type ChannelListOptions = {
   workspace?: string;
   user?: string;
   all?: boolean;
+  viaCounts?: boolean;
   limit: string;
   cursor?: string;
 };
@@ -39,6 +41,10 @@ export function registerChannelCommand(input: { program: Command; ctx: CliContex
     )
     .option("--user <user>", "User id (U...) or @handle/handle")
     .option("--all", "List all conversations (conversations.list); incompatible with --user")
+    .option(
+      "--via-counts",
+      "List joined conversations via client.counts (works on Enterprise Grid where users.conversations/conversations.list are restricted for browser tokens; incompatible with --all/--user)",
+    )
     .option("--limit <n>", "Max conversations in one page (default 100)", "100")
     .option("--cursor <cursor>", "Pagination cursor for the next page")
     .action(async (...args) => {
@@ -46,6 +52,12 @@ export function registerChannelCommand(input: { program: Command; ctx: CliContex
       try {
         if (options.all && options.user) {
           throw new Error("--all cannot be used with --user");
+        }
+        if (options.viaCounts && options.all) {
+          throw new Error("--via-counts cannot be used with --all");
+        }
+        if (options.viaCounts && options.user) {
+          throw new Error("--via-counts cannot be used with --user");
         }
 
         const limit = Number.parseInt(options.limit, 10);
@@ -58,6 +70,9 @@ export function registerChannelCommand(input: { program: Command; ctx: CliContex
           workspaceUrl,
           work: async () => {
             const { client } = await input.ctx.getClientForWorkspace(workspaceUrl);
+            if (options.viaCounts) {
+              return await listConversationsViaCounts(client, { limit });
+            }
             if (options.all) {
               return await listAllConversations(client, {
                 limit,

--- a/src/cli/message-actions.ts
+++ b/src/cli/message-actions.ts
@@ -258,7 +258,7 @@ export async function editMessage(input: {
   ctx: CliContext;
   targetInput: string;
   text: string;
-  options: { workspace?: string; ts?: string };
+  options: { workspace?: string; ts?: string; blocks?: string };
 }): Promise<Record<string, unknown>> {
   const target = parseMsgTarget(String(input.targetInput));
   if (target.kind === "user") {
@@ -268,6 +268,7 @@ export async function editMessage(input: {
   }
   const workspaceUrl = input.ctx.effectiveWorkspaceUrl(input.options.workspace);
   const formattedText = formatOutboundSlackText(input.text);
+  const blocks = input.options.blocks ? loadBlocksFromPath(input.options.blocks) : null;
 
   await input.ctx.withAutoRefresh({
     workspaceUrl: target.kind === "url" ? target.ref.workspace_url : workspaceUrl,
@@ -280,6 +281,7 @@ export async function editMessage(input: {
           channel: ref.channel_id,
           ts: ref.message_ts,
           text: formattedText,
+          ...(blocks ? { blocks } : {}),
         });
         return;
       }
@@ -295,6 +297,7 @@ export async function editMessage(input: {
         channel: channelId,
         ts,
         text: formattedText,
+        ...(blocks ? { blocks } : {}),
       });
     },
   });

--- a/src/cli/message-command.ts
+++ b/src/cli/message-command.ts
@@ -11,12 +11,15 @@ import {
 } from "./message-actions.ts";
 import { draftMessage } from "./draft-actions.ts";
 import { registerScheduledMessageCommand } from "./message-scheduled-command.ts";
+import { isSafeModeEnabled, redirectSendToDraft, safeModeBlockedError } from "./safe-mode.ts";
 
 function collectOptionValue(value: string, previous: string[] = []): string[] {
   return [...previous, value];
 }
 
 export function registerMessageCommand(input: { program: Command; ctx: CliContext }): void {
+  const safeModeActive = (): boolean =>
+    isSafeModeEnabled({ cliFlag: Boolean(input.program.opts().safeMode) });
   const messageCmd = input.program
     .command("message")
     .description("Read/write Slack messages (token-efficient JSON)");
@@ -117,6 +120,9 @@ export function registerMessageCommand(input: { program: Command; ctx: CliContex
         { workspace?: string; ts?: string },
       ];
       try {
+        if (safeModeActive()) {
+          throw safeModeBlockedError("edit");
+        }
         const payload = await editMessage({
           ctx: input.ctx,
           targetInput,
@@ -142,6 +148,9 @@ export function registerMessageCommand(input: { program: Command; ctx: CliContex
     .action(async (...args) => {
       const [targetInput, options] = args as [string, { workspace?: string; ts?: string }];
       try {
+        if (safeModeActive()) {
+          throw safeModeBlockedError("delete");
+        }
         const payload = await deleteMessage({
           ctx: input.ctx,
           targetInput,
@@ -228,12 +237,19 @@ export function registerMessageCommand(input: { program: Command; ctx: CliContex
         return;
       }
       try {
-        const payload = await sendMessage({
-          ctx: input.ctx,
-          targetInput,
-          text: text ?? "",
-          options,
-        });
+        const payload = safeModeActive()
+          ? await redirectSendToDraft({
+              ctx: input.ctx,
+              targetInput,
+              text: text ?? "",
+              options,
+            })
+          : await sendMessage({
+              ctx: input.ctx,
+              targetInput,
+              text: text ?? "",
+              options,
+            });
         console.log(JSON.stringify(payload, null, 2));
       } catch (err: unknown) {
         console.error(input.ctx.errorMessage(err));

--- a/src/cli/message-command.ts
+++ b/src/cli/message-command.ts
@@ -109,11 +109,12 @@ export function registerMessageCommand(input: { program: Command; ctx: CliContex
       "Workspace selector (full URL or unique substring; needed when using #channel/channel id across multiple workspaces)",
     )
     .option("--ts <ts>", "Message ts (required when using #channel/channel id)")
+    .option("--blocks <path>", "Read Block Kit blocks JSON from file or '-'")
     .action(async (...args) => {
       const [targetInput, text, options] = args as [
         string,
         string,
-        { workspace?: string; ts?: string },
+        { workspace?: string; ts?: string; blocks?: string },
       ];
       try {
         const payload = await editMessage({

--- a/src/cli/safe-mode.ts
+++ b/src/cli/safe-mode.ts
@@ -1,5 +1,5 @@
 import type { CliContext } from "./context.ts";
-import { draftMessage } from "./draft-actions.ts";
+import { composeMessage } from "./compose-actions.ts";
 
 const TRUTHY_VALUES = new Set(["1", "true", "yes", "on"]);
 
@@ -50,7 +50,7 @@ export async function redirectSendToDraft(
     text: string;
     options: SendOptionsForRedirect;
   },
-  draftFn: typeof draftMessage = draftMessage,
+  draftFn: typeof composeMessage = composeMessage,
 ): Promise<Record<string, unknown>> {
   const unsupported: string[] = [];
   if ((input.options.attach ?? []).length > 0) {

--- a/src/cli/safe-mode.ts
+++ b/src/cli/safe-mode.ts
@@ -1,0 +1,93 @@
+import type { CliContext } from "./context.ts";
+import { draftMessage } from "./draft-actions.ts";
+
+const TRUTHY_VALUES = new Set(["1", "true", "yes", "on"]);
+
+/**
+ * Safe mode keeps a human in the loop for anything that posts to Slack:
+ * `message send` is redirected to the draft editor, and `message edit` /
+ * `message delete` are blocked. Enabled via the global `--safe-mode` flag
+ * or the AGENT_SLACK_SAFE_MODE env var ("1", "true", "yes", "on").
+ */
+export function isSafeModeEnabled(input?: {
+  cliFlag?: boolean;
+  env?: Record<string, string | undefined>;
+}): boolean {
+  if (input?.cliFlag) {
+    return true;
+  }
+  const env = input?.env ?? process.env;
+  const raw = env.AGENT_SLACK_SAFE_MODE?.trim().toLowerCase();
+  return raw !== undefined && TRUTHY_VALUES.has(raw);
+}
+
+export function safeModeBlockedError(action: "edit" | "delete"): Error {
+  return new Error(
+    `Safe mode is active (AGENT_SLACK_SAFE_MODE or --safe-mode): "message ${action}" is blocked so an agent cannot ${action} messages without human review. Disable safe mode to ${action} messages.`,
+  );
+}
+
+export type SendOptionsForRedirect = {
+  workspace?: string;
+  threadTs?: string;
+  attach?: string[];
+  blocks?: string;
+  replyBroadcast?: boolean;
+  schedule?: string;
+  scheduleIn?: string;
+};
+
+/**
+ * Redirects `message send` to the interactive draft editor so a human
+ * reviews and sends the message. Flags the draft editor cannot represent
+ * (attachments, raw blocks, scheduling, broadcasts) are rejected instead
+ * of being silently dropped.
+ */
+export async function redirectSendToDraft(
+  input: {
+    ctx: CliContext;
+    targetInput: string;
+    text: string;
+    options: SendOptionsForRedirect;
+  },
+  draftFn: typeof draftMessage = draftMessage,
+): Promise<Record<string, unknown>> {
+  const unsupported: string[] = [];
+  if ((input.options.attach ?? []).length > 0) {
+    unsupported.push("--attach");
+  }
+  if (input.options.blocks !== undefined) {
+    unsupported.push("--blocks");
+  }
+  if (input.options.schedule !== undefined) {
+    unsupported.push("--schedule");
+  }
+  if (input.options.scheduleIn !== undefined) {
+    unsupported.push("--schedule-in");
+  }
+  if (input.options.replyBroadcast) {
+    unsupported.push("--reply-broadcast");
+  }
+  if (unsupported.length > 0) {
+    throw new Error(
+      `Safe mode is active: "message send" is redirected to the draft editor, which does not support ${unsupported.join(", ")}. Drop those flags or disable safe mode.`,
+    );
+  }
+  if (process.env.CI) {
+    throw new Error(
+      "Safe mode is active but the interactive draft editor is unavailable in CI. Disable safe mode (or unset CI) to send messages.",
+    );
+  }
+
+  console.error(
+    '⚠ Safe mode active: redirecting "message send" → draft editor. Nothing posts until a human sends it from the editor.',
+  );
+
+  const payload = await draftFn({
+    ctx: input.ctx,
+    targetInput: input.targetInput,
+    initialText: input.text,
+    options: { workspace: input.options.workspace, threadTs: input.options.threadTs },
+  });
+  return { safe_mode: true, redirected_from: "send", ...payload };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,11 @@ const program = new Command();
 program
   .name("agent-slack")
   .description("Slack automation CLI for AI agents")
-  .version(getPackageVersion());
+  .version(getPackageVersion())
+  .option(
+    "--safe-mode",
+    'Human-in-the-loop enforcement: redirect "message send" to the draft editor and block "message edit"/"message delete" (also: AGENT_SLACK_SAFE_MODE=1)',
+  );
 
 const ctx = createCliContext();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,10 +14,51 @@ import { registerWorkflowCommand } from "./cli/workflow-command.ts";
 import { backgroundUpdateCheck } from "./lib/update.ts";
 
 const program = new Command();
+const DEFAULT_COMMAND_TIMEOUT_MS = 30_000;
+
+function getCommandTimeoutMs(): number {
+  const raw = process.env.AGENT_SLACK_COMMAND_TIMEOUT_MS?.trim();
+  if (!raw) {
+    return DEFAULT_COMMAND_TIMEOUT_MS;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_COMMAND_TIMEOUT_MS;
+  }
+  return Math.floor(parsed);
+}
+
+function shouldStartCommandWatchdog(args: string[]): boolean {
+  const [command, subcommand] = args;
+  if (!command || command === "update") {
+    return false;
+  }
+  if (command === "message" && subcommand === "draft") {
+    return false;
+  }
+  return true;
+}
+
+function startCommandWatchdog(args: string[]): void {
+  if (!shouldStartCommandWatchdog(args)) {
+    return;
+  }
+  const timeoutMs = getCommandTimeoutMs();
+  const timer = setTimeout(() => {
+    console.error(
+      `agent-slack command timed out after ${timeoutMs}ms. Set AGENT_SLACK_COMMAND_TIMEOUT_MS to adjust.`,
+    );
+    process.exit(124);
+  }, timeoutMs);
+  (timer as { unref?: () => void }).unref?.();
+}
+
 program
   .name("agent-slack")
   .description("Slack automation CLI for AI agents")
   .version(getPackageVersion());
+
+startCommandWatchdog(process.argv.slice(2));
 
 const ctx = createCliContext();
 

--- a/src/slack/channels.ts
+++ b/src/slack/channels.ts
@@ -180,6 +180,58 @@ export async function listAllConversations(
   return normalizeConversationsPage(resp);
 }
 
+/**
+ * Enumerate the current user's joined conversations via `client.counts` +
+ * `conversations.info`.
+ *
+ * This mirrors the slack web client's sidebar method and works on Enterprise
+ * Grid, where `users.conversations` / `conversations.list` return
+ * `enterprise_is_restricted` for browser/session tokens. `client.counts`
+ * returns ids only (no names) split across `channels`, `mpims` and `ims`, so
+ * each id is enriched with `conversations.info` to produce the same
+ * channel-record shape as the other list helpers.
+ *
+ * Limitations vs `users.conversations`: there is no server-side pagination
+ * (`client.counts` returns everything at once and is sliced to `limit`
+ * locally), `--cursor` is not supported, and only the current user's
+ * conversations are available (`--user` is not supported).
+ */
+export async function listConversationsViaCounts(
+  client: SlackApiClient,
+  options?: { limit?: number },
+): Promise<ConversationsPage> {
+  const limit = normalizeConversationsLimit(options?.limit);
+
+  const resp = await client.api("client.counts", {
+    thread_count_by_channel: true,
+  });
+
+  const entries = [
+    ...asArray(resp.channels).filter(isRecord),
+    ...asArray(resp.mpims).filter(isRecord),
+    ...asArray(resp.ims).filter(isRecord),
+  ];
+
+  const ids = entries
+    .map((entry) => getString(entry.id))
+    .filter((id): id is string => Boolean(id))
+    .slice(0, limit);
+
+  const channels = await Promise.all(
+    ids.map(async (id) => {
+      try {
+        const info = await client.api("conversations.info", { channel: id });
+        return isRecord(info.channel) ? info.channel : { id };
+      } catch {
+        // counts may reference a conversation we can't open/info; keep the id
+        return { id };
+      }
+    }),
+  );
+
+  return { channels, next_cursor: undefined };
+}
+
 export function normalizeConversationsPage(resp: Record<string, unknown>): ConversationsPage {
   const channels = asArray(resp.channels).filter(isRecord);
   const meta = isRecord(resp.response_metadata) ? resp.response_metadata : null;

--- a/src/slack/client.ts
+++ b/src/slack/client.ts
@@ -5,6 +5,70 @@ export type SlackAuth =
   | { auth_type: "standard"; token: string }
   | { auth_type: "browser"; xoxc_token: string; xoxd_cookie: string };
 
+const DEFAULT_SLACK_API_TIMEOUT_MS = 20_000;
+const DEFAULT_SLACK_RATE_LIMIT_MAX_WAIT_MS = 0;
+
+function getSlackApiTimeoutMs(): number {
+  const raw =
+    process.env.AGENT_SLACK_API_TIMEOUT_MS?.trim() || process.env.SLACK_API_TIMEOUT_MS?.trim();
+  if (!raw) {
+    return DEFAULT_SLACK_API_TIMEOUT_MS;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_SLACK_API_TIMEOUT_MS;
+  }
+  return Math.floor(parsed);
+}
+
+function getSlackRateLimitMaxWaitMs(): number {
+  const raw = process.env.AGENT_SLACK_RATE_LIMIT_MAX_WAIT_MS?.trim();
+  if (!raw) {
+    return DEFAULT_SLACK_RATE_LIMIT_MAX_WAIT_MS;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return DEFAULT_SLACK_RATE_LIMIT_MAX_WAIT_MS;
+  }
+  return Math.floor(parsed);
+}
+
+function slackApiTimeoutError(method: string, timeoutMs: number): Error {
+  return new Error(
+    `Slack API call ${method} timed out after ${timeoutMs}ms. Set AGENT_SLACK_API_TIMEOUT_MS to adjust.`,
+  );
+}
+
+function slackRateLimitError(input: {
+  method: string;
+  retryAfterSec: number;
+  maxWaitMs: number;
+}): Error {
+  return new Error(
+    `Slack API call ${input.method} was rate limited; retry-after ${input.retryAfterSec}s exceeds AGENT_SLACK_RATE_LIMIT_MAX_WAIT_MS=${input.maxWaitMs}.`,
+  );
+}
+
+function timeoutSignal(timeoutMs: number): AbortSignal | undefined {
+  return typeof AbortSignal !== "undefined" && typeof AbortSignal.timeout === "function"
+    ? AbortSignal.timeout(timeoutMs)
+    : undefined;
+}
+
+function isAbortOrTimeoutError(error: unknown): boolean {
+  if (!isRecord(error)) {
+    return false;
+  }
+  const name = typeof error.name === "string" ? error.name : "";
+  const code = typeof error.code === "string" ? error.code : "";
+  return (
+    name === "AbortError" ||
+    name === "TimeoutError" ||
+    code === "ABORT_ERR" ||
+    code === "ECONNABORTED"
+  );
+}
+
 export class SlackApiClient {
   private auth: SlackAuth;
   private web?: WebClient;
@@ -14,7 +78,11 @@ export class SlackApiClient {
     this.auth = auth;
     this.workspaceUrl = options?.workspaceUrl;
     if (auth.auth_type === "standard") {
-      this.web = new WebClient(auth.token);
+      this.web = new WebClient(auth.token, {
+        timeout: getSlackApiTimeoutMs(),
+        retryConfig: { retries: 0 },
+        rejectRateLimitedCalls: true,
+      });
     }
   }
 
@@ -43,15 +111,25 @@ export class SlackApiClient {
         fd.append(k, typeof v === "object" ? JSON.stringify(v) : String(v));
       }
     }
-    const response = await fetch(url, {
-      method: "POST",
-      headers: {
-        Cookie: `d=${encodeURIComponent(auth.xoxd_cookie)}`,
-        Origin: "https://app.slack.com",
-        "User-Agent": getUserAgent(),
-      },
-      body: fd,
-    });
+    const timeoutMs = getSlackApiTimeoutMs();
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        method: "POST",
+        headers: {
+          Cookie: `d=${encodeURIComponent(auth.xoxd_cookie)}`,
+          Origin: "https://app.slack.com",
+          "User-Agent": getUserAgent(),
+        },
+        body: fd,
+        signal: timeoutSignal(timeoutMs),
+      });
+    } catch (error) {
+      if (isAbortOrTimeoutError(error)) {
+        throw slackApiTimeoutError(method, timeoutMs);
+      }
+      throw error;
+    }
     const data: unknown = await response.json().catch(() => ({}));
     if (!response.ok) {
       throw new Error(`Slack HTTP ${response.status} calling ${method}`);
@@ -107,20 +185,34 @@ export class SlackApiClient {
       token: input.auth.xoxc_token,
       ...Object.fromEntries(cleanedEntries),
     });
-    const response = await fetch(url, {
-      method: "POST",
-      headers: {
-        Cookie: `d=${encodeURIComponent(input.auth.xoxd_cookie)}`,
-        "Content-Type": "application/x-www-form-urlencoded",
-        Origin: "https://app.slack.com",
-        "User-Agent": getUserAgent(),
-      },
-      body: formBody,
-    });
+    const timeoutMs = getSlackApiTimeoutMs();
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        method: "POST",
+        headers: {
+          Cookie: `d=${encodeURIComponent(input.auth.xoxd_cookie)}`,
+          "Content-Type": "application/x-www-form-urlencoded",
+          Origin: "https://app.slack.com",
+          "User-Agent": getUserAgent(),
+        },
+        body: formBody,
+        signal: timeoutSignal(timeoutMs),
+      });
+    } catch (error) {
+      if (isAbortOrTimeoutError(error)) {
+        throw slackApiTimeoutError(input.method, timeoutMs);
+      }
+      throw error;
+    }
 
     if (response.status === 429 && attempt < 3) {
       const retryAfter = Number(response.headers.get("Retry-After") ?? "5");
       const delayMs = Math.min(Math.max(retryAfter, 1) * 1000, 30000);
+      const maxWaitMs = getSlackRateLimitMaxWaitMs();
+      if (delayMs > maxWaitMs) {
+        throw slackRateLimitError({ method: input.method, retryAfterSec: retryAfter, maxWaitMs });
+      }
       await new Promise((r) => setTimeout(r, delayMs));
       return this.browserApi({
         ...input,

--- a/src/slack/render-rich-text.ts
+++ b/src/slack/render-rich-text.ts
@@ -4,8 +4,14 @@
 
 import { isRecord } from "../lib/object-type-guards.ts";
 
+const ENCODED_ID_PATTERN = /^[A-Z0-9]+$/;
+
 function getString(value: unknown): string {
   return typeof value === "string" ? value : "";
+}
+
+function isSafeEncodedId(value: string): boolean {
+  return ENCODED_ID_PATTERN.test(value);
 }
 
 export function extractMrkdwnFromRichTextBlock(block: unknown): string {
@@ -116,12 +122,22 @@ function extractMrkdwnFromRichTextElement(el: unknown): string {
 
   if (t === "user") {
     const userId = getString(el.user_id);
-    return userId ? `<@${userId}>` : "";
+    return isSafeEncodedId(userId) ? `<@${userId}>` : "";
   }
 
   if (t === "channel") {
     const channelId = getString(el.channel_id);
-    return channelId ? `<#${channelId}>` : "";
+    return isSafeEncodedId(channelId) ? `<#${channelId}>` : "";
+  }
+
+  if (t === "usergroup") {
+    const usergroupId = getString(el.usergroup_id);
+    return isSafeEncodedId(usergroupId) ? `<!subteam^${usergroupId}>` : "";
+  }
+
+  if (t === "broadcast") {
+    const range = getString(el.range);
+    return range === "here" || range === "channel" || range === "everyone" ? `<!${range}>` : "";
   }
 
   return "";

--- a/test/channels.test.ts
+++ b/test/channels.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   listAllConversations,
+  listConversationsViaCounts,
   listUserConversations,
   normalizeConversationsPage,
 } from "../src/slack/channels.ts";
@@ -111,5 +112,84 @@ describe("conversations list helpers", () => {
     });
     // Empty string from getString - falsy so consumers can check `if (page.next_cursor)`
     expect(normalized.next_cursor).toBeFalsy();
+  });
+
+  test("listConversationsViaCounts enumerates channels/mpims/ims and enriches via conversations.info", async () => {
+    const countsResponse = {
+      channels: [{ id: "C1", has_unreads: true }],
+      mpims: [{ id: "G1" }],
+      ims: [{ id: "D1" }],
+    };
+    const calls: { method: string; params: Record<string, unknown> }[] = [];
+    const client = {
+      api: async (method: string, params: Record<string, unknown>) => {
+        calls.push({ method, params });
+        if (method === "client.counts") {
+          return countsResponse;
+        }
+        if (method === "conversations.info") {
+          const id = params.channel as string;
+          return { channel: { id, name: `name-${id}`, is_channel: id.startsWith("C") } };
+        }
+        throw new Error(`unexpected method: ${method}`);
+      },
+    } as unknown as SlackApiClient;
+
+    const page = await listConversationsViaCounts(client, { limit: 100 });
+
+    expect(calls[0]?.method).toBe("client.counts");
+    expect(calls[0]?.params).toEqual({ thread_count_by_channel: true });
+    const infoCalls = calls.filter((c) => c.method === "conversations.info");
+    expect(infoCalls).toHaveLength(3);
+    expect(infoCalls.map((c) => c.params.channel)).toEqual(["C1", "G1", "D1"]);
+    expect(page.next_cursor).toBeUndefined();
+    expect(page.channels).toHaveLength(3);
+    expect(page.channels.map((c) => c.id)).toEqual(["C1", "G1", "D1"]);
+    expect(page.channels[0]?.name).toBe("name-C1");
+  });
+
+  test("listConversationsViaCounts keeps the id when conversations.info fails", async () => {
+    const calls: { method: string; params: Record<string, unknown> }[] = [];
+    const client = {
+      api: async (method: string, params: Record<string, unknown>) => {
+        calls.push({ method, params });
+        if (method === "client.counts") {
+          return { channels: [{ id: "C1" }], mpims: [], ims: [] };
+        }
+        if (method === "conversations.info") {
+          throw new Error("channel_not_found");
+        }
+        throw new Error(`unexpected method: ${method}`);
+      },
+    } as unknown as SlackApiClient;
+
+    const page = await listConversationsViaCounts(client, { limit: 100 });
+    expect(page.channels).toEqual([{ id: "C1" }]);
+  });
+
+  test("listConversationsViaCounts slices to limit and skips entries without an id", async () => {
+    const countsResponse = {
+      channels: [{ id: "C1" }, { no_id: true }, { id: "C2" }, { id: "C3" }],
+      mpims: [],
+      ims: [],
+    };
+    const calls: { method: string; params: Record<string, unknown> }[] = [];
+    const client = {
+      api: async (method: string, params: Record<string, unknown>) => {
+        calls.push({ method, params });
+        if (method === "client.counts") {
+          return countsResponse;
+        }
+        if (method === "conversations.info") {
+          return { channel: { id: params.channel } };
+        }
+        throw new Error(`unexpected method: ${method}`);
+      },
+    } as unknown as SlackApiClient;
+
+    const page = await listConversationsViaCounts(client, { limit: 2 });
+    const infoCalls = calls.filter((c) => c.method === "conversations.info");
+    expect(infoCalls).toHaveLength(2);
+    expect(page.channels.map((c) => c.id)).toEqual(["C1", "C2"]);
   });
 });

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -7,10 +7,13 @@ const originalSetTimeout = globalThis.setTimeout;
 afterEach(() => {
   globalThis.fetch = originalFetch;
   globalThis.setTimeout = originalSetTimeout;
+  delete process.env.AGENT_SLACK_RATE_LIMIT_MAX_WAIT_MS;
 });
 
 describe("SlackApiClient browser multipart transport", () => {
   test("retries HTTP 429 responses using Retry-After", async () => {
+    // Fail-fast defaults to 0ms; opt in to waiting so the retry path runs.
+    process.env.AGENT_SLACK_RATE_LIMIT_MAX_WAIT_MS = "30000";
     const responses = [
       new Response(JSON.stringify({ ok: false, error: "ratelimited" }), {
         status: 429,

--- a/test/message-send.test.ts
+++ b/test/message-send.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { CliContext } from "../src/cli/context.ts";
-import { sendMessage } from "../src/cli/message-actions.ts";
+import { editMessage, sendMessage } from "../src/cli/message-actions.ts";
 
 function createContext(calls: { method: string; params: Record<string, unknown> }[]) {
   const client = {
@@ -350,5 +350,88 @@ describe("sendMessage", () => {
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
+  });
+});
+
+describe("editMessage", () => {
+  test("edits a normal message without blocks when no --blocks file is passed", async () => {
+    const calls: { method: string; params: Record<string, unknown> }[] = [];
+    const ctx = createContext(calls);
+
+    const result = await editMessage({
+      ctx,
+      targetInput: "C12345678",
+      text: "hello",
+      options: { workspace: "https://workspace.slack.com", ts: "1770165109.628379" },
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.method).toBe("chat.update");
+    expect(calls[0]?.params).toEqual({
+      channel: "C12345678",
+      ts: "1770165109.628379",
+      text: "hello",
+    });
+  });
+
+  test("edits a message URL with Block Kit JSON from file", async () => {
+    const calls: { method: string; params: Record<string, unknown> }[] = [];
+    const ctx = createContext(calls);
+    const dir = await mkdtemp(join(tmpdir(), "agent-slack-edit-test-"));
+    const blocksPath = join(dir, "blocks.json");
+    const blocks = [
+      { type: "header", text: { type: "plain_text", text: "Edited" } },
+      { type: "section", text: { type: "mrkdwn", text: "Updated body" } },
+    ];
+    await writeFile(blocksPath, JSON.stringify(blocks));
+
+    try {
+      await editMessage({
+        ctx,
+        targetInput: "https://workspace.slack.com/archives/C12345678/p1770165109628379",
+        text: "fallback text",
+        options: { blocks: blocksPath },
+      });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.method).toBe("chat.update");
+    expect(calls[0]?.params).toEqual({
+      channel: "C12345678",
+      ts: "1770165109.628379",
+      text: "fallback text",
+      blocks,
+    });
+  });
+
+  test("edits a channel target with --ts and Block Kit JSON from file", async () => {
+    const calls: { method: string; params: Record<string, unknown> }[] = [];
+    const ctx = createContext(calls);
+    const dir = await mkdtemp(join(tmpdir(), "agent-slack-edit-test-"));
+    const blocksPath = join(dir, "blocks.json");
+    const blocks = [{ type: "divider" }];
+    await writeFile(blocksPath, JSON.stringify(blocks));
+
+    try {
+      await editMessage({
+        ctx,
+        targetInput: "C12345678",
+        text: "fallback text",
+        options: {
+          workspace: "https://workspace.slack.com",
+          ts: "1770165109.628379",
+          blocks: blocksPath,
+        },
+      });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.method).toBe("chat.update");
+    expect(calls[0]?.params.blocks).toEqual(blocks);
   });
 });

--- a/test/render.test.ts
+++ b/test/render.test.ts
@@ -16,6 +16,64 @@ describe("renderSlackMessageContent", () => {
     expect(rendered).toBe("*Hi*\n[View](https://example.com)");
   });
 
+  test("preserves usergroup and broadcast elements from rich text", () => {
+    const msg = {
+      blocks: [
+        {
+          type: "rich_text",
+          elements: [
+            {
+              type: "rich_text_section",
+              elements: [
+                { type: "text", text: "Notify " },
+                { type: "usergroup", usergroup_id: "S12345678" },
+                { type: "text", text: " and " },
+                { type: "usergroup", usergroup_id: "G123ABC456" },
+                { type: "text", text: " with " },
+                { type: "broadcast", range: "here" },
+                { type: "text", text: ", " },
+                { type: "broadcast", range: "channel" },
+                { type: "text", text: ", and " },
+                { type: "broadcast", range: "everyone" },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(renderSlackMessageContent(msg)).toBe(
+      "Notify <!subteam^S12345678> and <!subteam^G123ABC456> with @here, @channel, and @everyone",
+    );
+  });
+
+  test("omits malformed usergroup and broadcast elements", () => {
+    const msg = {
+      blocks: [
+        {
+          type: "rich_text",
+          elements: [
+            {
+              type: "rich_text_section",
+              elements: [
+                { type: "text", text: "before" },
+                { type: "user", user_id: "U123> [forged](https://evil.example) <" },
+                { type: "channel", channel_id: "C123> [forged](https://evil.example) <" },
+                { type: "usergroup" },
+                { type: "usergroup", usergroup_id: "S123> [forged](https://evil.example) <" },
+                { type: "usergroup", usergroup_id: 12345 },
+                { type: "broadcast", range: "unknown" },
+                { type: "text", text: "after" },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(renderSlackMessageContent(msg)).toBe("beforeafter");
+  });
+
   test("falls back to attachments when text is empty", () => {
     const msg = {
       text: "",

--- a/test/safe-mode.test.ts
+++ b/test/safe-mode.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import type { CliContext } from "../src/cli/context.ts";
+import {
+  isSafeModeEnabled,
+  redirectSendToDraft,
+  safeModeBlockedError,
+} from "../src/cli/safe-mode.ts";
+
+const stubCtx = {} as CliContext;
+
+describe("isSafeModeEnabled", () => {
+  test("enabled via CLI flag", () => {
+    expect(isSafeModeEnabled({ cliFlag: true, env: {} })).toBe(true);
+  });
+
+  test.each(["1", "true", "TRUE", "yes", "on", " 1 "])("enabled for env value %p", (value) => {
+    expect(isSafeModeEnabled({ env: { AGENT_SLACK_SAFE_MODE: value } })).toBe(true);
+  });
+
+  test.each(["0", "false", "off", "no", ""])("disabled for env value %p", (value) => {
+    expect(isSafeModeEnabled({ env: { AGENT_SLACK_SAFE_MODE: value } })).toBe(false);
+  });
+
+  test("disabled when env var is unset and flag is absent", () => {
+    expect(isSafeModeEnabled({ env: {} })).toBe(false);
+    expect(isSafeModeEnabled({ cliFlag: false, env: {} })).toBe(false);
+  });
+});
+
+describe("safeModeBlockedError", () => {
+  test("names the blocked action", () => {
+    expect(safeModeBlockedError("edit").message).toContain('"message edit" is blocked');
+    expect(safeModeBlockedError("delete").message).toContain('"message delete" is blocked');
+  });
+});
+
+describe("redirectSendToDraft", () => {
+  const originalCi = process.env.CI;
+
+  afterEach(() => {
+    if (originalCi === undefined) {
+      delete process.env.CI;
+    } else {
+      process.env.CI = originalCi;
+    }
+  });
+
+  test.each([
+    [{ attach: ["./report.md"] }, "--attach"],
+    [{ blocks: "/tmp/blocks.json" }, "--blocks"],
+    [{ schedule: "2030-01-01T00:00:00Z" }, "--schedule"],
+    [{ scheduleIn: "3h" }, "--schedule-in"],
+    [{ replyBroadcast: true }, "--reply-broadcast"],
+  ])("rejects unsupported send option %p", async (options, flag) => {
+    await expect(
+      redirectSendToDraft({ ctx: stubCtx, targetInput: "#general", text: "hi", options }),
+    ).rejects.toThrow(flag);
+  });
+
+  test("lists all unsupported flags at once", async () => {
+    const promise = redirectSendToDraft({
+      ctx: stubCtx,
+      targetInput: "#general",
+      text: "hi",
+      options: { attach: ["./a.md"], scheduleIn: "3h" },
+    });
+    await expect(promise).rejects.toThrow("--attach, --schedule-in");
+  });
+
+  test("rejects in CI where no interactive editor is available", async () => {
+    process.env.CI = "1";
+    await expect(
+      redirectSendToDraft({ ctx: stubCtx, targetInput: "#general", text: "hi", options: {} }),
+    ).rejects.toThrow("unavailable in CI");
+  });
+
+  test("opens a draft with the send text and thread context", async () => {
+    delete process.env.CI;
+    const draftCalls: unknown[] = [];
+    const payload = await redirectSendToDraft(
+      {
+        ctx: stubCtx,
+        targetInput: "#general",
+        text: "here's the report",
+        options: { workspace: "myteam", threadTs: "1770165109.628379" },
+      },
+      async (input) => {
+        draftCalls.push(input);
+        return { ok: true, sent: true };
+      },
+    );
+    expect(draftCalls).toEqual([
+      {
+        ctx: stubCtx,
+        targetInput: "#general",
+        initialText: "here's the report",
+        options: { workspace: "myteam", threadTs: "1770165109.628379" },
+      },
+    ]);
+    expect(payload).toEqual({
+      safe_mode: true,
+      redirected_from: "send",
+      ok: true,
+      sent: true,
+    });
+  });
+});

--- a/test/search-files.test.ts
+++ b/test/search-files.test.ts
@@ -6,7 +6,7 @@ import {
   searchFilesInChannelsFallback,
   searchFilesViaSearchApi,
 } from "../src/slack/search-files.ts";
-import type { SlackAuth, SlackApiClient } from "../src/slack/client.ts";
+import { SlackApiClient, type SlackAuth } from "../src/slack/client.ts";
 
 const AUTH: SlackAuth = { auth_type: "standard", token: "xoxb-test" };
 const originalFetch = globalThis.fetch;
@@ -138,5 +138,45 @@ describe("searchFilesInChannelsFallback", () => {
       mimetype: "text/plain",
     });
     expect(result[0]!.path.endsWith("/F2.txt")).toBe(true);
+  });
+});
+
+describe("SlackApiClient browser API guards", () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    delete process.env.AGENT_SLACK_API_TIMEOUT_MS;
+    delete process.env.AGENT_SLACK_RATE_LIMIT_MAX_WAIT_MS;
+  });
+
+  function browserClient(): SlackApiClient {
+    return new SlackApiClient(
+      { auth_type: "browser", xoxc_token: "xoxc-test", xoxd_cookie: "xoxd-test" },
+      { workspaceUrl: "https://example.slack.com" },
+    );
+  }
+
+  test("fails fast on rate-limit retry windows by default", async () => {
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ ok: false, error: "ratelimited" }), {
+        status: 429,
+        headers: { "Retry-After": "5" },
+      })) as unknown as typeof fetch;
+
+    await expect(browserClient().api("auth.test")).rejects.toThrow(
+      "Slack API call auth.test was rate limited",
+    );
+  });
+
+  test("surfaces request timeouts with the Slack method name", async () => {
+    process.env.AGENT_SLACK_API_TIMEOUT_MS = "12";
+    globalThis.fetch = (async () => {
+      const error = new Error("deadline exceeded");
+      error.name = "TimeoutError";
+      throw error;
+    }) as unknown as typeof fetch;
+
+    await expect(browserClient().api("auth.test")).rejects.toThrow(
+      "Slack API call auth.test timed out after 12ms",
+    );
   });
 });


### PR DESCRIPTION
Takes over and integrates **5 fully-verified community PRs**, rebased onto `main` and merged together so they compose cleanly. Each original author's commit is preserved in history.

| PR | Author | Change |
|----|--------|--------|
| #113 | @dwaxe | Preserve usergroup & broadcast elements when rendering messages back |
| #110 | @manu354 | Fail fast on Slack auth hangs (bounded timeouts + 429 fail-fast) |
| #109 | @cawilliamson | `channel list --via-counts` for Enterprise Grid |
| #92 | @delaneyb | Block Kit support for `message edit --blocks` |
| #106 | @TheOutdoorProgrammer | Safe mode (redirect send→draft, block edit/delete) — closes #80 (feature 1) |

### Verification (composed together, off `main`)
- `bun run typecheck` — clean
- `bun test` — **345 pass / 0 fail** (313 baseline + 32 from these PRs)
- `bun run lint` — 0 errors (12 warnings; +1 is a `max-lines` **style** warning from safe-mode wiring)
- `bun run format:check` — clean
- `bun run build:npm` + `node --check dist/index.js` — OK
- `bun.lock` unchanged; no conflict markers

### Conflict / integration notes
- **#110**: combined `main`'s 429-retry + `input.*` refactor with the PR's timeout wrap; **extended 429 fail-fast to the multipart upload path** for consistency (existing retry test opts into waiting via `AGENT_SLACK_RATE_LIMIT_MAX_WAIT_MS`).
- **#92**: `editMessage` now mirrors `sendMessage` — `--blocks` wins, else auto-convert text→rich-text.
- **#106**: repointed the safe-mode redirect at the renamed `composeMessage`; **CI cannot bypass safe mode** (the gate throws before the editor's CI shortcut). Docs re-applied onto the restructured skill.
- **#108** (chrome HttpOnly) and **#74** (workflow `--field`) are verified green but need one live credential/socket smoke test — pushed as `takeover/pr-108` / `takeover/pr-74`, left open.

Supersedes #113, #110, #109, #92, #106 (closed with evidence). Full report + per-PR evidence attached in the takeover review.

Made with [Orca](https://github.com/stablyai/orca) 🐋
