### PR TITLE
fix(auth): use browser-shaped User-Agent for browser-session API calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,15 @@ export SLACK_TOKEN="xoxb-..."
 agent-slack auth test
 ```
 
+> [!NOTE]
+> Browser-session (xoxc/xoxd) requests send a browser-shaped `User-Agent` by default, since they replay your real browser's session cookie and a non-browser UA can get flagged by Slack's Enterprise Grid session-security policy as `unexpected_user_agent`, which kills the session and logs out the browser tab it came from, not just the failing request. Override it if you need to, via `AGENT_SLACK_USER_AGENT` or the global `--user-agent <string>` flag:
+>
+> ```bash
+> export AGENT_SLACK_USER_AGENT="Mozilla/5.0 ..."
+> # or
+> agent-slack --user-agent "Mozilla/5.0 ..." auth test
+> ```
+
 ## Targets: URL or channel
 
 `message get` / `message list` accept either a Slack message URL or a channel reference:
@@ -233,7 +242,7 @@ After sending, the editor shows a "View in Slack" link to the posted message.
 Manage drafts through Slack's own drafts API, so they show up natively in the user's Slack client (mobile and desktop) ready to review and send. Requires browser-style auth (xoxc/xoxd).
 
 > [!NOTE]
-> These commands use Slack's **undocumented** internal `drafts.*` client endpoints (the same ones the Slack app uses), authenticated with your own browser session. They act only as you, on your own drafts — nothing is exposed that you can't already see, and `create` posts nothing. But because the endpoints are unsupported: their behavior may change without notice, and on **Enterprise Grid** this style of session-token API use can be flagged by Slack's security/anomaly detection. This is the same auth model the rest of agent-slack already uses (`later`, `unreads`, `search`); use it where that's acceptable.
+> These commands use Slack's **undocumented** internal `drafts.*` client endpoints (the same ones the Slack app uses), authenticated with your own browser session. They act only as you, on your own drafts; nothing is exposed that you can't already see, and `create` posts nothing. But because the endpoints are unsupported: their behavior may change without notice, and on **Enterprise Grid** this style of session-token API use can be flagged by Slack's security/anomaly detection (see the User-Agent note under [Authentication](#authentication-no-fancy-setup) for the specific `unexpected_user_agent` case and its mitigation). This is the same auth model the rest of agent-slack already uses (`later`, `unreads`, `search`); use it where that's acceptable.
 
 ```bash
 # List unsent drafts

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,24 @@ program
   .option(
     "--safe-mode",
     'Human-in-the-loop enforcement: redirect "message send" to the draft editor and block "message edit"/"message delete" (also: AGENT_SLACK_SAFE_MODE=1)',
+  )
+  .option(
+    "--user-agent <string>",
+    "Override the User-Agent header sent for Slack browser-session API calls (also: AGENT_SLACK_USER_AGENT)",
   );
+
+// getUserAgent() (src/lib/version.ts) reads AGENT_SLACK_USER_AGENT directly,
+// since it's called from deep inside slack/client.ts, slack/files.ts, and
+// slack/canvas.ts, which don't have access to the commander Command instance.
+// This hook is what lets the --user-agent flag reach it: it runs before any
+// subcommand's action, once options are parsed, and copies the flag into the
+// env var the getter already checks.
+program.hook("preAction", (thisCommand) => {
+  const { userAgent } = thisCommand.opts();
+  if (typeof userAgent === "string" && userAgent.trim()) {
+    process.env.AGENT_SLACK_USER_AGENT = userAgent;
+  }
+});
 
 startCommandWatchdog(process.argv.slice(2));
 

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -52,7 +52,7 @@ export function getPackageVersion(): string {
   return cachedVersion;
 }
 
-const DEFAULT_USER_AGENT =
+export const DEFAULT_USER_AGENT =
   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36";
 
 // Used only for Slack browser-session (xoxc/xoxd) API calls in slack/client.ts,

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -52,6 +52,21 @@ export function getPackageVersion(): string {
   return cachedVersion;
 }
 
+const DEFAULT_USER_AGENT =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36";
+
+// Used only for Slack browser-session (xoxc/xoxd) API calls in slack/client.ts,
+// slack/files.ts, and slack/canvas.ts. Those requests replay a real browser's
+// session cookie, so the UA must look like a browser too, or Slack's
+// enterprise session-security policy flags the mismatch as a fingerprint
+// anomaly (`unexpected_user_agent`) and kills the session, logging the real
+// browser out. Defaults to a static Chrome/macOS UA; bump DEFAULT_USER_AGENT
+// periodically to a current Chrome release (Slack's check appears to be
+// "is this browser-shaped", not an exact version match).
+//
+// Override via the AGENT_SLACK_USER_AGENT env var, or the global
+// `--user-agent <string>` CLI flag (index.ts copies the flag into the env
+// var via a commander preAction hook before any command runs).
 export function getUserAgent(): string {
-  return `agent-slack/${getPackageVersion()}`;
+  return process.env.AGENT_SLACK_USER_AGENT?.trim() || DEFAULT_USER_AGENT;
 }

--- a/test/version.test.ts
+++ b/test/version.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { DEFAULT_USER_AGENT, getUserAgent } from "../src/lib/version.ts";
+
+describe("getUserAgent", () => {
+  const originalUserAgent = process.env.AGENT_SLACK_USER_AGENT;
+
+  afterEach(() => {
+    if (originalUserAgent === undefined) {
+      delete process.env.AGENT_SLACK_USER_AGENT;
+    } else {
+      process.env.AGENT_SLACK_USER_AGENT = originalUserAgent;
+    }
+  });
+
+  test("defaults to a browser-shaped UA, not agent-slack/<version>", () => {
+    delete process.env.AGENT_SLACK_USER_AGENT;
+    expect(getUserAgent()).toBe(DEFAULT_USER_AGENT);
+    expect(getUserAgent()).not.toContain("agent-slack/");
+  });
+
+  test("falls back to the default for an unset, empty, or whitespace-only env var", () => {
+    for (const value of [undefined, "", "   "]) {
+      if (value === undefined) {
+        delete process.env.AGENT_SLACK_USER_AGENT;
+      } else {
+        process.env.AGENT_SLACK_USER_AGENT = value;
+      }
+      expect(getUserAgent()).toBe(DEFAULT_USER_AGENT);
+    }
+  });
+
+  test("honors AGENT_SLACK_USER_AGENT when set", () => {
+    process.env.AGENT_SLACK_USER_AGENT = "CustomAgent/1.0";
+    expect(getUserAgent()).toBe("CustomAgent/1.0");
+  });
+
+  test("trims surrounding whitespace from the env var", () => {
+    process.env.AGENT_SLACK_USER_AGENT = "  CustomAgent/1.0  ";
+    expect(getUserAgent()).toBe("CustomAgent/1.0");
+  });
+});


### PR DESCRIPTION
## What's broken

Browser-session (xoxc/xoxd) API calls in `src/slack/client.ts` (`browserApi`, `browserApiMultipart`), `src/slack/files.ts`, and `src/slack/canvas.ts` send `User-Agent: agent-slack/<version>` while replaying a real browser's session cookie (`Cookie: d=...`) and spoofing `Origin`/`Referer` as `https://app.slack.com`. That UA is a value no real browser sends.

On a workspace with enterprise session-security policies, this UA/session mismatch gets flagged as a fingerprint anomaly and Slack kills the session outright, logging out the real browser tab that owned it (`unexpected_user_agent`), sometimes mid-login.

Fixes #141.

## Fix

- `getUserAgent()` (`src/lib/version.ts`) now defaults to a static, browser-shaped UA string instead of `agent-slack/<version>`.
- Added an escape hatch since a hardcoded UA is never a perfect match for every user's real browser/OS, and Chrome versions age:
  - `AGENT_SLACK_USER_AGENT` env var.
  - Global `--user-agent <string>` CLI flag, wired to the env var via a commander `preAction` hook (needed because `getUserAgent()` is called from modules with no access to the `Command` instance).
- Documented both in the README's Authentication section (mirroring the existing `--safe-mode`/`AGENT_SLACK_SAFE_MODE` entry), and cross-referenced from the Slack-native drafts note, which already warned about Enterprise Grid session/anomaly detection but predated this fix.
- Added `test/version.test.ts` covering the default UA and the env var override (unset/empty/whitespace fallback, trimming), mirroring the style in `test/safe-mode.test.ts`.

## Testing

- `tsc --noEmit`: clean.
- `bun test`: full suite green (349 pass, 0 fail), including the 4 new tests.
- `coderabbit review --committed --base origin/main`: no findings, on all 4 changed files.
- Verified live against an affected Enterprise Grid workspace: `agent-slack auth test --workspace <url>` returned `{"ok": true, ...}` with no `unexpected_user_agent`, and the real browser session stayed logged in throughout.
