### PR TITLE
fix: surface the root cause of wrapped errors in CLI output

### DIFF
--- a/src/cli/context.ts
+++ b/src/cli/context.ts
@@ -49,7 +49,12 @@ export function errorMessage(err: unknown): string {
   const { message: rootMessage, cause: rootCause } = err;
   let message = rootMessage;
   let cause: unknown = rootCause;
+  const seenCauses = new Set<unknown>([err]);
   while (cause !== undefined && cause !== null) {
+    if (seenCauses.has(cause)) {
+      break;
+    }
+    seenCauses.add(cause);
     if (cause instanceof AggregateError && cause.errors.length > 0) {
       message += `: ${cause.errors.map((e) => (e instanceof Error ? e.message : String(e))).join("; ")}`;
       break;

--- a/src/cli/context.ts
+++ b/src/cli/context.ts
@@ -42,8 +42,28 @@ function effectiveWorkspaceUrl(flag?: string): string | undefined {
   return flag?.trim() || process.env.SLACK_WORKSPACE_URL?.trim() || undefined;
 }
 
-function errorMessage(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
+export function errorMessage(err: unknown): string {
+  if (!(err instanceof Error)) {
+    return String(err);
+  }
+  const { message: rootMessage, cause: rootCause } = err;
+  let message = rootMessage;
+  let cause: unknown = rootCause;
+  while (cause !== undefined && cause !== null) {
+    if (cause instanceof AggregateError && cause.errors.length > 0) {
+      message += `: ${cause.errors.map((e) => (e instanceof Error ? e.message : String(e))).join("; ")}`;
+      break;
+    }
+    if (cause instanceof Error) {
+      const { message: causeMessage, cause: nextCause } = cause;
+      message += `: ${causeMessage}`;
+      cause = nextCause;
+      continue;
+    }
+    message += `: ${String(cause)}`;
+    break;
+  }
+  return message;
 }
 
 function parseContentType(value: unknown): "any" | "text" | "image" | "snippet" | "file" {

--- a/test/error-message.test.ts
+++ b/test/error-message.test.ts
@@ -35,4 +35,17 @@ describe("errorMessage", () => {
     const err = new Error("fetch failed", { cause: middle });
     expect(errorMessage(err)).toBe("fetch failed: request failed: connect ECONNREFUSED");
   });
+
+  test("terminates on a self-referential cause instead of looping forever", () => {
+    const err = new Error("boom");
+    err.cause = err;
+    expect(errorMessage(err)).toBe("boom");
+  });
+
+  test("terminates on a longer cause cycle", () => {
+    const a = new Error("a");
+    const b = new Error("b", { cause: a });
+    a.cause = b;
+    expect(errorMessage(a)).toBe("a: b");
+  });
 });

--- a/test/error-message.test.ts
+++ b/test/error-message.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { errorMessage } from "../src/cli/context.ts";
+
+describe("errorMessage", () => {
+  test("returns the message for a plain error", () => {
+    expect(errorMessage(new Error("boom"))).toBe("boom");
+  });
+
+  test("stringifies non-Error values", () => {
+    expect(errorMessage("boom")).toBe("boom");
+  });
+
+  test("appends a single Error cause", () => {
+    const err = new Error("fetch failed", { cause: new Error("connect ECONNREFUSED") });
+    expect(errorMessage(err)).toBe("fetch failed: connect ECONNREFUSED");
+  });
+
+  test("appends AggregateError causes from a failed fetch through a dead proxy", () => {
+    const cause = new AggregateError(
+      [
+        new Error("connect ECONNREFUSED 127.0.0.1:9090"),
+        new Error("connect ECONNREFUSED ::1:9090"),
+      ],
+      "ECONNREFUSED",
+    );
+    const err = new Error("fetch failed", { cause });
+    expect(errorMessage(err)).toBe(
+      "fetch failed: connect ECONNREFUSED 127.0.0.1:9090; connect ECONNREFUSED ::1:9090",
+    );
+  });
+
+  test("walks multi-level cause chains", () => {
+    const root = new Error("connect ECONNREFUSED");
+    const middle = new Error("request failed", { cause: root });
+    const err = new Error("fetch failed", { cause: middle });
+    expect(errorMessage(err)).toBe("fetch failed: request failed: connect ECONNREFUSED");
+  });
+});


### PR DESCRIPTION
I got annoyed by the unhelpful error message that you get anytime there is some form of network problem:

```console
$ agent-slack auth test
fetch failed
```

With this patch, the actual error will be shown. For example, in my case, it was:

```
fetch failed: self-signed certificate in certificate chain
```

other example when I was testing `HTTPS_PROXY` in #125:

```
fetch failed: connect ECONNREFUSED 127.0.0.1:9090; connect ECONNREFUSED ::1:9090
```

Much more useful!

I manually tested this with Node, but not with the Bun-produced binary.

_(code by Claude)_
