### PR TITLE
Add a verified thread unsubscribe command

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ nix run github:stablyai/agent-slack
 - **Search**: messages + files (with filters)
 - **Artifacts**: auto-download snippets/images/files to local paths for agents
 - **Write**: send now or schedule delivery, edit/delete messages, add reactions (bullet lists auto-render as native Slack rich text)
+- **Thread subscriptions**: unsubscribe from one exact thread and verify the result
 - **Compose & drafts**: open a browser editor (`message compose`), or manage Slack-native drafts that show up in your Slack client (`message draft`)
 - **Channels**: list conversations, create channels, and invite users by id/handle/email
 - **Canvas**: create Slack canvases from Markdown and fetch them as Markdown
@@ -91,6 +92,8 @@ agent-slack
 │   └── react
 │       ├── add    <target> <emoji>
 │       └── remove <target> <emoji>
+├── thread
+│   └── unsubscribe <message-url>    # stop following one exact thread
 ├── channel
 │   ├── list                        # list conversations (user-scoped or all)
 │   ├── new                         # create channel
@@ -208,6 +211,20 @@ Optional:
 # Include reactions + which users reacted
 agent-slack message get "https://workspace.slack.com/archives/C123/p1700000000000000" --include-reactions
 ```
+
+### Unsubscribe from thread notifications
+
+Stop following one exact thread by passing its root or reply permalink:
+
+```bash
+agent-slack thread unsubscribe "https://workspace.slack.com/archives/C123/p1700000000000000"
+```
+
+This command requires browser-style auth (xoxc/xoxd). It reads the current subscription,
+uses Slack's undocumented `subscriptions.thread.remove` client endpoint, and reads the
+subscription state back to verify `subscribed: false`. Running it again returns
+`status: "already_unsubscribed"` without repeating the mutation. Only exact HTTPS Slack
+message URLs are accepted.
 
 ### Compose a message (browser editor)
 

--- a/llms.txt
+++ b/llms.txt
@@ -21,6 +21,7 @@
 - Slack-native drafts that appear in the user's Slack client via `message draft` (list/create/update/delete)
 - Slack canvas creation from Markdown files or inline content, plus export to Markdown
 - Slack channel creation, user invites, and Slack Connect external invites
+- Verified thread unsubscription from an exact Slack message URL
 
 ## Optional
 

--- a/skills/agent-slack/SKILL.md
+++ b/skills/agent-slack/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-slack
-description: "Slack CLI for agents: read URLs/threads/history/unreads/later/canvases/workflows, create canvases from Markdown, search messages/files, download attachments, lookup users, list/create/invite channels, open DMs, compose messages, manage Slack-native drafts, schedule sends, and explicit sends/edits/deletes/reactions/mark-read/uploads."
+description: "Slack CLI for agents: read URLs/threads/history/unreads/later/canvases/workflows, create canvases from Markdown, search messages/files, download attachments, lookup users, list/create/invite channels, open DMs, compose messages, manage Slack-native drafts and thread subscriptions, schedule sends, and explicit sends/edits/deletes/reactions/mark-read/uploads."
 ---
 
 # agent-slack
@@ -19,7 +19,7 @@ If a capability named here is absent from installed help, report version skew in
 ## Safety
 
 - Read and search freely.
-- Perform write actions only when explicitly requested: sends, edits, deletes, reactions, invitations, channel or canvas creation, mark-read operations, scheduling or canceling delivery, uploads, Later state/reminder changes, DM/group-DM creation, and `workflow run`. Workflow runs can execute downstream actions.
+- Perform write actions only when explicitly requested: sends, edits, deletes, reactions, invitations, channel or canvas creation, mark-read operations, thread unsubscriptions, scheduling or canceling delivery, uploads, Later state/reminder changes, DM/group-DM creation, and `workflow run`. Workflow runs can execute downstream actions.
 - For compose- or review-only requests, return proposed text without invoking Slack, or use `message draft create` to add a Slack-native draft the user can review and send (nothing is posted). `message compose` is send-capable; use it only when the user explicitly asks to open the interactive editor. In CI or another noninteractive environment, do not invoke it without separate authorization to send immediately: CI skips the editor and sends supplied text.
 - With `AGENT_SLACK_SAFE_MODE=1` (or the global `--safe-mode` flag) set, safe mode is enforced at the tool level: `message send` is redirected to the draft editor and `message edit`/`message delete` are blocked. Use it when nothing should post without human review.
 
@@ -39,7 +39,9 @@ Ordinary `message send` and `message edit` calls auto-convert lists. `message se
 
 Slack-native drafts (`message draft list|create|update|delete`) manage drafts that appear in the user's Slack client; `create` posts nothing. They use undocumented session endpoints and require browser-style auth (xoxc/xoxd).
 
+`thread unsubscribe <message-url>` stops following one exact thread. It requires an exact HTTPS Slack message URL and browser-style auth, uses an undocumented session endpoint, and verifies the resulting subscription state.
+
 ## Conditional references
 
 - Read [references/targets.md](references/targets.md) only when choosing between a message URL, channel, or user target, or when resolving multiple workspaces.
-- Read [references/output.md](references/output.md) only when handling returned message or canvas metadata, resolved users, or downloaded and failed attachments.
+- Read [references/output.md](references/output.md) only when handling returned message, canvas, or thread-subscription metadata, resolved users, or downloaded and failed attachments.

--- a/skills/agent-slack/references/output.md
+++ b/skills/agent-slack/references/output.md
@@ -9,6 +9,8 @@ Slack data commands print JSON to stdout. Help, update, and some authentication 
 
 Immediate non-attachment sends return `ts` and usually a `permalink`. Attachment sends return neither; scheduled sends return `scheduled_message_id` and `post_at` instead.
 
+`thread unsubscribe` returns `status: "unsubscribed"` after a verified change or `status: "already_unsubscribed"` after an idempotent no-op, plus the canonical workspace, channel, thread timestamp, and root permalink. Both successful states report `subscribed: false`.
+
 `canvas create` returns `canvas: { id, title?, channel_id? }`. `canvas get` returns `canvas: { id, title?, markdown }`.
 
 Message payloads keep canonical user IDs. Pass `--resolve-users` to add display metadata under `referenced_users`, or `--refresh-users` to refresh the 24-hour per-workspace cache before resolving.

--- a/skills/agent-slack/references/targets.md
+++ b/skills/agent-slack/references/targets.md
@@ -12,6 +12,7 @@ A URL supplies the workspace, channel, and message timestamp. With a URL target:
 - `message list` returns the thread root and all replies.
 - `message send` replies in that message's thread. `message compose` and `message draft create` do the same unless `--thread-ts` explicitly overrides the URL-derived thread.
 - `channel mark` marks through that message timestamp; `--ts` explicitly overrides the timestamp. It rejects `--workspace` because the URL supplies it.
+- `thread unsubscribe` derives the thread root from the URL and accepts no non-URL target.
 
 Use a channel name or a `C...`, `G...`, or `D...` channel ID only when no URL is available:
 

--- a/src/cli/thread-command.ts
+++ b/src/cli/thread-command.ts
@@ -1,0 +1,139 @@
+import type { Command } from "commander";
+import type { CliContext } from "./context.ts";
+import { pruneEmpty } from "../lib/compact-json.ts";
+import { unsubscribeThread } from "../slack/thread-subscriptions.ts";
+import { buildSlackMessageUrl, parseSlackMessageUrl } from "../slack/url.ts";
+import { warnOnTruncatedSlackUrl } from "./message-url-warning.ts";
+import { getString, isRecord } from "../lib/object-type-guards.ts";
+import type { SlackApiClient, SlackAuth } from "../slack/client.ts";
+
+type ThreadSubscriptionEndpoint = {
+  client: SlackApiClient;
+  auth: SlackAuth;
+  teamId?: string;
+};
+
+async function resolveThreadSubscriptionEndpoint(input: {
+  ctx: CliContext;
+  workspaceClient: SlackApiClient;
+  workspaceAuth: SlackAuth;
+}): Promise<ThreadSubscriptionEndpoint> {
+  if (input.workspaceAuth.auth_type !== "browser") {
+    throw new Error("Thread unsubscribe requires browser auth (xoxc token and xoxd cookie).");
+  }
+
+  const response = await input.workspaceClient.api("team.info", {});
+  const team = isRecord(response.team) ? response.team : null;
+  const teamId = team ? getString(team.id)?.trim() : undefined;
+  const enterpriseId = team ? getString(team.enterprise_id)?.trim() : undefined;
+  if (!enterpriseId) {
+    return { client: input.workspaceClient, auth: input.workspaceAuth };
+  }
+  if (!teamId) {
+    throw new Error("Slack did not return the workspace team ID required for Enterprise Grid.");
+  }
+
+  const enterpriseDomain = team
+    ? getString(team.enterprise_domain)?.trim().toLowerCase()
+    : undefined;
+  if (!enterpriseDomain || !/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(enterpriseDomain)) {
+    throw new Error(
+      "Slack did not return a valid Enterprise Grid domain for thread subscriptions.",
+    );
+  }
+
+  const enterpriseWorkspaceUrl = `https://${enterpriseDomain}.enterprise.slack.com`;
+  const enterprise = await input.ctx.getClientForWorkspace(enterpriseWorkspaceUrl);
+  if (enterprise.auth.auth_type !== "browser") {
+    throw new Error(
+      "Enterprise Grid thread unsubscribe requires browser auth for the organization.",
+    );
+  }
+  const [workspaceIdentity, enterpriseIdentity] = await Promise.all([
+    input.workspaceClient.api("auth.test", {}),
+    enterprise.client.api("auth.test", {}),
+  ]);
+  if (getString(enterpriseIdentity.team_id)?.trim() !== enterpriseId) {
+    throw new Error(
+      "The resolved Enterprise Grid credentials do not match the target workspace's organization.",
+    );
+  }
+  const workspaceUserId = getString(workspaceIdentity.user_id)?.trim();
+  const enterpriseUserId = getString(enterpriseIdentity.user_id)?.trim();
+  if (!workspaceUserId || !enterpriseUserId || workspaceUserId !== enterpriseUserId) {
+    throw new Error(
+      "The workspace and Enterprise Grid credentials do not belong to the same Slack user.",
+    );
+  }
+  return { client: enterprise.client, auth: enterprise.auth, teamId };
+}
+
+export async function unsubscribeThreadTarget(input: {
+  ctx: CliContext;
+  targetInput: string;
+}): Promise<Record<string, unknown>> {
+  const ref = parseSlackMessageUrl(input.targetInput);
+  if (!ref.workspace_url.startsWith("https://")) {
+    throw new Error("Thread unsubscribe requires an https Slack message URL.");
+  }
+  warnOnTruncatedSlackUrl(ref);
+
+  return input.ctx.withAutoRefresh({
+    workspaceUrl: ref.workspace_url,
+    work: async () => {
+      const { client, auth, workspace_url } = await input.ctx.getClientForWorkspace(
+        ref.workspace_url,
+      );
+      const threadTs = ref.thread_ts_hint ?? ref.message_ts;
+      const subscription = await resolveThreadSubscriptionEndpoint({
+        ctx: input.ctx,
+        workspaceClient: client,
+        workspaceAuth: auth,
+      });
+      const result = await unsubscribeThread({
+        client,
+        subscriptionClient: subscription.client,
+        auth: subscription.auth,
+        channelId: ref.channel_id,
+        threadTs,
+        teamId: subscription.teamId,
+      });
+      const resolvedWorkspaceUrl = workspace_url ?? ref.workspace_url;
+      return pruneEmpty({
+        ...result,
+        workspace_url: resolvedWorkspaceUrl,
+        permalink: buildSlackMessageUrl({
+          workspace_url: resolvedWorkspaceUrl,
+          channel_id: ref.channel_id,
+          message_ts: threadTs,
+        }),
+      }) as Record<string, unknown>;
+    },
+  });
+}
+
+export function registerThreadCommand(input: { program: Command; ctx: CliContext }): void {
+  const threadCmd = input.program
+    .command("thread")
+    .description("Manage Slack thread subscriptions");
+
+  threadCmd
+    .command("unsubscribe")
+    .description(
+      "Unsubscribe from one thread (requires browser auth; uses an unsupported Slack API)",
+    )
+    .argument("<target>", "Exact Slack message URL for the thread root or one of its replies")
+    .action(async (...args) => {
+      const [targetInput] = args as [string];
+      try {
+        const payload = await unsubscribeThreadTarget({
+          ctx: input.ctx,
+          targetInput,
+        });
+        console.log(JSON.stringify(payload, null, 2));
+      } catch (err: unknown) {
+        console.error(input.ctx.errorMessage(err));
+        process.exitCode = 1;
+      }
+    });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { registerUpdateCommand } from "./cli/update-command.ts";
 import { registerUserCommand } from "./cli/user-command.ts";
 import { registerChannelCommand } from "./cli/channel-command.ts";
 import { registerWorkflowCommand } from "./cli/workflow-command.ts";
+import { registerThreadCommand } from "./cli/thread-command.ts";
 import { backgroundUpdateCheck } from "./lib/update.ts";
 
 const program = new Command();
@@ -76,6 +77,7 @@ registerUpdateCommand({ program });
 registerUserCommand({ program, ctx });
 registerChannelCommand({ program, ctx });
 registerWorkflowCommand({ program, ctx });
+registerThreadCommand({ program, ctx });
 
 program.parse(process.argv);
 if (!process.argv.slice(2).length) {

--- a/src/slack/thread-subscriptions.ts
+++ b/src/slack/thread-subscriptions.ts
@@ -1,0 +1,128 @@
+import type { SlackAuth, SlackApiClient } from "./client.ts";
+import { asArray, getString, isRecord } from "../lib/object-type-guards.ts";
+
+type ThreadSubscriptionClient = Pick<SlackApiClient, "api">;
+
+export type ThreadUnsubscribeResult = {
+  ok: true;
+  status: "unsubscribed" | "already_unsubscribed";
+  channel_id: string;
+  thread_ts: string;
+  subscribed: false;
+};
+
+async function readThreadSubscription(
+  client: ThreadSubscriptionClient,
+  input: { channelId: string; threadTs: string; teamId?: string },
+): Promise<boolean> {
+  const response = await client.api("subscriptions.thread.get", {
+    channel: input.channelId,
+    thread_ts: input.threadTs,
+    team_id: input.teamId,
+  });
+  if (!Array.isArray(response.subscriptions)) {
+    throw new Error(
+      "Slack did not return an unambiguous thread subscription state; refusing to change it.",
+    );
+  }
+  if (response.subscriptions.some((subscription) => typeof subscription !== "string")) {
+    throw new Error("Slack returned a malformed thread subscription state; refusing to change it.");
+  }
+  if (response.subscriptions.length === 0) {
+    return false;
+  }
+  if (response.subscriptions.length === 1 && response.subscriptions[0] === input.threadTs) {
+    return true;
+  }
+  throw new Error("Slack returned an unexpected thread subscription state; refusing to change it.");
+}
+
+async function readThreadLastRead(
+  client: ThreadSubscriptionClient,
+  input: { channelId: string; threadTs: string },
+): Promise<string> {
+  const response = await client.api("conversations.replies", {
+    channel: input.channelId,
+    ts: input.threadTs,
+    limit: 1,
+  });
+  const root = asArray(response.messages).find(
+    (message): message is Record<string, unknown> =>
+      isRecord(message) && getString(message.ts) === input.threadTs,
+  );
+  if (!root) {
+    throw new Error("Thread root was not returned by Slack; refusing to change its subscription.");
+  }
+
+  const lastRead = getString(root.last_read)?.trim() || undefined;
+  if (!lastRead) {
+    throw new Error(
+      "Slack did not return the thread's current last_read value; refusing to unsubscribe.",
+    );
+  }
+  return lastRead;
+}
+
+/**
+ * Unfollow one exact Slack thread and verify the resulting state.
+ *
+ * Slack does not expose a public unfollow method. Keep the unsupported
+ * browser-session endpoint isolated here so callers cannot supply credentials,
+ * raw API methods, or arbitrary request fields.
+ */
+export async function unsubscribeThread(input: {
+  client: ThreadSubscriptionClient;
+  subscriptionClient?: ThreadSubscriptionClient;
+  auth: SlackAuth;
+  channelId: string;
+  threadTs: string;
+  teamId?: string;
+}): Promise<ThreadUnsubscribeResult> {
+  if (input.auth.auth_type !== "browser") {
+    throw new Error("Thread unsubscribe requires browser auth (xoxc token and xoxd cookie).");
+  }
+
+  const subscriptionClient = input.subscriptionClient ?? input.client;
+  const subscribedBefore = await readThreadSubscription(subscriptionClient, {
+    channelId: input.channelId,
+    threadTs: input.threadTs,
+    teamId: input.teamId,
+  });
+  if (!subscribedBefore) {
+    return {
+      ok: true,
+      status: "already_unsubscribed",
+      channel_id: input.channelId,
+      thread_ts: input.threadTs,
+      subscribed: false,
+    };
+  }
+  const lastRead = await readThreadLastRead(input.client, {
+    channelId: input.channelId,
+    threadTs: input.threadTs,
+  });
+
+  await subscriptionClient.api("subscriptions.thread.remove", {
+    channel: input.channelId,
+    thread_ts: input.threadTs,
+    last_read: lastRead,
+    team_id: input.teamId,
+  });
+
+  const subscribedAfter = await readThreadSubscription(subscriptionClient, {
+    channelId: input.channelId,
+    threadTs: input.threadTs,
+    teamId: input.teamId,
+  });
+  if (subscribedAfter) {
+    throw new Error("Slack still reports the thread as subscribed after the unsubscribe request.");
+  }
+
+  return {
+    ok: true,
+    status: "unsubscribed",
+    channel_id: input.channelId,
+    thread_ts: input.threadTs,
+    subscribed: false,
+  };
+}

--- a/test/help-contracts.test.ts
+++ b/test/help-contracts.test.ts
@@ -6,6 +6,7 @@ import type { CliContext } from "../src/cli/context.ts";
 import { registerLaterCommand } from "../src/cli/later-command.ts";
 import { registerMessageCommand } from "../src/cli/message-command.ts";
 import { registerUserCommand } from "../src/cli/user-command.ts";
+import { registerThreadCommand } from "../src/cli/thread-command.ts";
 
 function findCommand(root: Command, ...path: string[]): Command {
   let current = root;
@@ -35,6 +36,7 @@ function buildProgram(): Command {
   registerChannelCommand({ program, ctx });
   registerLaterCommand({ program, ctx });
   registerUserCommand({ program, ctx });
+  registerThreadCommand({ program, ctx });
   return program;
 }
 
@@ -99,5 +101,13 @@ describe("agent-facing help contracts", () => {
 
     expect(dmOpen.registeredArguments[0]?.description).toContain("One to 8 other user");
     expect(dmOpen.registeredArguments[0]?.description).toContain("caller is implicit");
+  });
+
+  test("thread unsubscribe documents its target, auth, and API constraints", () => {
+    const unsubscribe = findCommand(buildProgram(), "thread", "unsubscribe");
+
+    expect(unsubscribe.description()).toContain("requires browser auth");
+    expect(unsubscribe.description()).toContain("unsupported Slack API");
+    expect(unsubscribe.registeredArguments[0]?.description).toContain("Exact Slack message URL");
   });
 });

--- a/test/thread-command.test.ts
+++ b/test/thread-command.test.ts
@@ -1,0 +1,287 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { Command } from "commander";
+import type { CliContext } from "../src/cli/context.ts";
+import { registerThreadCommand, unsubscribeThreadTarget } from "../src/cli/thread-command.ts";
+
+type ApiCall = {
+  client: "workspace" | "enterprise";
+  method: string;
+  params: Record<string, unknown>;
+};
+
+const workspaceUrl = "https://workspace.slack.com";
+const enterpriseUrl = "https://grid.enterprise.slack.com";
+const threadTs = "1700000000.000001";
+
+function createContext(input?: {
+  authType?: "browser" | "standard";
+  enterprise?: boolean;
+  mismatchedEnterprise?: boolean;
+  mismatchedEnterpriseUser?: boolean;
+}) {
+  const calls: ApiCall[] = [];
+  const workspaceCalls: (string | undefined)[] = [];
+  let subscribed = true;
+  const api =
+    (kind: "workspace" | "enterprise") =>
+    async (method: string, params: Record<string, unknown> = {}) => {
+      calls.push({ client: kind, method, params });
+      if (method === "team.info") {
+        return input?.enterprise
+          ? {
+              ok: true,
+              team: {
+                id: "T12345678",
+                enterprise_id: "E12345678",
+                enterprise_domain: "grid",
+              },
+            }
+          : { ok: true, team: { id: "T12345678" } };
+      }
+      if (method === "auth.test") {
+        return kind === "workspace"
+          ? { ok: true, team_id: "T12345678", user_id: "U12345678" }
+          : {
+              ok: true,
+              team_id: input?.mismatchedEnterprise ? "E99999999" : "E12345678",
+              user_id: input?.mismatchedEnterpriseUser ? "U99999999" : "U12345678",
+            };
+      }
+      if (method === "subscriptions.thread.get") {
+        return { ok: true, subscriptions: subscribed ? [threadTs] : [] };
+      }
+      if (method === "subscriptions.thread.remove") {
+        subscribed = false;
+        return { ok: true };
+      }
+      if (method === "conversations.replies") {
+        return {
+          ok: true,
+          messages: [{ ts: params.ts, last_read: "1700000001.000002" }],
+        };
+      }
+      throw new Error(`Unexpected method: ${method}`);
+    };
+  const workspaceClient = { api: api("workspace") };
+  const enterpriseClient = { api: api("enterprise") };
+  const auth =
+    input?.authType === "standard"
+      ? ({ auth_type: "standard", token: "xoxb-test" } as const)
+      : ({
+          auth_type: "browser",
+          xoxc_token: "xoxc-test",
+          xoxd_cookie: "xoxd-test",
+        } as const);
+
+  const ctx: CliContext = {
+    effectiveWorkspaceUrl: (flag?: string) => flag,
+    assertWorkspaceSpecifiedForChannelNames: async () => {},
+    withAutoRefresh: async <T>(request: {
+      workspaceUrl: string | undefined;
+      work: () => Promise<T>;
+    }) => request.work(),
+    getClientForWorkspace: async (selector?: string) => {
+      workspaceCalls.push(selector);
+      if (selector === enterpriseUrl) {
+        return {
+          client: enterpriseClient as never,
+          auth,
+          workspace_url: enterpriseUrl,
+        };
+      }
+      return {
+        client: workspaceClient as never,
+        auth,
+        workspace_url: workspaceUrl,
+      };
+    },
+    normalizeUrl: (url: string) => url,
+    errorMessage: (err: unknown) => (err instanceof Error ? err.message : String(err)),
+    parseContentType: () => "any",
+    parseCurl: (_curl: string) => ({
+      workspace_url: workspaceUrl,
+      xoxc_token: "xoxc-test",
+      xoxd_cookie: "xoxd-test",
+    }),
+    importDesktop: async () => ({
+      cookie_d: "",
+      teams: [],
+      source: { leveldb_path: "", cookies_path: "" },
+    }),
+    importChrome: () => ({ cookie_d: "", teams: [] }),
+    importBrave: async () => null,
+    importFirefox: async () => null,
+  };
+
+  return { ctx, calls, workspaceCalls };
+}
+
+describe("unsubscribeThreadTarget", () => {
+  test("uses a root message URL as the exact thread target", async () => {
+    const { ctx, calls, workspaceCalls } = createContext();
+
+    await expect(
+      unsubscribeThreadTarget({
+        ctx,
+        targetInput: `${workspaceUrl}/archives/C12345678/p1700000000000001`,
+      }),
+    ).resolves.toEqual({
+      ok: true,
+      status: "unsubscribed",
+      channel_id: "C12345678",
+      thread_ts: threadTs,
+      subscribed: false,
+      workspace_url: workspaceUrl,
+      permalink: `${workspaceUrl}/archives/C12345678/p1700000000000001`,
+    });
+    expect(workspaceCalls).toEqual([workspaceUrl]);
+    expect(calls.map((call) => call.method)).toEqual([
+      "team.info",
+      "subscriptions.thread.get",
+      "conversations.replies",
+      "subscriptions.thread.remove",
+      "subscriptions.thread.get",
+    ]);
+  });
+
+  test("uses thread_ts from a reply permalink", async () => {
+    const { ctx, calls } = createContext();
+
+    const result = await unsubscribeThreadTarget({
+      ctx,
+      targetInput: `${workspaceUrl}/archives/C12345678/p1700000009000009?thread_ts=${threadTs}&cid=C12345678`,
+    });
+
+    expect(result.thread_ts).toBe(threadTs);
+    const rootRead = calls.find((call) => call.method === "conversations.replies");
+    expect(rootRead?.params.ts).toBe(threadTs);
+  });
+
+  test("routes Enterprise Grid subscription calls through the organization", async () => {
+    const { ctx, calls, workspaceCalls } = createContext({ enterprise: true });
+
+    await unsubscribeThreadTarget({
+      ctx,
+      targetInput: `${workspaceUrl}/archives/C12345678/p1700000000000001`,
+    });
+
+    expect(workspaceCalls).toEqual([workspaceUrl, enterpriseUrl]);
+    expect(calls.find((call) => call.method === "conversations.replies")?.client).toBe("workspace");
+    for (const call of calls.filter((candidate) => candidate.method.startsWith("subscriptions."))) {
+      expect(call.client).toBe("enterprise");
+      expect(call.params.team_id).toBe("T12345678");
+    }
+  });
+
+  test("rejects mismatched Enterprise Grid credentials before subscription access", async () => {
+    const { ctx, calls } = createContext({ enterprise: true, mismatchedEnterprise: true });
+
+    await expect(
+      unsubscribeThreadTarget({
+        ctx,
+        targetInput: `${workspaceUrl}/archives/C12345678/p1700000000000001`,
+      }),
+    ).rejects.toThrow("do not match the target workspace's organization");
+    expect(calls.some((call) => call.method.startsWith("subscriptions."))).toBe(false);
+  });
+
+  test("rejects Enterprise Grid credentials for a different Slack user", async () => {
+    const { ctx, calls } = createContext({
+      enterprise: true,
+      mismatchedEnterpriseUser: true,
+    });
+
+    await expect(
+      unsubscribeThreadTarget({
+        ctx,
+        targetInput: `${workspaceUrl}/archives/C12345678/p1700000000000001`,
+      }),
+    ).rejects.toThrow("do not belong to the same Slack user");
+    expect(calls.some((call) => call.method.startsWith("subscriptions."))).toBe(false);
+  });
+
+  test("rejects non-https URLs before resolving credentials", async () => {
+    const { ctx, calls, workspaceCalls } = createContext();
+
+    await expect(
+      unsubscribeThreadTarget({
+        ctx,
+        targetInput: "http://workspace.slack.com/archives/C12345678/p1700000000000001",
+      }),
+    ).rejects.toThrow("requires an https Slack message URL");
+    expect(workspaceCalls).toHaveLength(0);
+    expect(calls).toHaveLength(0);
+  });
+
+  test("rejects non-URL targets before resolving credentials", async () => {
+    const { ctx, calls, workspaceCalls } = createContext();
+
+    await expect(unsubscribeThreadTarget({ ctx, targetInput: "#general" })).rejects.toThrow(
+      "Invalid URL",
+    );
+    expect(workspaceCalls).toHaveLength(0);
+    expect(calls).toHaveLength(0);
+  });
+
+  test("rejects standard auth before making a Slack request", async () => {
+    const { ctx, calls } = createContext({ authType: "standard" });
+
+    await expect(
+      unsubscribeThreadTarget({
+        ctx,
+        targetInput: `${workspaceUrl}/archives/C12345678/p1700000000000001`,
+      }),
+    ).rejects.toThrow("requires browser auth");
+    expect(calls).toHaveLength(0);
+  });
+});
+
+describe("thread unsubscribe command", () => {
+  const originalLog = console.log;
+  const originalError = console.error;
+
+  beforeEach(() => {
+    process.exitCode = 0;
+  });
+
+  afterEach(() => {
+    process.exitCode = 0;
+    console.log = originalLog;
+    console.error = originalError;
+  });
+
+  test("prints verified JSON on success", async () => {
+    const { ctx } = createContext();
+    const program = new Command();
+    registerThreadCommand({ program, ctx });
+    const log = mock((_message: string) => {});
+    console.log = log as typeof console.log;
+
+    await program.parseAsync(
+      ["thread", "unsubscribe", `${workspaceUrl}/archives/C12345678/p1700000000000001`],
+      { from: "user" },
+    );
+
+    expect(process.exitCode).toBe(0);
+    expect(log).toHaveBeenCalledTimes(1);
+    const payload = JSON.parse(String(log.mock.calls[0]?.[0]));
+    expect(payload).toMatchObject({
+      ok: true,
+      status: "unsubscribed",
+      subscribed: false,
+    });
+  });
+
+  test("prints an error and exits nonzero on invalid input", async () => {
+    const { ctx } = createContext();
+    const program = new Command();
+    registerThreadCommand({ program, ctx });
+    const error = mock((_message: string) => {});
+    console.error = error as typeof console.error;
+
+    await program.parseAsync(["thread", "unsubscribe", "#general"], { from: "user" });
+
+    expect(process.exitCode).toBe(1);
+    expect(String(error.mock.calls[0]?.[0])).toContain("Invalid URL");
+  });
+});

--- a/test/thread-subscriptions.test.ts
+++ b/test/thread-subscriptions.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, test } from "bun:test";
+import type { SlackAuth, SlackApiClient } from "../src/slack/client.ts";
+import { unsubscribeThread } from "../src/slack/thread-subscriptions.ts";
+
+type ApiCall = { method: string; params: Record<string, unknown> };
+
+const channelId = "C12345678";
+const threadTs = "1700000000.000001";
+const lastRead = "1700000001.000002";
+const browserAuth: SlackAuth = {
+  auth_type: "browser",
+  xoxc_token: "xoxc-test",
+  xoxd_cookie: "xoxd-test",
+};
+
+function createClient(
+  handler: (call: ApiCall, index: number) => Promise<Record<string, unknown>>,
+): { client: SlackApiClient; calls: ApiCall[] } {
+  const calls: ApiCall[] = [];
+  const client = {
+    api: async (method: string, params: Record<string, unknown> = {}) => {
+      const call = { method, params };
+      calls.push(call);
+      return handler(call, calls.length - 1);
+    },
+  } as SlackApiClient;
+  return { client, calls };
+}
+
+function threadRoot(input?: { lastRead?: string; ts?: string }): Record<string, unknown> {
+  return {
+    ts: input?.ts ?? threadTs,
+    last_read: input?.lastRead ?? lastRead,
+  };
+}
+
+describe("unsubscribeThread", () => {
+  test("rejects standard auth before making a Slack request", async () => {
+    const { client, calls } = createClient(async () => ({ ok: true }));
+
+    await expect(
+      unsubscribeThread({
+        client,
+        auth: { auth_type: "standard", token: "xoxb-test" },
+        channelId,
+        threadTs,
+      }),
+    ).rejects.toThrow("requires browser auth");
+    expect(calls).toHaveLength(0);
+  });
+
+  test("returns idempotent success when the thread is already unsubscribed", async () => {
+    const { client, calls } = createClient(async () => ({ ok: true, subscriptions: [] }));
+
+    await expect(
+      unsubscribeThread({ client, auth: browserAuth, channelId, threadTs }),
+    ).resolves.toEqual({
+      ok: true,
+      status: "already_unsubscribed",
+      channel_id: channelId,
+      thread_ts: threadTs,
+      subscribed: false,
+    });
+    expect(calls).toEqual([
+      {
+        method: "subscriptions.thread.get",
+        params: { channel: channelId, thread_ts: threadTs, team_id: undefined },
+      },
+    ]);
+  });
+
+  test("preserves last_read, removes through the subscription client, and verifies", async () => {
+    const root = createClient(async () => ({ ok: true, messages: [threadRoot()] }));
+    let subscribed = true;
+    const subscription = createClient(async (call) => {
+      if (call.method === "subscriptions.thread.remove") {
+        subscribed = false;
+        return { ok: true };
+      }
+      return { ok: true, subscriptions: subscribed ? [threadTs] : [] };
+    });
+
+    await expect(
+      unsubscribeThread({
+        client: root.client,
+        subscriptionClient: subscription.client,
+        auth: browserAuth,
+        channelId,
+        threadTs,
+        teamId: "T12345678",
+      }),
+    ).resolves.toEqual({
+      ok: true,
+      status: "unsubscribed",
+      channel_id: channelId,
+      thread_ts: threadTs,
+      subscribed: false,
+    });
+    expect(root.calls).toEqual([
+      {
+        method: "conversations.replies",
+        params: { channel: channelId, ts: threadTs, limit: 1 },
+      },
+    ]);
+    expect(subscription.calls).toEqual([
+      {
+        method: "subscriptions.thread.get",
+        params: { channel: channelId, thread_ts: threadTs, team_id: "T12345678" },
+      },
+      {
+        method: "subscriptions.thread.remove",
+        params: {
+          channel: channelId,
+          thread_ts: threadTs,
+          last_read: lastRead,
+          team_id: "T12345678",
+        },
+      },
+      {
+        method: "subscriptions.thread.get",
+        params: { channel: channelId, thread_ts: threadTs, team_id: "T12345678" },
+      },
+    ]);
+  });
+
+  test("fails closed when a subscribed thread has no last_read value", async () => {
+    const { client, calls } = createClient(async (call) =>
+      call.method === "subscriptions.thread.get"
+        ? { ok: true, subscriptions: [threadTs] }
+        : { ok: true, messages: [{ ts: threadTs }] },
+    );
+
+    await expect(
+      unsubscribeThread({ client, auth: browserAuth, channelId, threadTs }),
+    ).rejects.toThrow("current last_read");
+    expect(calls.map((call) => call.method)).toEqual([
+      "subscriptions.thread.get",
+      "conversations.replies",
+    ]);
+  });
+
+  test("fails closed when Slack omits the subscription list", async () => {
+    const { client, calls } = createClient(async () => ({ ok: true }));
+
+    await expect(
+      unsubscribeThread({ client, auth: browserAuth, channelId, threadTs }),
+    ).rejects.toThrow("unambiguous thread subscription state");
+    expect(calls).toHaveLength(1);
+  });
+
+  test("fails closed on malformed or unexpected subscription entries", async () => {
+    for (const subscriptions of [[123], ["1700000009.000009"]]) {
+      const { client, calls } = createClient(async () => ({ ok: true, subscriptions }));
+
+      await expect(
+        unsubscribeThread({ client, auth: browserAuth, channelId, threadTs }),
+      ).rejects.toThrow(/malformed|unexpected/);
+      expect(calls).toHaveLength(1);
+    }
+  });
+
+  test("fails closed when Slack does not return the exact thread root", async () => {
+    const { client, calls } = createClient(async (call) =>
+      call.method === "subscriptions.thread.get"
+        ? { ok: true, subscriptions: [threadTs] }
+        : { ok: true, messages: [threadRoot({ ts: "1700000009.000009" })] },
+    );
+
+    await expect(
+      unsubscribeThread({ client, auth: browserAuth, channelId, threadTs }),
+    ).rejects.toThrow("Thread root was not returned");
+    expect(calls).toHaveLength(2);
+  });
+
+  test("fails when read-back still reports a subscription", async () => {
+    const { client, calls } = createClient(async (call) => {
+      if (call.method === "subscriptions.thread.remove") {
+        return { ok: true };
+      }
+      if (call.method === "conversations.replies") {
+        return { ok: true, messages: [threadRoot()] };
+      }
+      return { ok: true, subscriptions: [threadTs] };
+    });
+
+    await expect(
+      unsubscribeThread({ client, auth: browserAuth, channelId, threadTs }),
+    ).rejects.toThrow("still reports the thread as subscribed");
+    expect(calls.map((call) => call.method)).toEqual([
+      "subscriptions.thread.get",
+      "conversations.replies",
+      "subscriptions.thread.remove",
+      "subscriptions.thread.get",
+    ]);
+  });
+
+  test("propagates removal errors without retrying the mutation", async () => {
+    const { client, calls } = createClient(async (call) => {
+      if (call.method === "subscriptions.thread.remove") {
+        throw new Error("not_allowed");
+      }
+      if (call.method === "conversations.replies") {
+        return { ok: true, messages: [threadRoot()] };
+      }
+      return { ok: true, subscriptions: [threadTs] };
+    });
+
+    await expect(
+      unsubscribeThread({ client, auth: browserAuth, channelId, threadTs }),
+    ).rejects.toThrow("not_allowed");
+    expect(calls.map((call) => call.method)).toEqual([
+      "subscriptions.thread.get",
+      "conversations.replies",
+      "subscriptions.thread.remove",
+    ]);
+  });
+
+  test("a retry after an inconclusive read-back does not repeat a successful removal", async () => {
+    let subscribed = true;
+    let failReadBack = true;
+    const { client, calls } = createClient(async (call) => {
+      if (call.method === "subscriptions.thread.remove") {
+        subscribed = false;
+        return { ok: true };
+      }
+      if (call.method === "conversations.replies") {
+        return { ok: true, messages: [threadRoot()] };
+      }
+      if (!subscribed && failReadBack) {
+        failReadBack = false;
+        throw new Error("invalid_auth");
+      }
+      return { ok: true, subscriptions: subscribed ? [threadTs] : [] };
+    });
+    const request = { client, auth: browserAuth, channelId, threadTs };
+
+    await expect(unsubscribeThread(request)).rejects.toThrow("invalid_auth");
+    await expect(unsubscribeThread(request)).resolves.toMatchObject({
+      status: "already_unsubscribed",
+      subscribed: false,
+    });
+    expect(calls.filter((call) => call.method === "subscriptions.thread.remove")).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Adds `agent-slack thread unsubscribe <message-url>` to stop notifications from one exact Slack thread.

The command requires browser-session auth and an exact HTTPS Slack message URL. It preserves the current `last_read`, supports Enterprise Grid by routing subscription calls through the organization workspace after confirming the workspace and organization credentials belong to the same Slack user and organization, verifies that the thread is no longer subscribed, and treats repeat runs as an idempotent no-op.

Slack doesn’t expose a public thread-unsubscribe API, so the unsupported endpoint is isolated behind a narrow adapter and fails closed if the response shape is unexpected.