### PR TITLE
docs(skill): prevent missing context in Slack thread investigations

### DIFF
--- a/skills/agent-slack/SKILL.md
+++ b/skills/agent-slack/SKILL.md
@@ -41,5 +41,6 @@ Slack-native drafts (`message draft list|create|update|delete`) manage drafts th
 
 ## Conditional references
 
+- Read [references/thread-investigation.md](references/thread-investigation.md) only when interpreting a Slack thread, verifying its claims, advising an action from it, or preparing a reply to that thread.
 - Read [references/targets.md](references/targets.md) only when choosing between a message URL, channel, or user target, or when resolving multiple workspaces.
 - Read [references/output.md](references/output.md) only when handling returned message or canvas metadata, resolved users, or downloaded and failed attachments.

--- a/skills/agent-slack/references/thread-investigation.md
+++ b/skills/agent-slack/references/thread-investigation.md
@@ -1,0 +1,15 @@
+# Thread investigation
+
+- Anchor the investigation to the exact message permalink and the workspace it identifies.
+- Read the root and every reply before searching elsewhere; note later corrections and the newest reply.
+- Follow only attachments, canvases, and linked material needed to answer the focal question.
+- Search only to fill a specific gap.
+- Bound searches to the anchored workspace and, where useful, by channel, participant, and date range.
+- Treat Slack claims about mutable state as leads, not authoritative current state.
+- Verify decision-relevant mutable claims in their current authoritative source when access is available.
+- Prefer current source state over older thread claims; surface material conflicts or uncertainty.
+- Keep proposed, approved, merged, built, deployed, and completed states distinct.
+- Do not infer through inaccessible content or failed downloads.
+- Keep evidence in the anchored workspace unless cross-workspace work is explicit; do not broaden DM/private-channel evidence without authorization; minimize sensitive detail.
+- Before an authorized reply, reread the full thread from the same permalink.
+- If new activity changes or answers the question, stop and revise rather than send a stale or duplicate reply.

--- a/skills/agent-slack/references/thread-investigation.md
+++ b/skills/agent-slack/references/thread-investigation.md
@@ -1,0 +1,10 @@
+# Thread investigation
+
+- Anchor to the exact message permalink and workspace. Read the root and every reply, note later corrections, and reread the thread before an authorized reply.
+- Follow only attachments, canvases, and linked material needed to answer the focal question.
+- Search only to fill a specific gap, bounded to the anchored workspace and, where useful, by channel, participant, and date range.
+- Treat mutable Slack claims as leads. Verify decision-relevant claims in their current authoritative source when available, prefer current state, and surface material conflicts or uncertainty.
+- Keep proposed, approved, merged, built, deployed, and completed states distinct.
+- Do not infer through inaccessible content or failed downloads.
+- Keep evidence in the anchored workspace unless cross-workspace work is explicit; do not broaden DM/private-channel evidence without authorization; minimize sensitive detail.
+- If new activity changes or answers the question, stop and revise rather than send a stale or duplicate reply.


### PR DESCRIPTION
## Problem

Agents working from a Slack link can miss later corrections, treat old claims as current, or search outside the intended workspace or conversation.

## Fix

Add a short, conditionally loaded guide for thread investigations. It covers reading the full thread, limiting follow-up searches, checking changing facts at their source, respecting privacy boundaries, and rereading before replying.

The core skill remains small because this guidance loads only for thread work.
