### PR TITLE
feat(canvas): add Slack canvas editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ nix run github:stablyai/agent-slack
 - **Write**: send now or schedule delivery, edit/delete messages, add reactions (bullet lists auto-render as native Slack rich text)
 - **Compose & drafts**: open a browser editor (`message compose`), or manage Slack-native drafts that show up in your Slack client (`message draft`)
 - **Channels**: list conversations, create channels, and invite users by id/handle/email
-- **Canvas**: create Slack canvases from Markdown and fetch them as Markdown
+- **Canvas**: create, edit, and fetch Slack canvases as Markdown
 
 ## Agent skill
 
@@ -109,6 +109,7 @@ agent-slack
 │   └── run     <trigger-id>       # trip a workflow trigger
 └── canvas
     ├── create                     # markdown file/blob → canvas
+    ├── edit <canvas-url-or-id>    # replace/insert/delete/rename a canvas
     └── get <canvas-url-or-id>     # canvas → markdown
 ```
 
@@ -562,7 +563,7 @@ agent-slack later remind "https://workspace.slack.com/archives/C123/p17000000000
 
 Named reminder days such as `tomorrow` and `monday` mean 9:00 in the CLI process's local timezone. Use a Unix timestamp when timezone precision matters.
 
-### Create or fetch a Canvas as Markdown
+### Create, edit, or fetch a Canvas as Markdown
 
 ```bash
 # Create from a local Markdown file
@@ -577,12 +578,32 @@ agent-slack canvas create --file ./launch-plan.md --channel "project-launch"
 # Fetch an existing canvas as Markdown
 agent-slack canvas get "https://workspace.slack.com/docs/T123/F456"
 agent-slack canvas get "F456" --workspace "https://workspace.slack.com"
+
+# Replace the entire canvas (the default operation)
+agent-slack canvas edit "F12345678" --file ./revised-plan.md --workspace "https://workspace.slack.com"
+
+# Apply a section-level edit (look up section IDs with Slack's Canvas tools)
+agent-slack canvas edit "F12345678" --operation insert_after --section-id "temp:C:SECTION" \
+  --markdown $'## Follow-up\n\n- [ ] Verify rollout' --workspace "https://workspace.slack.com"
+
+# Delete a section or rename the canvas
+agent-slack canvas edit "F12345678" --operation delete --section-id "temp:C:SECTION" \
+  --workspace "https://workspace.slack.com"
+agent-slack canvas edit "F12345678" --operation rename --title "Launch plan (final)" \
+  --workspace "https://workspace.slack.com"
 ```
 
 `canvas create` requires exactly one of `--file <path>` or `--markdown <text>`. Use
 `--workspace <url-or-unique-substring>` to select a workspace when needed. The command returns
 `canvas: { id, title?, channel_id? }`. Imported browser credentials can create standalone
 canvases; `--channel` requires a standard Slack token with Slack's `canvases:write` scope.
+
+`canvas edit` calls Slack's `canvases.edit` method and supports one operation per call:
+`insert_after`, `insert_before`, `insert_at_start`, `insert_at_end`, `replace`, `delete`, or
+`rename`. `replace` is the default and replaces the entire canvas unless `--section-id` is
+provided. Content operations require exactly one Markdown source; `delete` requires a section ID;
+`rename` requires `--title`. Editing requires a standard token with Slack's `canvases:write` scope;
+imported browser credentials cannot edit canvases.
 
 ## Developing / Contributing
 

--- a/llms.txt
+++ b/llms.txt
@@ -19,7 +19,7 @@
 - Multi-workspace Slack management with automatic workspace resolution
 - Human-in-the-loop message composing via browser-based WYSIWYG rich text editor (`message compose`)
 - Slack-native drafts that appear in the user's Slack client via `message draft` (list/create/update/delete), with file attachments
-- Slack canvas creation from Markdown files or inline content, plus export to Markdown
+- Slack canvas creation and editing from Markdown files or inline content, plus export to Markdown
 - Slack channel creation, user invites, and Slack Connect external invites
 
 ## Optional

--- a/skills/agent-slack/SKILL.md
+++ b/skills/agent-slack/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-slack
-description: "Slack CLI for agents: read URLs/threads/history/unreads/later/canvases/workflows, create canvases from Markdown, search messages/files, download attachments, lookup users, list/create/invite channels, open DMs, compose messages, manage Slack-native drafts, schedule sends, and explicit sends/edits/deletes/reactions/mark-read/uploads."
+description: "Slack CLI for agents: read URLs/threads/history/unreads/later/canvases/workflows, create/edit canvases from Markdown, search messages/files, download attachments, lookup users, list/create/invite channels, open DMs, compose messages, manage Slack-native drafts, schedule sends, and explicit sends/edits/deletes/reactions/mark-read/uploads."
 ---
 
 # agent-slack
@@ -19,7 +19,7 @@ If a capability named here is absent from installed help, report version skew in
 ## Safety
 
 - Read and search freely.
-- Perform write actions only when explicitly requested: sends, edits, deletes, reactions, invitations, channel or canvas creation, mark-read operations, scheduling or canceling delivery, uploads, Later state/reminder changes, DM/group-DM creation, and `workflow run`. Workflow runs can execute downstream actions.
+- Perform write actions only when explicitly requested: sends, edits, deletes, reactions, invitations, channel or canvas creation/editing, mark-read operations, scheduling or canceling delivery, uploads, Later state/reminder changes, DM/group-DM creation, and `workflow run`. Workflow runs can execute downstream actions.
 - For compose- or review-only requests, return proposed text without invoking Slack, or use `message draft create` to add a Slack-native draft the user can review and send (nothing is posted). `message compose` is send-capable; use it only when the user explicitly asks to open the interactive editor. In CI or another noninteractive environment, do not invoke it without separate authorization to send immediately: CI skips the editor and sends supplied text.
 - With `AGENT_SLACK_SAFE_MODE=1` (or the global `--safe-mode` flag) set, safe mode is enforced at the tool level: `message send` is redirected to the draft editor and `message edit`/`message delete` are blocked. Use it when nothing should post without human review.
 
@@ -40,6 +40,12 @@ Use `--no-unfurl` with `message send` or `message compose` when the user wants S
 Ordinary `message send` and `message edit` calls auto-convert lists. `message send --blocks` and `message edit --blocks` use supplied Block Kit blocks, while `message send --attach` sends its initial comment without automatic list conversion. Inside auto-converted lists, use Slack's `<URL|label>` syntax because CommonMark `[label](URL)` links are not converted into labeled link elements.
 
 Slack-native drafts (`message draft list|create|update|delete`) manage drafts that appear in the user's Slack client; `create` posts nothing. `create` and `update` accept repeatable `--attach <path>`; on `update` the files are added to the draft's existing attachments rather than replacing them. They use undocumented session endpoints and require browser-style auth (xoxc/xoxd).
+
+`canvas edit` uses Slack's public `canvases.edit` API and applies exactly one operation per call. The
+default `replace` operation replaces the whole canvas; section-targeted inserts/replacements and
+deletes require the section ID returned by Slack's Canvas tooling, while `rename` takes `--title`.
+Content operations take exactly one `--file` or `--markdown` source. It requires a standard token
+with `canvases:write`; imported browser credentials can create standalone canvases but cannot edit.
 
 ## Conditional references
 

--- a/skills/agent-slack/references/output.md
+++ b/skills/agent-slack/references/output.md
@@ -10,6 +10,7 @@ Slack data commands print JSON to stdout. Help, update, and some authentication 
 Immediate non-attachment sends return `ts` and usually a `permalink`. Attachment sends return neither; scheduled sends return `scheduled_message_id` and `post_at` instead.
 
 `canvas create` returns `canvas: { id, title?, channel_id? }`. `canvas get` returns `canvas: { id, title?, markdown }`.
+`canvas edit` returns `ok: true` and `canvas: { id, operation }` after Slack accepts the change.
 
 Message payloads keep canonical user IDs. Pass `--resolve-users` to add display metadata under `referenced_users`, or `--refresh-users` to refresh the 24-hour per-workspace cache before resolving.
 

--- a/src/cli/canvas-command.ts
+++ b/src/cli/canvas-command.ts
@@ -1,8 +1,11 @@
 import type { Command } from "commander";
 import type { CliContext } from "./context.ts";
 import {
+  BROWSER_AUTH_CANVAS_EDIT_ERROR,
   BROWSER_AUTH_CANVAS_CHANNEL_ERROR,
+  CANVAS_EDIT_OPERATIONS,
   createCanvasFromMarkdown,
+  editCanvas,
   fetchCanvasMarkdown,
   parseSlackCanvasUrl,
 } from "../slack/canvas.ts";
@@ -15,6 +18,15 @@ type CanvasCreateOptions = {
   markdown?: string;
   title?: string;
   channel?: string;
+  workspace?: string;
+};
+
+type CanvasEditOptions = {
+  file?: string;
+  markdown?: string;
+  operation: string;
+  sectionId?: string;
+  title?: string;
   workspace?: string;
 };
 
@@ -44,6 +56,27 @@ export async function readCanvasMarkdownInput(options: {
     throw new Error("Canvas Markdown is empty");
   }
   return markdown;
+}
+
+function resolveCanvasTarget(
+  value: string,
+  workspace?: string,
+): {
+  workspaceUrl?: string;
+  canvasId: string;
+} {
+  try {
+    const ref = parseSlackCanvasUrl(value);
+    return { workspaceUrl: ref.workspace_url, canvasId: ref.canvas_id };
+  } catch {
+    const trimmed = String(value).trim();
+    if (!/^F[A-Z0-9]{8,}$/.test(trimmed)) {
+      throw new Error(
+        `Unsupported canvas input: ${value} (expected Slack canvas URL or id like F...)`,
+      );
+    }
+    return { workspaceUrl: workspace?.trim() || undefined, canvasId: trimmed };
+  }
 }
 
 export function registerCanvasCommand(input: { program: Command; ctx: CliContext }): void {
@@ -117,23 +150,8 @@ export function registerCanvasCommand(input: { program: Command; ctx: CliContext
     .action(async (...args) => {
       const [value, options] = args as [string, { workspace?: string; maxChars: string }];
       try {
-        let workspaceUrl: string | undefined;
-        let canvasId: string;
-
-        try {
-          const ref = parseSlackCanvasUrl(value);
-          workspaceUrl = ref.workspace_url;
-          canvasId = ref.canvas_id;
-        } catch {
-          const trimmed = String(value).trim();
-          if (!/^F[A-Z0-9]{8,}$/.test(trimmed)) {
-            throw new Error(
-              `Unsupported canvas input: ${value} (expected Slack canvas URL or id like F...)`,
-            );
-          }
-          canvasId = trimmed;
-          workspaceUrl = options.workspace?.trim() || undefined;
-        }
+        const target = resolveCanvasTarget(value, options.workspace);
+        const { workspaceUrl } = target;
 
         const payload = await input.ctx.withAutoRefresh({
           workspaceUrl,
@@ -144,8 +162,73 @@ export function registerCanvasCommand(input: { program: Command; ctx: CliContext
             return await fetchCanvasMarkdown(client, {
               auth,
               workspaceUrl: workspace_url ?? workspaceUrl ?? "",
-              canvasId,
+              canvasId: target.canvasId,
               options: { maxChars },
+            });
+          },
+        });
+
+        console.log(JSON.stringify(pruneEmpty(payload), null, 2));
+      } catch (err: unknown) {
+        console.error(input.ctx.errorMessage(err));
+        process.exitCode = 1;
+      }
+    });
+
+  canvasCmd
+    .command("edit")
+    .description("Edit a Slack canvas with one documented operation")
+    .argument("<canvas>", "Slack canvas URL (…/docs/…/F…) or canvas id (F…)")
+    .option("--operation <operation>", `Operation: ${CANVAS_EDIT_OPERATIONS.join(", ")}`, "replace")
+    .option(
+      "--file <path>",
+      "Read Markdown from a local file (required for content operations; mutually exclusive with --markdown)",
+    )
+    .option(
+      "--markdown <text>",
+      "Use a Markdown string (required for content operations; mutually exclusive with --file)",
+    )
+    .option(
+      "--section-id <id>",
+      "Canvas section ID (required for insert_before/after/delete; identifies a replace target)",
+    )
+    .option("--title <title>", "New Markdown canvas title (required only for rename)")
+    .option(
+      "--workspace <url>",
+      "Workspace selector (full URL or unique substring; required if passing a canvas id across multiple workspaces)",
+    )
+    .action(async (...args) => {
+      const [value, options] = args as [string, CanvasEditOptions];
+      try {
+        const target = resolveCanvasTarget(value, options.workspace);
+        const operation = options.operation.trim();
+        if (!(CANVAS_EDIT_OPERATIONS as readonly string[]).includes(operation)) {
+          throw new Error(
+            `Unsupported canvas edit operation "${operation}". Expected one of: ${CANVAS_EDIT_OPERATIONS.join(", ")}`,
+          );
+        }
+        const needsMarkdown = operation !== "delete" && operation !== "rename";
+        let markdown: string | undefined;
+        if (needsMarkdown) {
+          markdown = await readCanvasMarkdownInput(options);
+        } else if (options.file !== undefined || options.markdown !== undefined) {
+          throw new Error(`Canvas edit operation "${operation}" does not accept Markdown content`);
+        }
+        const { workspaceUrl } = target;
+
+        const payload = await input.ctx.withAutoRefresh({
+          workspaceUrl,
+          work: async () => {
+            const { client, auth } = await input.ctx.getClientForWorkspace(workspaceUrl);
+            if (auth.auth_type === "browser") {
+              throw new Error(BROWSER_AUTH_CANVAS_EDIT_ERROR);
+            }
+            return await editCanvas(client, {
+              canvasId: target.canvasId,
+              operation,
+              markdown,
+              title: options.title,
+              sectionId: options.sectionId,
             });
           },
         });

--- a/src/slack/canvas.ts
+++ b/src/slack/canvas.ts
@@ -12,8 +12,32 @@ export type SlackCanvasRef = {
   raw: string;
 };
 
+export const CANVAS_EDIT_OPERATIONS = [
+  "insert_after",
+  "insert_before",
+  "insert_at_start",
+  "insert_at_end",
+  "replace",
+  "delete",
+  "rename",
+] as const;
+
+export const MAX_CANVAS_EDIT_MARKDOWN_CHARS = 1_048_576;
+
+export type SlackCanvasEditOperation = (typeof CANVAS_EDIT_OPERATIONS)[number];
+
+export type SlackCanvasEditChange = {
+  operation: SlackCanvasEditOperation;
+  section_id?: string;
+  document_content?: { type: "markdown"; markdown: string };
+  title_content?: { type: "markdown"; markdown: string };
+};
+
 export const BROWSER_AUTH_CANVAS_CHANNEL_ERROR =
   "Adding a canvas as a channel tab requires a standard Slack token; imported browser credentials can create standalone canvases only";
+
+export const BROWSER_AUTH_CANVAS_EDIT_ERROR =
+  "Editing a canvas requires a standard Slack token with the canvases:write scope; imported browser credentials cannot call canvases.edit";
 
 export async function createCanvasFromMarkdown(
   client: SlackApiClient,
@@ -65,6 +89,116 @@ export async function createCanvasFromMarkdown(
       channel_id: input.channelId,
     },
   };
+}
+
+function isCanvasEditOperation(value: string): value is SlackCanvasEditOperation {
+  return (CANVAS_EDIT_OPERATIONS as readonly string[]).includes(value);
+}
+
+/**
+ * Apply one documented Slack Canvas edit operation.
+ *
+ * Slack currently accepts exactly one change per canvases.edit call. Keeping
+ * the operation validation here makes the library safe for callers other than
+ * the CLI and prevents malformed requests from reaching Slack.
+ */
+export async function editCanvas(
+  client: SlackApiClient,
+  input: {
+    canvasId: string;
+    operation: string;
+    markdown?: string;
+    title?: string;
+    sectionId?: string;
+  },
+): Promise<{ ok: true; canvas: { id: string; operation: SlackCanvasEditOperation } }> {
+  const canvasId = input.canvasId.trim();
+  if (!canvasId) {
+    throw new Error("Canvas id is required");
+  }
+
+  const operation = input.operation.trim();
+  if (!isCanvasEditOperation(operation)) {
+    throw new Error(
+      `Unsupported canvas edit operation "${input.operation}". Expected one of: ${CANVAS_EDIT_OPERATIONS.join(", ")}`,
+    );
+  }
+
+  const sectionId = input.sectionId?.trim() || undefined;
+  const { markdown } = input;
+  const title = input.title?.trim() || undefined;
+  const contentOperations = new Set<SlackCanvasEditOperation>([
+    "insert_after",
+    "insert_before",
+    "insert_at_start",
+    "insert_at_end",
+    "replace",
+  ]);
+
+  if (contentOperations.has(operation)) {
+    if (markdown === undefined || !markdown.trim()) {
+      throw new Error(`Canvas edit operation "${operation}" requires non-empty Markdown content`);
+    }
+    if (markdown.length > MAX_CANVAS_EDIT_MARKDOWN_CHARS) {
+      throw new Error(
+        `Canvas edit Markdown exceeds Slack's ${MAX_CANVAS_EDIT_MARKDOWN_CHARS.toLocaleString("en-US")} character limit`,
+      );
+    }
+    if (title !== undefined) {
+      throw new Error(`--title is only valid with the rename operation`);
+    }
+    if ((operation === "insert_after" || operation === "insert_before") && !sectionId) {
+      throw new Error(`Canvas edit operation "${operation}" requires --section-id`);
+    }
+    if (
+      (operation === "insert_at_start" || operation === "insert_at_end") &&
+      sectionId !== undefined
+    ) {
+      throw new Error(`Canvas edit operation "${operation}" cannot use --section-id`);
+    }
+  } else if (operation === "delete") {
+    if (!sectionId) {
+      throw new Error('Canvas edit operation "delete" requires --section-id');
+    }
+    if (markdown !== undefined) {
+      throw new Error('Canvas edit operation "delete" does not accept Markdown content');
+    }
+    if (title !== undefined) {
+      throw new Error(`--title is only valid with the rename operation`);
+    }
+  } else {
+    if (!title) {
+      throw new Error('Canvas edit operation "rename" requires a non-empty --title');
+    }
+    if (title.length > MAX_CANVAS_EDIT_MARKDOWN_CHARS) {
+      throw new Error(
+        `Canvas edit title exceeds Slack's ${MAX_CANVAS_EDIT_MARKDOWN_CHARS.toLocaleString("en-US")} character limit`,
+      );
+    }
+    if (markdown !== undefined) {
+      throw new Error('Canvas edit operation "rename" does not accept Markdown content');
+    }
+    if (sectionId !== undefined) {
+      throw new Error('Canvas edit operation "rename" cannot use --section-id');
+    }
+  }
+
+  const change: SlackCanvasEditChange = { operation };
+  if (sectionId !== undefined) {
+    change.section_id = sectionId;
+  }
+  if (contentOperations.has(operation)) {
+    change.document_content = { type: "markdown", markdown: markdown! };
+  } else if (operation === "rename") {
+    change.title_content = { type: "markdown", markdown: title! };
+  }
+
+  await client.api("canvases.edit", {
+    canvas_id: canvasId,
+    changes: [change],
+  });
+
+  return { ok: true, canvas: { id: canvasId, operation } };
 }
 
 export function parseSlackCanvasUrl(input: string): SlackCanvasRef {

--- a/test/canvas-create.test.ts
+++ b/test/canvas-create.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import { Command } from "commander";
 import type { CliContext } from "../src/cli/context.ts";
 import { readCanvasMarkdownInput, registerCanvasCommand } from "../src/cli/canvas-command.ts";
-import { createCanvasFromMarkdown } from "../src/slack/canvas.ts";
+import { createCanvasFromMarkdown, editCanvas } from "../src/slack/canvas.ts";
 import type { SlackApiClient, SlackAuth } from "../src/slack/client.ts";
 
 function createClient(response: Record<string, unknown> = { ok: true, canvas_id: "F12345678" }) {
@@ -167,6 +167,158 @@ describe("createCanvasFromMarkdown", () => {
   });
 });
 
+describe("editCanvas", () => {
+  test.each([
+    [
+      "replace",
+      undefined,
+      { operation: "replace", document_content: { type: "markdown", markdown: "# Revised\n" } },
+    ],
+    [
+      "replace section",
+      "temp:C:SECTION",
+      {
+        operation: "replace",
+        section_id: "temp:C:SECTION",
+        document_content: { type: "markdown", markdown: "Updated section" },
+      },
+    ],
+    [
+      "insert before",
+      "temp:C:SECTION",
+      {
+        operation: "insert_before",
+        section_id: "temp:C:SECTION",
+        document_content: { type: "markdown", markdown: "Before" },
+      },
+    ],
+    [
+      "insert after",
+      "temp:C:SECTION",
+      {
+        operation: "insert_after",
+        section_id: "temp:C:SECTION",
+        document_content: { type: "markdown", markdown: "After" },
+      },
+    ],
+    [
+      "insert at start",
+      undefined,
+      {
+        operation: "insert_at_start",
+        document_content: { type: "markdown", markdown: "Start" },
+      },
+    ],
+    [
+      "insert at end",
+      undefined,
+      {
+        operation: "insert_at_end",
+        document_content: { type: "markdown", markdown: "End" },
+      },
+    ],
+    ["delete section", "temp:C:SECTION", { operation: "delete", section_id: "temp:C:SECTION" }],
+    [
+      "rename",
+      undefined,
+      {
+        operation: "rename",
+        title_content: { type: "markdown", markdown: "Project status" },
+      },
+    ],
+  ] as const)("sends the documented %s change", async (_name, sectionId, expectedChange) => {
+    const { client, calls } = createClient({ ok: true });
+    const { operation } = expectedChange;
+    const markdown =
+      "document_content" in expectedChange ? expectedChange.document_content.markdown : undefined;
+    const title =
+      "title_content" in expectedChange ? expectedChange.title_content.markdown : undefined;
+    const result = await editCanvas(client, {
+      canvasId: " F12345678 ",
+      operation,
+      markdown,
+      title,
+      sectionId,
+    });
+
+    expect(calls).toEqual([
+      {
+        transport: "json",
+        method: "canvases.edit",
+        params: { canvas_id: "F12345678", changes: [expectedChange] },
+      },
+    ]);
+    expect(result).toEqual({ ok: true, canvas: { id: "F12345678", operation } });
+  });
+
+  test("rejects invalid combinations before calling Slack", async () => {
+    const cases = [
+      {
+        input: { operation: "insert_after", markdown: "Body" },
+        message: 'operation "insert_after" requires --section-id',
+      },
+      {
+        input: { operation: "insert_at_end", markdown: "Body", sectionId: "temp:C:SECTION" },
+        message: 'operation "insert_at_end" cannot use --section-id',
+      },
+      {
+        input: { operation: "delete" },
+        message: 'operation "delete" requires --section-id',
+      },
+      {
+        input: { operation: "rename" },
+        message: 'operation "rename" requires a non-empty --title',
+      },
+      {
+        input: { operation: "replace", markdown: "Body", title: "Wrong" },
+        message: "--title is only valid with the rename operation",
+      },
+      {
+        input: { operation: "nope", markdown: "Body" },
+        message: 'Unsupported canvas edit operation "nope"',
+      },
+    ] as const;
+
+    for (const testCase of cases) {
+      const { client, calls } = createClient({ ok: true });
+      await expect(
+        editCanvas(client, { canvasId: "F12345678", ...testCase.input }),
+      ).rejects.toThrow(testCase.message);
+      expect(calls).toHaveLength(0);
+    }
+  });
+
+  test("rejects empty Markdown and canvas ids before calling Slack", async () => {
+    const { client, calls } = createClient({ ok: true });
+    await expect(
+      editCanvas(client, { canvasId: "F12345678", operation: "replace", markdown: " \n" }),
+    ).rejects.toThrow("requires non-empty Markdown");
+    await expect(
+      editCanvas(client, { canvasId: " ", operation: "delete", sectionId: "temp:C:SECTION" }),
+    ).rejects.toThrow("Canvas id is required");
+    expect(calls).toHaveLength(0);
+  });
+
+  test("rejects Markdown over Slack's per-change limit before calling Slack", async () => {
+    const { client, calls } = createClient({ ok: true });
+    await expect(
+      editCanvas(client, {
+        canvasId: "F12345678",
+        operation: "replace",
+        markdown: "x".repeat(1_048_577),
+      }),
+    ).rejects.toThrow("character limit");
+    await expect(
+      editCanvas(client, {
+        canvasId: "F12345678",
+        operation: "rename",
+        title: "x".repeat(1_048_577),
+      }),
+    ).rejects.toThrow("character limit");
+    expect(calls).toHaveLength(0);
+  });
+});
+
 describe("readCanvasMarkdownInput", () => {
   test("reads a Markdown file without changing its contents", async () => {
     const dir = await mkdtemp(join(tmpdir(), "agent-slack-canvas-"));
@@ -301,6 +453,167 @@ describe("canvas create command", () => {
     expect(error).toHaveBeenCalledTimes(2);
     expect(workspaceSelections).toHaveLength(0);
     expect(calls).toHaveLength(0);
+    expect(process.exitCode).toBe(1);
+  });
+});
+
+describe("canvas edit command", () => {
+  const originalLog = console.log;
+  const originalError = console.error;
+
+  beforeEach(() => {
+    process.exitCode = 0;
+  });
+
+  afterEach(() => {
+    process.exitCode = 0;
+    console.log = originalLog;
+    console.error = originalError;
+  });
+
+  test("replaces a canvas from a Markdown URL target", async () => {
+    const { client, calls } = createClient({ ok: true });
+    const { ctx, workspaceSelections } = createContext(client);
+    const program = new Command();
+    registerCanvasCommand({ program, ctx });
+    const log = mock((_value?: unknown) => {});
+    console.log = log as typeof console.log;
+
+    await program.parseAsync(
+      ["canvas", "edit", "https://acme.slack.com/docs/T123/F12345678", "--markdown", "# Revised\n"],
+      { from: "user" },
+    );
+
+    expect(workspaceSelections).toEqual(["https://acme.slack.com"]);
+    expect(calls[0]).toEqual({
+      transport: "json",
+      method: "canvases.edit",
+      params: {
+        canvas_id: "F12345678",
+        changes: [
+          { operation: "replace", document_content: { type: "markdown", markdown: "# Revised\n" } },
+        ],
+      },
+    });
+    expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toEqual({
+      ok: true,
+      canvas: { id: "F12345678", operation: "replace" },
+    });
+  });
+
+  test("inserts content from a file and passes a section id", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "agent-slack-canvas-edit-command-"));
+    const path = join(dir, "addition.md");
+    try {
+      await writeFile(path, "Added\n", "utf8");
+      const { client, calls } = createClient({ ok: true });
+      const { ctx } = createContext(client);
+      const program = new Command();
+      registerCanvasCommand({ program, ctx });
+      console.log = mock(() => {}) as typeof console.log;
+
+      await program.parseAsync(
+        [
+          "canvas",
+          "edit",
+          "F12345678",
+          "--operation",
+          "insert_after",
+          "--section-id",
+          "temp:C:SECTION",
+          "--file",
+          path,
+        ],
+        { from: "user" },
+      );
+
+      expect(calls[0]?.params).toEqual({
+        canvas_id: "F12345678",
+        changes: [
+          {
+            operation: "insert_after",
+            section_id: "temp:C:SECTION",
+            document_content: { type: "markdown", markdown: "Added\n" },
+          },
+        ],
+      });
+      expect(process.exitCode).toBe(0);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("renames without a Markdown source", async () => {
+    const { client, calls } = createClient({ ok: true });
+    const { ctx } = createContext(client);
+    const program = new Command();
+    registerCanvasCommand({ program, ctx });
+    console.log = mock(() => {}) as typeof console.log;
+
+    await program.parseAsync(
+      ["canvas", "edit", "F12345678", "--operation", "rename", "--title", "Renamed"],
+      { from: "user" },
+    );
+
+    expect(calls[0]?.params).toEqual({
+      canvas_id: "F12345678",
+      changes: [{ operation: "rename", title_content: { type: "markdown", markdown: "Renamed" } }],
+    });
+  });
+
+  test("rejects delete content and malformed inputs before authenticating", async () => {
+    const { client, calls } = createClient({ ok: true });
+    const { ctx, workspaceSelections } = createContext(client);
+    const program = new Command();
+    registerCanvasCommand({ program, ctx });
+    const error = mock((_value?: unknown) => {});
+    console.error = error as typeof console.error;
+
+    await program.parseAsync(
+      [
+        "canvas",
+        "edit",
+        "F12345678",
+        "--operation",
+        "delete",
+        "--section-id",
+        "x",
+        "--markdown",
+        "nope",
+      ],
+      { from: "user" },
+    );
+    await program.parseAsync(
+      ["canvas", "edit", "F12345678", "--operation", "not-real", "--markdown", "nope"],
+      { from: "user" },
+    );
+
+    expect(calls).toHaveLength(0);
+    expect(workspaceSelections).toHaveLength(0);
+    expect(error).toHaveBeenCalledTimes(2);
+    expect(String(error.mock.calls[0]?.[0])).toContain("does not accept Markdown content");
+    expect(String(error.mock.calls[1]?.[0])).toContain("Unsupported canvas edit operation");
+    expect(process.exitCode).toBe(1);
+  });
+
+  test("rejects browser credentials before calling canvases.edit", async () => {
+    const { client, calls } = createClient({ ok: true });
+    const { ctx } = createContext(client, {
+      auth_type: "browser",
+      xoxc_token: "xoxc-test",
+      xoxd_cookie: "xoxd-test",
+    });
+    const program = new Command();
+    registerCanvasCommand({ program, ctx });
+    const error = mock((_value?: unknown) => {});
+    console.error = error as typeof console.error;
+
+    await program.parseAsync(["canvas", "edit", "F12345678", "--markdown", "# Revised"], {
+      from: "user",
+    });
+
+    expect(calls).toHaveLength(0);
+    expect(String(error.mock.calls[0]?.[0])).toContain("standard Slack token");
     expect(process.exitCode).toBe(1);
   });
 });

--- a/test/help-contracts.test.ts
+++ b/test/help-contracts.test.ts
@@ -89,6 +89,16 @@ describe("agent-facing help contracts", () => {
     expect(optionDescription(create, "--channel")).toContain("browser auth");
   });
 
+  test("canvas editing identifies operations, targeting, and content constraints", () => {
+    const edit = findCommand(buildProgram(), "canvas", "edit");
+
+    expect(edit.description()).toContain("one documented operation");
+    expect(optionDescription(edit, "--operation")).toContain("replace");
+    expect(optionDescription(edit, "--file")).toContain("mutually exclusive");
+    expect(optionDescription(edit, "--section-id")).toContain("required");
+    expect(optionDescription(edit, "--title")).toContain("rename");
+  });
+
   test("channel mark distinguishes URL and non-URL workspace handling", () => {
     const mark = findCommand(buildProgram(), "channel", "mark");
 


### PR DESCRIPTION
## Summary

- Add `agent-slack canvas edit <canvas-url-or-id>` backed by Slack’s public `canvases.edit` API.
- Support every documented single-change operation: `replace` (default), `insert_before`, `insert_after`, `insert_at_start`, `insert_at_end`, `delete`, and `rename`.
- Accept exactly one Markdown file/blob for content changes; require section IDs where Slack requires them; use `--title` for rename.
- Enforce Slack’s 1 MiB per-change Markdown/title limit and reject malformed edits before authentication/API calls.
- Explain that imported browser credentials cannot use `canvases.edit`; editing requires a standard token with `canvases:write`.
- Update README, agent skill, output reference, and llms metadata.

## Research

Slack documents `canvases.edit` as `POST https://slack.com/api/canvases.edit`, requiring `canvas_id` and a `changes` array. The API currently accepts one change per call. Content operations and the `rename`/`title_content` form match the examples in the official docs:

https://docs.slack.dev/reference/methods/canvases.edit

## Verification

- `bun test` (399 pass, 0 fail)
- `bun run typecheck`
- `bun run format:check`
- `bun run lint` (0 errors; existing warnings only)
- `bun run build`
- `git diff --check`