### PR TITLE
feat: add --no-unfurl to message sends

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,9 @@ agent-slack message compose "#general"
 # Open editor with initial text
 agent-slack message compose "#general" "Here's my update"
 
+# Open the editor and suppress link/media previews when sent
+agent-slack message compose "#general" "Release notes: https://example.com" --no-unfurl
+
 # Reply in a thread
 agent-slack message compose "https://workspace.slack.com/archives/C123/p1700000000000000"
 ```
@@ -297,6 +300,7 @@ Send options for `message send`:
 - `--attach <path>` upload a local file (repeatable; `<text>` is optional when attaching files)
 - `--blocks <path>` send raw [Block Kit](https://docs.slack.dev/block-kit/) blocks from a JSON file (or `-` for stdin). Bypasses the automatic markdown-to-rich-text conversion, unlocking header/divider/section/table blocks and other structured layouts. Cannot be combined with `--attach`.
 - `--reply-broadcast` when replying in a thread, also post the reply to the parent channel (Slack's "Also send to #channel" checkbox). For channel targets, pair with `--thread-ts`; for URL targets, the thread context is derived from the message. Not supported for DM targets; cannot be combined with `--attach`.
+- `--no-unfurl` suppress Slack link and media previews. Also available on `message compose`; cannot be combined with `--attach`.
 - `--schedule <time>` schedule delivery at an ISO 8601 timestamp with explicit timezone (for example `YYYY-MM-DDTHH:mm:ss-07:00`) or a Unix timestamp. The timestamp must be in the future and within Slack's 120-day scheduled-send limit. Works with `--blocks`, `--thread-ts`, and `--reply-broadcast`; cannot be combined with `--attach`.
 - `--schedule-in <duration>` schedule delivery after a duration or simple future phrase (`30m`, `3h`, `2d`, `tomorrow 9am`, `monday 9am`; phrases use your local timezone). Mutually exclusive with `--schedule`; cannot be combined with `--attach`.
 

--- a/skills/agent-slack/SKILL.md
+++ b/skills/agent-slack/SKILL.md
@@ -35,6 +35,8 @@ For scheduled writes, prefer `--schedule` with an ISO 8601 timestamp and explici
 
 Named `later remind --in` values such as `tomorrow` or `monday` also use the executing environment's local timezone at 9:00. Confirm that timezone or pass an explicit Unix timestamp.
 
+Use `--no-unfurl` with `message send` or `message compose` when the user wants Slack link and media previews suppressed. It cannot be combined with `message send --attach`.
+
 Ordinary `message send` and `message edit` calls auto-convert lists. `message send --blocks` and `message edit --blocks` use supplied Block Kit blocks, while `message send --attach` sends its initial comment without automatic list conversion. Inside auto-converted lists, use Slack's `<URL|label>` syntax because CommonMark `[label](URL)` links are not converted into labeled link elements.
 
 Slack-native drafts (`message draft list|create|update|delete`) manage drafts that appear in the user's Slack client; `create` posts nothing. They use undocumented session endpoints and require browser-style auth (xoxc/xoxd).

--- a/src/cli/compose-actions.ts
+++ b/src/cli/compose-actions.ts
@@ -4,12 +4,13 @@ import { parseMsgTarget } from "./targets.ts";
 import { resolveChannelId, resolveChannelName, normalizeChannelInput } from "../slack/channels.ts";
 import { warnOnTruncatedSlackUrl } from "./message-url-warning.ts";
 import { openDraftEditor } from "./draft-server.ts";
+import { buildUnfurlApiParams } from "./unfurl-options.ts";
 
 export async function composeMessage(input: {
   ctx: CliContext;
   targetInput: string;
   initialText?: string;
-  options: { workspace?: string; threadTs?: string };
+  options: { workspace?: string; threadTs?: string; unfurl?: boolean };
 }): Promise<Record<string, unknown>> {
   const target = parseMsgTarget(String(input.targetInput));
   if (target.kind === "user") {
@@ -41,6 +42,7 @@ export async function composeMessage(input: {
               channel: ref.channel_id,
               text,
               thread_ts: threadTs,
+              ...buildUnfurlApiParams(input.options.unfurl),
             });
             return { ts: resp.ts as string };
           },
@@ -76,6 +78,7 @@ export async function composeMessage(input: {
             channel: channelId,
             text,
             thread_ts: input.options.threadTs,
+            ...buildUnfurlApiParams(input.options.unfurl),
           });
           return { ts: resp.ts as string };
         },

--- a/src/cli/message-actions.ts
+++ b/src/cli/message-actions.ts
@@ -11,6 +11,7 @@ import type { SlackApiClient } from "../slack/client.ts";
 import { uploadLocalFileToSlack } from "../slack/upload.ts";
 import { buildSlackMessageUrl } from "../slack/url.ts";
 import { resolveSchedulePostAt } from "../slack/scheduled-messages.ts";
+import { buildUnfurlApiParams } from "./unfurl-options.ts";
 
 function loadBlocksFromPath(path: string): unknown[] {
   const raw = path === "-" ? readFileSync(0, "utf8") : readFileSync(path, "utf8");
@@ -114,6 +115,7 @@ export async function sendMessage(input: {
     replyBroadcast?: boolean;
     schedule?: string;
     scheduleIn?: string;
+    unfurl?: boolean;
   };
 }): Promise<Record<string, unknown>> {
   const target = parseMsgTarget(String(input.targetInput));
@@ -125,6 +127,11 @@ export async function sendMessage(input: {
   if (postAt !== undefined && attachPaths.length > 0) {
     throw new Error(
       "--schedule/--schedule-in cannot be combined with --attach (Slack scheduled messages do not support file uploads).",
+    );
+  }
+  if (input.options.unfurl === false && attachPaths.length > 0) {
+    throw new Error(
+      "--no-unfurl cannot be combined with --attach (Slack file uploads do not accept unfurl parameters).",
     );
   }
   const formattedText = formatOutboundSlackText(input.text);
@@ -153,6 +160,7 @@ export async function sendMessage(input: {
           replyBroadcast: input.options.replyBroadcast,
           attachPaths,
           postAt,
+          unfurl: input.options.unfurl,
         });
       },
     });
@@ -176,6 +184,7 @@ export async function sendMessage(input: {
           blocks,
           attachPaths,
           postAt,
+          unfurl: input.options.unfurl,
         });
       },
     });
@@ -204,6 +213,7 @@ export async function sendMessage(input: {
         replyBroadcast: input.options.replyBroadcast,
         attachPaths,
         postAt,
+        unfurl: input.options.unfurl,
       });
     },
   });
@@ -232,6 +242,7 @@ async function sendMessageToChannel(input: {
   replyBroadcast?: boolean;
   attachPaths: string[];
   postAt?: number;
+  unfurl?: boolean;
 }): Promise<Record<string, unknown>> {
   if (input.postAt !== undefined) {
     const resp = await input.client.api("chat.scheduleMessage", {
@@ -241,6 +252,7 @@ async function sendMessageToChannel(input: {
       thread_ts: input.threadTs,
       ...(input.blocks ? { blocks: input.blocks } : {}),
       ...(input.replyBroadcast && input.threadTs ? { reply_broadcast: true } : {}),
+      ...buildUnfurlApiParams(input.unfurl),
     });
     const channelId = typeof resp.channel === "string" ? resp.channel : input.channelId;
     const scheduledMessageId =
@@ -261,6 +273,7 @@ async function sendMessageToChannel(input: {
       thread_ts: input.threadTs,
       ...(input.blocks ? { blocks: input.blocks } : {}),
       ...(input.replyBroadcast && input.threadTs ? { reply_broadcast: true } : {}),
+      ...buildUnfurlApiParams(input.unfurl),
     });
     const ts = typeof resp.ts === "string" ? resp.ts : undefined;
     const channelId = typeof resp.channel === "string" ? resp.channel : input.channelId;

--- a/src/cli/message-command.ts
+++ b/src/cli/message-command.ts
@@ -203,6 +203,7 @@ export function registerMessageCommand(input: { program: Command; ctx: CliContex
       "--schedule-in <duration>",
       "Schedule delivery within 120 days after a duration or future phrase, e.g. 3h or monday 9am. Named phrases use this process's local timezone. Cannot be combined with --attach.",
     )
+    .option("--no-unfurl", "Suppress link and media previews. Cannot be combined with --attach.")
     .action(async (...args) => {
       const [targetInput, text, options] = args as [
         string,
@@ -215,6 +216,7 @@ export function registerMessageCommand(input: { program: Command; ctx: CliContex
           replyBroadcast?: boolean;
           schedule?: string;
           scheduleIn?: string;
+          unfurl?: boolean;
         },
       ];
       const hasAttach = (options.attach ?? []).length > 0;
@@ -288,11 +290,12 @@ export function registerMessageCommand(input: { program: Command; ctx: CliContex
       "--thread-ts <ts>",
       "Thread root ts to post into; overrides the URL-derived thread when supplied",
     )
+    .option("--no-unfurl", "Suppress link and media previews")
     .action(async (...args) => {
       const [targetInput, text, options] = args as [
         string,
         string | undefined,
-        { workspace?: string; threadTs?: string },
+        { workspace?: string; threadTs?: string; unfurl?: boolean },
       ];
       try {
         const payload = await composeMessage({

--- a/src/cli/safe-mode.ts
+++ b/src/cli/safe-mode.ts
@@ -35,6 +35,7 @@ export type SendOptionsForRedirect = {
   replyBroadcast?: boolean;
   schedule?: string;
   scheduleIn?: string;
+  unfurl?: boolean;
 };
 
 /**
@@ -87,7 +88,11 @@ export async function redirectSendToDraft(
     ctx: input.ctx,
     targetInput: input.targetInput,
     initialText: input.text,
-    options: { workspace: input.options.workspace, threadTs: input.options.threadTs },
+    options: {
+      workspace: input.options.workspace,
+      threadTs: input.options.threadTs,
+      unfurl: input.options.unfurl,
+    },
   });
   return { safe_mode: true, redirected_from: "send", ...payload };
 }

--- a/src/cli/unfurl-options.ts
+++ b/src/cli/unfurl-options.ts
@@ -1,0 +1,6 @@
+export function buildUnfurlApiParams(unfurl: boolean | undefined): {
+  unfurl_links?: false;
+  unfurl_media?: false;
+} {
+  return unfurl === false ? { unfurl_links: false, unfurl_media: false } : {};
+}

--- a/test/help-contracts.test.ts
+++ b/test/help-contracts.test.ts
@@ -47,6 +47,7 @@ describe("agent-facing help contracts", () => {
     expect(optionDescription(send, "--schedule-in")).toContain("local timezone");
     expect(optionDescription(send, "--thread-ts")).toContain("channel targets");
     expect(optionDescription(send, "--reply-broadcast")).toContain("DM targets");
+    expect(optionDescription(send, "--no-unfurl")).toContain("link and media previews");
   });
 
   test("message compose identifies its CI send behavior", () => {
@@ -55,6 +56,7 @@ describe("agent-facing help contracts", () => {
     expect(compose.description()).toContain("CI skips the editor");
     expect(compose.registeredArguments[1]?.description).toContain("sent immediately");
     expect(optionDescription(compose, "--thread-ts")).toContain("overrides the URL-derived thread");
+    expect(optionDescription(compose, "--no-unfurl")).toContain("link and media previews");
   });
 
   test("Slack-native drafts document DM targeting and inherited-broadcast controls", () => {

--- a/test/helpers/environment.ts
+++ b/test/helpers/environment.ts
@@ -1,0 +1,27 @@
+export async function withEnvironment<T>(
+  overrides: Record<string, string | undefined>,
+  work: () => T | Promise<T>,
+): Promise<T> {
+  const originalValues = new Map(
+    Object.keys(overrides).map((name) => [name, process.env[name]] as const),
+  );
+
+  try {
+    for (const [name, value] of Object.entries(overrides)) {
+      setEnvironmentVariable(name, value);
+    }
+    return await work();
+  } finally {
+    for (const [name, value] of originalValues) {
+      setEnvironmentVariable(name, value);
+    }
+  }
+}
+
+function setEnvironmentVariable(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+  process.env[name] = value;
+}

--- a/test/message-send.test.ts
+++ b/test/message-send.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { CliContext } from "../src/cli/context.ts";
+import { composeMessage } from "../src/cli/compose-actions.ts";
 import { editMessage, sendMessage } from "../src/cli/message-actions.ts";
 import {
   cancelScheduledMessage,
@@ -13,8 +14,12 @@ import {
   parseRelativeSchedule,
   resolveSchedulePostAt,
 } from "../src/slack/scheduled-messages.ts";
+import { withEnvironment } from "./helpers/environment.ts";
 
-function createContext(calls: { method: string; params: Record<string, unknown> }[]) {
+function createContext(
+  calls: { method: string; params: Record<string, unknown> }[],
+  fixtures: { historyMessages?: Record<string, unknown>[] } = {},
+) {
   const client = {
     api: async (method: string, params: Record<string, unknown>) => {
       calls.push({ method, params });
@@ -57,6 +62,9 @@ function createContext(calls: { method: string; params: Record<string, unknown> 
       }
       if (method === "conversations.open") {
         return { ok: true, channel: { id: "D12345678" } };
+      }
+      if (method === "conversations.history") {
+        return { ok: true, messages: fixtures.historyMessages ?? [] };
       }
       return { ok: true };
     },
@@ -127,6 +135,29 @@ describe("sendMessage", () => {
       ts: "1770165109.628379",
       thread_ts: undefined,
       permalink: "https://workspace.slack.com/archives/C12345678/p1770165109628379",
+    });
+  });
+
+  test("--no-unfurl disables link and media previews for immediate sends", async () => {
+    const calls: { method: string; params: Record<string, unknown> }[] = [];
+    const ctx = createContext(calls);
+
+    await sendMessage({
+      ctx,
+      targetInput: "C12345678",
+      text: "https://example.com",
+      options: { unfurl: false },
+    });
+
+    expect(calls[0]).toEqual({
+      method: "chat.postMessage",
+      params: {
+        channel: "C12345678",
+        text: "https://example.com",
+        thread_ts: undefined,
+        unfurl_links: false,
+        unfurl_media: false,
+      },
     });
   });
 
@@ -258,30 +289,9 @@ describe("sendMessage", () => {
 
   test("--reply-broadcast on a URL target broadcasts using the message's derived thread_ts", async () => {
     const calls: { method: string; params: Record<string, unknown> }[] = [];
-    const ctx: CliContext = {
-      ...createContext(calls),
-      getClientForWorkspace: async () => ({
-        client: {
-          api: async (method: string, params: Record<string, unknown>) => {
-            calls.push({ method, params });
-            if (method === "conversations.history") {
-              return {
-                ok: true,
-                messages: [
-                  { ts: "1770160500.000100", thread_ts: "1770160000.000001", text: "root" },
-                ],
-              };
-            }
-            if (method === "chat.postMessage") {
-              return { ok: true, channel: String(params.channel), ts: "1770165109.628379" };
-            }
-            return { ok: true };
-          },
-        } as never,
-        auth: { auth_type: "standard", token: "x" as const },
-        workspace_url: "https://workspace.slack.com",
-      }),
-    };
+    const ctx = createContext(calls, {
+      historyMessages: [{ ts: "1770160500.000100", thread_ts: "1770160000.000001", text: "root" }],
+    });
 
     await sendMessage({
       ctx,
@@ -373,6 +383,22 @@ describe("sendMessage", () => {
     expect(calls[1]?.params.initial_comment).toBe("here's the report");
     expect(calls.some((c) => c.method === "chat.postMessage")).toBe(false);
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("--no-unfurl cannot be combined with file attachments", async () => {
+    const calls: { method: string; params: Record<string, unknown> }[] = [];
+    const ctx = createContext(calls);
+
+    await expect(
+      sendMessage({
+        ctx,
+        targetInput: "C12345678",
+        text: "https://example.com",
+        options: { attach: ["./report.md"], unfurl: false },
+      }),
+    ).rejects.toThrow(/--no-unfurl cannot be combined with --attach/);
+
+    expect(calls).toHaveLength(0);
   });
 
   test("sends initial comment only for the first attachment", async () => {
@@ -646,6 +672,24 @@ describe("sendMessage", () => {
     expect(calls[0]?.params.post_at as number).toBeLessThanOrEqual(before + 3 * 3600 + 1);
   });
 
+  test("--no-unfurl disables link and media previews for scheduled sends", async () => {
+    const calls: { method: string; params: Record<string, unknown> }[] = [];
+    const ctx = createContext(calls);
+
+    await sendMessage({
+      ctx,
+      targetInput: "C12345678",
+      text: "https://example.com",
+      options: { scheduleIn: "3h", unfurl: false },
+    });
+
+    expect(calls[0]?.method).toBe("chat.scheduleMessage");
+    expect(calls[0]?.params).toMatchObject({
+      unfurl_links: false,
+      unfurl_media: false,
+    });
+  });
+
   test("--schedule composes with blocks, thread replies, and reply broadcast", async () => {
     const calls: { method: string; params: Record<string, unknown> }[] = [];
     const ctx = createContext(calls);
@@ -695,6 +739,83 @@ describe("sendMessage", () => {
     ).rejects.toThrow(/cannot be combined with --attach/);
 
     expect(calls).toHaveLength(0);
+  });
+});
+
+describe("composeMessage", () => {
+  test("--no-unfurl disables link and media previews when CI sends immediately", async () => {
+    await withEnvironment({ CI: "1" }, async () => {
+      const calls: { method: string; params: Record<string, unknown> }[] = [];
+      const ctx = createContext(calls);
+
+      await composeMessage({
+        ctx,
+        targetInput: "#general",
+        initialText: "https://example.com",
+        options: { unfurl: false },
+      });
+
+      expect(calls.at(-1)).toEqual({
+        method: "chat.postMessage",
+        params: {
+          channel: "C12345678",
+          text: "https://example.com",
+          thread_ts: undefined,
+          unfurl_links: false,
+          unfurl_media: false,
+        },
+      });
+    });
+  });
+
+  test("keeps Slack's default preview behavior for a standard CI send", async () => {
+    await withEnvironment({ CI: "1" }, async () => {
+      const calls: { method: string; params: Record<string, unknown> }[] = [];
+      const ctx = createContext(calls);
+
+      await composeMessage({
+        ctx,
+        targetInput: "#general",
+        initialText: "https://example.com",
+        options: {},
+      });
+
+      expect(calls.at(-1)).toEqual({
+        method: "chat.postMessage",
+        params: {
+          channel: "C12345678",
+          text: "https://example.com",
+          thread_ts: undefined,
+        },
+      });
+    });
+  });
+
+  test("--no-unfurl disables previews for a URL target when CI sends immediately", async () => {
+    await withEnvironment({ CI: "1" }, async () => {
+      const calls: { method: string; params: Record<string, unknown> }[] = [];
+      const ctx = createContext(calls, {
+        historyMessages: [{ ts: "1770160500.000100", text: "root" }],
+      });
+
+      await composeMessage({
+        ctx,
+        targetInput: "https://workspace.slack.com/archives/C12345678/p1770160500000100",
+        initialText: "https://example.com",
+        options: { unfurl: false },
+      });
+
+      expect(calls.at(-1)).toEqual({
+        method: "chat.postMessage",
+        params: {
+          channel: "C12345678",
+          text: "https://example.com",
+          thread_ts: "1770160500.000100",
+          unfurl_links: false,
+          unfurl_media: false,
+        },
+      });
+    });
   });
 });
 

--- a/test/safe-mode.test.ts
+++ b/test/safe-mode.test.ts
@@ -1,10 +1,11 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import type { CliContext } from "../src/cli/context.ts";
 import {
   isSafeModeEnabled,
   redirectSendToDraft,
   safeModeBlockedError,
 } from "../src/cli/safe-mode.ts";
+import { withEnvironment } from "./helpers/environment.ts";
 
 const stubCtx = {} as CliContext;
 
@@ -35,16 +36,6 @@ describe("safeModeBlockedError", () => {
 });
 
 describe("redirectSendToDraft", () => {
-  const originalCi = process.env.CI;
-
-  afterEach(() => {
-    if (originalCi === undefined) {
-      delete process.env.CI;
-    } else {
-      process.env.CI = originalCi;
-    }
-  });
-
   test.each([
     [{ attach: ["./report.md"] }, "--attach"],
     [{ blocks: "/tmp/blocks.json" }, "--blocks"],
@@ -68,40 +59,42 @@ describe("redirectSendToDraft", () => {
   });
 
   test("rejects in CI where no interactive editor is available", async () => {
-    process.env.CI = "1";
-    await expect(
-      redirectSendToDraft({ ctx: stubCtx, targetInput: "#general", text: "hi", options: {} }),
-    ).rejects.toThrow("unavailable in CI");
+    await withEnvironment({ CI: "1" }, async () => {
+      await expect(
+        redirectSendToDraft({ ctx: stubCtx, targetInput: "#general", text: "hi", options: {} }),
+      ).rejects.toThrow("unavailable in CI");
+    });
   });
 
   test("opens a draft with the send text and thread context", async () => {
-    delete process.env.CI;
-    const draftCalls: unknown[] = [];
-    const payload = await redirectSendToDraft(
-      {
-        ctx: stubCtx,
-        targetInput: "#general",
-        text: "here's the report",
-        options: { workspace: "myteam", threadTs: "1770165109.628379" },
-      },
-      async (input) => {
-        draftCalls.push(input);
-        return { ok: true, sent: true };
-      },
-    );
-    expect(draftCalls).toEqual([
-      {
-        ctx: stubCtx,
-        targetInput: "#general",
-        initialText: "here's the report",
-        options: { workspace: "myteam", threadTs: "1770165109.628379" },
-      },
-    ]);
-    expect(payload).toEqual({
-      safe_mode: true,
-      redirected_from: "send",
-      ok: true,
-      sent: true,
+    await withEnvironment({ CI: undefined }, async () => {
+      const draftCalls: unknown[] = [];
+      const payload = await redirectSendToDraft(
+        {
+          ctx: stubCtx,
+          targetInput: "#general",
+          text: "here's the report",
+          options: { workspace: "myteam", threadTs: "1770165109.628379", unfurl: false },
+        },
+        async (input) => {
+          draftCalls.push(input);
+          return { ok: true, sent: true };
+        },
+      );
+      expect(draftCalls).toEqual([
+        {
+          ctx: stubCtx,
+          targetInput: "#general",
+          initialText: "here's the report",
+          options: { workspace: "myteam", threadTs: "1770165109.628379", unfurl: false },
+        },
+      ]);
+      expect(payload).toEqual({
+        safe_mode: true,
+        redirected_from: "send",
+        ok: true,
+        sent: true,
+      });
     });
   });
 });


### PR DESCRIPTION
## Background 📝

- Slack expands text and media links by default, while agent-slack had no per-message preview control.
- [Slack's unfurling contract](https://docs.slack.dev/messaging/unfurling-links-in-messages/) requires both `unfurl_links` and `unfurl_media` to be disabled to suppress previews.

## Changes 🛠️

- Add `--no-unfurl` to immediate and scheduled `message send` calls.
- Carry `--no-unfurl` through `message compose` and safe-mode redirects.
- Reject `--no-unfurl` with file attachments because Slack's upload API accepts no unfurl fields.
- Document the option in CLI help, README, and the bundled agent skill.

## Comments 🤔

- Slack-native drafts and message edits remain unchanged because they do not expose the same send-time unfurl controls.

## Test method 🔍

- [x] `mise x bun@1.3.9 -- bun test test/message-send.test.ts test/safe-mode.test.ts test/help-contracts.test.ts` - 74 tests passed
- [x] `mise x bun@1.3.9 -- bun test` - 351 tests passed
