### PR TITLE
fix(message): prevent unattended CI posts in safe mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ agent-slack message compose "https://workspace.slack.com/archives/C123/p17000000
 
 After sending, the editor shows a "View in Slack" link to the posted message.
 
-`message compose` is send-capable. In CI, it skips the browser editor and immediately sends supplied text; do not use it for a compose-only request in a noninteractive environment.
+`message compose` is send-capable. In CI, it skips the browser editor and immediately sends supplied text; do not use it for a compose-only request in a noninteractive environment. Safe mode blocks this CI direct-send shortcut.
 
 ### Slack-native drafts
 
@@ -264,7 +264,8 @@ agent-slack --safe-mode message send "#general" "hello"
 
 While safe mode is active:
 
-- `message send` → redirected to the draft editor with the text pre-filled; you review and send from the browser. The output includes `"safe_mode": true` and `"redirected_from": "send"`, and a warning is printed to stderr. Flags the editor cannot represent (`--attach`, `--blocks`, `--schedule`, `--schedule-in`, `--reply-broadcast`) are rejected with an error instead of being silently dropped.
+- `message send` → redirected to the compose editor with the text pre-filled; you review and send from the browser. The output includes `"safe_mode": true` and `"redirected_from": "send"`, and a warning is printed to stderr. Flags the editor cannot represent (`--attach`, `--blocks`, `--schedule`, `--schedule-in`, `--reply-broadcast`) are rejected with an error instead of being silently dropped.
+- `message compose` → opens the browser editor normally. In CI, where compose would skip the editor and send directly, it is blocked with an error.
 - `message edit` and `message delete` → blocked with an error.
 - All read operations (`get`, `list`, `search`, etc.) and reactions are unchanged.
 

--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ agent-slack --safe-mode message send "#general" "hello"
 While safe mode is active:
 
 - `message send` → redirected to the draft editor with the text pre-filled; you review and send from the browser. The output includes `"safe_mode": true` and `"redirected_from": "send"`, and a warning is printed to stderr. Flags the editor cannot represent (`--attach`, `--blocks`, `--schedule`, `--schedule-in`, `--reply-broadcast`) are rejected with an error instead of being silently dropped.
+- `message compose` → opens the browser editor normally. In CI, where compose would skip the editor and send directly, it is blocked with an error.
 - `message edit` and `message delete` → blocked with an error.
 - All read operations (`get`, `list`, `search`, etc.) and reactions are unchanged.
 

--- a/skills/agent-slack/SKILL.md
+++ b/skills/agent-slack/SKILL.md
@@ -20,8 +20,8 @@ If a capability named here is absent from installed help, report version skew in
 
 - Read and search freely.
 - Perform write actions only when explicitly requested: sends, edits, deletes, reactions, invitations, channel or canvas creation, mark-read operations, scheduling or canceling delivery, uploads, Later state/reminder changes, DM/group-DM creation, and `workflow run`. Workflow runs can execute downstream actions.
-- For compose- or review-only requests, return proposed text without invoking Slack, or use `message draft create` to add a Slack-native draft the user can review and send (nothing is posted). `message compose` is send-capable; use it only when the user explicitly asks to open the interactive editor. In CI or another noninteractive environment, do not invoke it without separate authorization to send immediately: CI skips the editor and sends supplied text.
-- With `AGENT_SLACK_SAFE_MODE=1` (or the global `--safe-mode` flag) set, safe mode is enforced at the tool level: `message send` is redirected to the draft editor and `message edit`/`message delete` are blocked. Use it when nothing should post without human review.
+- For compose- or review-only requests, return proposed text without invoking Slack, or use `message draft create` to add a Slack-native draft the user can review and send (nothing is posted). `message compose` is send-capable; use it only when the user explicitly asks to open the interactive editor. In CI or another noninteractive environment, do not invoke it without separate authorization to send immediately: CI skips the editor and sends supplied text unless safe mode blocks the shortcut.
+- With `AGENT_SLACK_SAFE_MODE=1` (or the global `--safe-mode` flag) set, safe mode is enforced at the tool level: `message send` is redirected to the compose editor, the CI `message compose` direct-send shortcut is blocked, and `message edit`/`message delete` are blocked. Use it when nothing should post without human review.
 
 ## Workflow
 

--- a/skills/agent-slack/SKILL.md
+++ b/skills/agent-slack/SKILL.md
@@ -21,7 +21,7 @@ If a capability named here is absent from installed help, report version skew in
 - Read and search freely.
 - Perform write actions only when explicitly requested: sends, edits, deletes, reactions, invitations, channel or canvas creation, mark-read operations, scheduling or canceling delivery, uploads, Later state/reminder changes, DM/group-DM creation, and `workflow run`. Workflow runs can execute downstream actions.
 - For compose- or review-only requests, return proposed text without invoking Slack, or use `message draft create` to add a Slack-native draft the user can review and send (nothing is posted). `message compose` is send-capable; use it only when the user explicitly asks to open the interactive editor. In CI or another noninteractive environment, do not invoke it without separate authorization to send immediately: CI skips the editor and sends supplied text.
-- With `AGENT_SLACK_SAFE_MODE=1` (or the global `--safe-mode` flag) set, safe mode is enforced at the tool level: `message send` is redirected to the draft editor and `message edit`/`message delete` are blocked. Use it when nothing should post without human review.
+- With `AGENT_SLACK_SAFE_MODE=1` (or the global `--safe-mode` flag) set, safe mode is enforced at the tool level: `message send` is redirected to the draft editor, the CI `message compose` direct-send shortcut is blocked, and `message edit`/`message delete` are blocked. Use it when nothing should post without human review.
 
 ## Workflow
 

--- a/src/cli/message-command.ts
+++ b/src/cli/message-command.ts
@@ -276,10 +276,13 @@ export function registerMessageCommand(input: { program: Command; ctx: CliContex
   messageCmd
     .command("compose")
     .description(
-      "Open a send-capable rich editor in the browser; CI skips the editor and immediately sends supplied text",
+      "Open a send-capable rich editor in the browser; CI skips the editor and immediately sends supplied text unless safe mode is active",
     )
     .argument("<target>", "Slack message URL, #name/name, or channel id")
-    .argument("[text]", "Initial message text (mrkdwn; sent immediately when CI skips the editor)")
+    .argument(
+      "[text]",
+      "Initial message text (mrkdwn; sent immediately when CI skips the editor unless safe mode is active)",
+    )
     .option(
       "--workspace <url>",
       "Workspace selector (full URL or unique substring; needed when using #channel/channel id across multiple workspaces)",
@@ -295,6 +298,11 @@ export function registerMessageCommand(input: { program: Command; ctx: CliContex
         { workspace?: string; threadTs?: string },
       ];
       try {
+        if (safeModeActive() && process.env.CI) {
+          throw new Error(
+            'Safe mode is active: "message compose" cannot skip the editor in CI because that would post without human review.',
+          );
+        }
         const payload = await composeMessage({
           ctx: input.ctx,
           targetInput,

--- a/src/cli/message-command.ts
+++ b/src/cli/message-command.ts
@@ -295,6 +295,11 @@ export function registerMessageCommand(input: { program: Command; ctx: CliContex
         { workspace?: string; threadTs?: string },
       ];
       try {
+        if (safeModeActive() && process.env.CI) {
+          throw new Error(
+            'Safe mode is active: "message compose" cannot skip the editor in CI because that would post without human review.',
+          );
+        }
         const payload = await composeMessage({
           ctx: input.ctx,
           targetInput,

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,7 @@ program
   .version(getPackageVersion())
   .option(
     "--safe-mode",
-    'Human-in-the-loop enforcement: redirect "message send" to the draft editor and block "message edit"/"message delete" (also: AGENT_SLACK_SAFE_MODE=1)',
+    'Human-in-the-loop enforcement: redirect "message send" to the compose editor, block the CI "message compose" direct-send shortcut, and block "message edit"/"message delete" (also: AGENT_SLACK_SAFE_MODE=1)',
   );
 
 startCommandWatchdog(process.argv.slice(2));

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,7 @@ program
   .version(getPackageVersion())
   .option(
     "--safe-mode",
-    'Human-in-the-loop enforcement: redirect "message send" to the draft editor and block "message edit"/"message delete" (also: AGENT_SLACK_SAFE_MODE=1)',
+    'Human-in-the-loop enforcement: redirect "message send" to the draft editor, block the CI "message compose" direct-send shortcut, and block "message edit"/"message delete" (also: AGENT_SLACK_SAFE_MODE=1)',
   );
 
 startCommandWatchdog(process.argv.slice(2));

--- a/test/safe-mode.test.ts
+++ b/test/safe-mode.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { Command } from "commander";
 import type { CliContext } from "../src/cli/context.ts";
+import { registerMessageCommand } from "../src/cli/message-command.ts";
 import {
   isSafeModeEnabled,
   redirectSendToDraft,
@@ -32,6 +34,73 @@ describe("safeModeBlockedError", () => {
     expect(safeModeBlockedError("edit").message).toContain('"message edit" is blocked');
     expect(safeModeBlockedError("delete").message).toContain('"message delete" is blocked');
   });
+});
+
+test("safe mode blocks message compose before CI can send directly", async () => {
+  const originalCi = process.env.CI;
+  const originalExitCode = process.exitCode;
+  const originalLog = console.log;
+  const originalError = console.error;
+  const apiCalls: string[] = [];
+  const errors: string[] = [];
+  const logs: string[] = [];
+  let exitCode: number | string | null | undefined;
+
+  const client = {
+    api: async (method: string) => {
+      apiCalls.push(method);
+      if (method === "conversations.info") {
+        return { channel: { id: "C12345678", name: "general" } };
+      }
+      if (method === "chat.postMessage") {
+        return { ok: true, ts: "1700000000.000001" };
+      }
+      throw new Error(`Unexpected API call: ${method}`);
+    },
+  };
+  const ctx = {
+    effectiveWorkspaceUrl: () => "https://workspace.slack.com",
+    assertWorkspaceSpecifiedForChannelNames: async () => {},
+    withAutoRefresh: async <T>(input: { work: () => Promise<T> }) => input.work(),
+    getClientForWorkspace: async () => ({
+      client,
+      auth: { auth_type: "standard", token: "xoxb-test" },
+    }),
+    errorMessage: (err: unknown) => (err instanceof Error ? err.message : String(err)),
+  } as unknown as CliContext;
+
+  try {
+    process.env.CI = "1";
+    process.exitCode = 0;
+    console.log = (...args: unknown[]) => {
+      logs.push(args.map(String).join(" "));
+    };
+    console.error = (...args: unknown[]) => {
+      errors.push(args.map(String).join(" "));
+    };
+
+    const program = new Command().option("--safe-mode");
+    registerMessageCommand({ program, ctx });
+    await program.parseAsync(
+      ["--safe-mode", "message", "compose", "C12345678", "review this first"],
+      { from: "user" },
+    );
+    ({ exitCode } = process);
+  } finally {
+    if (originalCi === undefined) {
+      delete process.env.CI;
+    } else {
+      process.env.CI = originalCi;
+    }
+    process.exitCode = originalExitCode ?? 0;
+    console.log = originalLog;
+    console.error = originalError;
+  }
+
+  expect(apiCalls).not.toContain("chat.postMessage");
+  expect(logs).toEqual([]);
+  expect(errors.join("\n")).toContain('"message compose" cannot skip the editor in CI');
+  expect(exitCode).toBe(1);
 });
 
 describe("redirectSendToDraft", () => {

--- a/test/safe-mode.test.ts
+++ b/test/safe-mode.test.ts
@@ -1,5 +1,7 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { Command } from "commander";
 import type { CliContext } from "../src/cli/context.ts";
+import { registerMessageCommand } from "../src/cli/message-command.ts";
 import {
   isSafeModeEnabled,
   redirectSendToDraft,
@@ -32,6 +34,47 @@ describe("safeModeBlockedError", () => {
     expect(safeModeBlockedError("edit").message).toContain('"message edit" is blocked');
     expect(safeModeBlockedError("delete").message).toContain('"message delete" is blocked');
   });
+});
+
+test("safe mode blocks CI compose before workspace or API work", async () => {
+  const originalCi = process.env.CI;
+  const originalExitCode = process.exitCode;
+  const originalLog = console.log;
+  const originalError = console.error;
+  const log = mock(() => {});
+  const error = mock(() => {});
+  const noWorkCtx = {
+    errorMessage: (err: unknown) => (err instanceof Error ? err.message : String(err)),
+  } as CliContext;
+
+  try {
+    process.env.CI = "1";
+    process.exitCode = 0;
+    console.log = log as typeof console.log;
+    console.error = error as typeof console.error;
+
+    const program = new Command().option("--safe-mode");
+    registerMessageCommand({ program, ctx: noWorkCtx });
+    await program.parseAsync(
+      ["--safe-mode", "message", "compose", "C12345678", "review this first"],
+      { from: "user" },
+    );
+
+    expect(log).not.toHaveBeenCalled();
+    expect(error).toHaveBeenCalledWith(
+      'Safe mode is active: "message compose" cannot skip the editor in CI because that would post without human review.',
+    );
+    expect(process.exitCode).toBe(1);
+  } finally {
+    if (originalCi === undefined) {
+      delete process.env.CI;
+    } else {
+      process.env.CI = originalCi;
+    }
+    process.exitCode = originalExitCode ?? 0;
+    console.log = originalLog;
+    console.error = originalError;
+  }
 });
 
 describe("redirectSendToDraft", () => {


### PR DESCRIPTION
## Problem

In CI, `message compose` skips the editor and sends immediately. This bypasses safe mode and can post without human review.

## Fix

Reject `message compose` when safe mode and CI are both active. The check runs before workspace resolution or any Slack API call. Other compose behavior is unchanged.

Related to #80
