### PR TITLE
fix(nix): sync flake to v0.10.2 and make hash updates testable

### DIFF
--- a/.github/workflows/update-nix-sources.yml
+++ b/.github/workflows/update-nix-sources.yml
@@ -4,15 +4,10 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 9 * * 1"
-  release:
-    types: [published]
-
-concurrency:
-  group: update-nix-sources
-  cancel-in-progress: false
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   update:
@@ -21,34 +16,21 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          ref: main
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: package.json
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
+      - name: Install Nix
+        uses: cachix/install-nix-action@2126ae7fc54c9df00dd18f7f18754393182c73cd # v31
 
       - name: Update nix sources
-        run: bun scripts/update-nix-sources.ts
+        run: ./scripts/update-nix-sources.sh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Commit updated hashes
-        run: |
-          set -euo pipefail
-          if git diff --quiet nix/sources.json; then
-            echo "nix/sources.json already matches the latest GitHub release"
-            exit 0
-          fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add nix/sources.json
-          version="$(node -e "console.log(JSON.parse(require('fs').readFileSync('nix/sources.json','utf8')).version)")"
-          git commit -m "chore(nix): update release hashes to ${version}"
-          git push
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
+        with:
+          commit-message: "chore(nix): update release hashes"
+          title: "chore(nix): update release hashes"
+          body: |
+            Automated update of `nix/sources.json` from the latest GitHub release checksums.
+          branch: chore/update-nix-sources
+          delete-branch: true

--- a/.github/workflows/update-nix-sources.yml
+++ b/.github/workflows/update-nix-sources.yml
@@ -4,10 +4,15 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 9 * * 1"
+  release:
+    types: [published]
+
+concurrency:
+  group: update-nix-sources
+  cancel-in-progress: false
 
 permissions:
   contents: write
-  pull-requests: write
 
 jobs:
   update:
@@ -16,21 +21,34 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: main
 
-      - name: Install Nix
-        uses: cachix/install-nix-action@2126ae7fc54c9df00dd18f7f18754393182c73cd # v31
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: package.json
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
 
       - name: Update nix sources
-        run: ./scripts/update-nix-sources.sh
+        run: bun scripts/update-nix-sources.ts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Create pull request
-        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
-        with:
-          commit-message: "chore(nix): update release hashes"
-          title: "chore(nix): update release hashes"
-          body: |
-            Automated update of `nix/sources.json` from the latest GitHub release checksums.
-          branch: chore/update-nix-sources
-          delete-branch: true
+      - name: Commit updated hashes
+        run: |
+          set -euo pipefail
+          if git diff --quiet nix/sources.json; then
+            echo "nix/sources.json already matches the latest GitHub release"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add nix/sources.json
+          version="$(node -e "console.log(JSON.parse(require('fs').readFileSync('nix/sources.json','utf8')).version)")"
+          git commit -m "chore(nix): update release hashes to ${version}"
+          git push

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,8 @@ Pushing the tag triggers the GitHub Actions `Release` workflow, which:
 - Builds native binaries for all platforms (macOS, Linux, Windows × x64, arm64)
 - Generates checksums
 - Uploads everything to the GitHub Release
-- After the GitHub Release is published, `Update Nix Sources` refreshes `nix/sources.json` so `nix run github:stablyai/agent-slack` tracks that release. You can also run `bun scripts/update-nix-sources.ts` locally.
+
+`nix run github:stablyai/agent-slack` reads version and hashes from `nix/sources.json`. After publishing a GitHub Release, refresh that file with `bun scripts/update-nix-sources.ts` (or `./scripts/update-nix-sources.sh`).
 
 ### Manual release (alternative)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,7 @@ Pushing the tag triggers the GitHub Actions `Release` workflow, which:
 - Builds native binaries for all platforms (macOS, Linux, Windows × x64, arm64)
 - Generates checksums
 - Uploads everything to the GitHub Release
+- After the GitHub Release is published, `Update Nix Sources` refreshes `nix/sources.json` so `nix run github:stablyai/agent-slack` tracks that release. You can also run `bun scripts/update-nix-sources.ts` locally.
 
 ### Manual release (alternative)
 

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,9 +1,9 @@
 {
-  "version": "0.5.2",
+  "version": "0.10.2",
   "hashes": {
-    "aarch64-darwin": "sha256-/amxMaLwMxmfyHqUZn8bKd6/bjrx/glCSzLSbFs+kKk=",
-    "x86_64-darwin": "sha256-w/uvefbqwaeiAsTSGt4VxY/VYWkFVQokQkjyIcL2EDw=",
-    "aarch64-linux": "sha256-CvpfyhuwI1V4XPSM6tiATq7h2tNHeK/Q1Ohwyq1ZFNw=",
-    "x86_64-linux": "sha256-7C+Z6CgXsagfgo+RPIj9dz7edwwzcqgpX2aJmRs2Xuc="
+    "aarch64-darwin": "sha256-/5ANXHZAM7c3ZiETtOjFqVPf4mRbhwhTb0GGet1U/js=",
+    "x86_64-darwin": "sha256-eR/qchRH4VprQ3hHl+yKGcXAedais847vSpBblS++H8=",
+    "aarch64-linux": "sha256-AucaaYFqpnmy61dW/uk0kZX9co2pnmWC3GrBp29j8e4=",
+    "x86_64-linux": "sha256-rU1l1O4sg+x+ulk5UVaOi3yXIrcpcaCejK5uCQBX1IM="
   }
 }

--- a/scripts/nix-sources.ts
+++ b/scripts/nix-sources.ts
@@ -1,0 +1,191 @@
+export const NIX_SYSTEM_ASSETS = [
+  { system: "aarch64-darwin", asset: "agent-slack-darwin-arm64" },
+  { system: "x86_64-darwin", asset: "agent-slack-darwin-x64" },
+  { system: "aarch64-linux", asset: "agent-slack-linux-arm64" },
+  { system: "x86_64-linux", asset: "agent-slack-linux-x64" },
+] as const;
+
+export type NixSystem = (typeof NIX_SYSTEM_ASSETS)[number]["system"];
+
+export type NixSources = {
+  version: string;
+  hashes: Record<NixSystem, string>;
+};
+
+export type GithubReleaseAsset = {
+  name?: string;
+  digest?: string;
+  browser_download_url?: string;
+};
+
+export type GithubRelease = {
+  tag_name?: string;
+  assets?: GithubReleaseAsset[];
+};
+
+export type FetchLike = (url: string | URL, init?: RequestInit) => Promise<Response>;
+
+const SHA256_HEX = /^[0-9a-f]{64}$/;
+
+export function hexToSri(hex: string): string {
+  const clean = hex
+    .trim()
+    .toLowerCase()
+    .replace(/^sha256:/, "");
+  if (!SHA256_HEX.test(clean)) {
+    throw new Error(`invalid sha256 hex: ${hex}`);
+  }
+  return `sha256-${Buffer.from(clean, "hex").toString("base64")}`;
+}
+
+export function parseChecksums(text: string): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const line of text.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      continue;
+    }
+    const match = trimmed.match(/^([0-9a-fA-F]{64})\s+\*?(\S+)$/);
+    if (!match) {
+      continue;
+    }
+    const [, hex, asset] = match;
+    if (!hex || !asset) {
+      continue;
+    }
+    map.set(asset, hex.toLowerCase());
+  }
+  return map;
+}
+
+export function versionFromTag(tagName: string | undefined): string {
+  const tag = tagName?.trim() ?? "";
+  if (!tag || tag === "null") {
+    throw new Error("unable to resolve latest release tag");
+  }
+  return tag.replace(/^v/, "");
+}
+
+function parseDigest(digest: string | undefined): string | undefined {
+  if (!digest) {
+    return undefined;
+  }
+  const match = digest.trim().match(/^(?:sha256:)?([0-9a-fA-F]{64})$/);
+  const hex = match?.[1];
+  return hex ? hex.toLowerCase() : undefined;
+}
+
+export function hashesFromRelease(input: {
+  assets: GithubReleaseAsset[];
+  checksums?: string;
+}): Record<NixSystem, string> {
+  const { assets, checksums } = input;
+  const byName = new Map(
+    assets.flatMap((asset) => {
+      const name = asset.name?.trim();
+      return name ? [[name, asset] as const] : [];
+    }),
+  );
+  const fromChecksums = checksums ? parseChecksums(checksums) : undefined;
+  const hashes = {} as Record<NixSystem, string>;
+
+  for (const { system, asset } of NIX_SYSTEM_ASSETS) {
+    const releaseAsset = byName.get(asset);
+    const hex = parseDigest(releaseAsset?.digest) ?? fromChecksums?.get(asset);
+    if (!hex) {
+      throw new Error(`missing checksum for ${asset}`);
+    }
+    hashes[system] = hexToSri(hex);
+  }
+
+  return hashes;
+}
+
+export function buildNixSources(input: {
+  version: string;
+  hashes: Record<NixSystem, string>;
+}): NixSources {
+  return {
+    version: input.version,
+    hashes: input.hashes,
+  };
+}
+
+export function formatSourcesJson(sources: NixSources): string {
+  return `${JSON.stringify(sources, null, 2)}\n`;
+}
+
+export async function fetchLatestRelease(input: {
+  repo: string;
+  token?: string;
+  fetchImpl?: FetchLike;
+}): Promise<GithubRelease> {
+  const fetchImpl = input.fetchImpl ?? fetch;
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+  };
+  if (input.token) {
+    headers.Authorization = `Bearer ${input.token}`;
+  }
+  const response = await fetchImpl(`https://api.github.com/repos/${input.repo}/releases/latest`, {
+    headers,
+  });
+  if (!response.ok) {
+    throw new Error(`GitHub API ${response.status} fetching latest release`);
+  }
+  return (await response.json()) as GithubRelease;
+}
+
+export async function fetchChecksumsFile(input: {
+  url: string;
+  token?: string;
+  fetchImpl?: FetchLike;
+}): Promise<string> {
+  const fetchImpl = input.fetchImpl ?? fetch;
+  const headers: Record<string, string> = {};
+  if (input.token) {
+    headers.Authorization = `Bearer ${input.token}`;
+  }
+  const response = await fetchImpl(input.url, { headers });
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status} fetching checksums from ${input.url}`);
+  }
+  return await response.text();
+}
+
+export function checksumsUrlForTag(input: { repo: string; tag: string }): string {
+  return `https://github.com/${input.repo}/releases/download/${input.tag}/checksums-sha256.txt`;
+}
+
+export async function resolveNixSources(input: {
+  repo: string;
+  token?: string;
+  fetchImpl?: FetchLike;
+  release?: GithubRelease;
+  checksums?: string;
+}): Promise<NixSources> {
+  const release = input.release ?? (await fetchLatestRelease(input));
+  const tag = release.tag_name?.trim() ?? "";
+  const version = versionFromTag(tag);
+  const assets = Array.isArray(release.assets) ? release.assets : [];
+
+  try {
+    return buildNixSources({
+      version,
+      hashes: hashesFromRelease({ assets, checksums: input.checksums }),
+    });
+  } catch (error) {
+    if (input.checksums !== undefined) {
+      throw error;
+    }
+    const checksums = await fetchChecksumsFile({
+      url: checksumsUrlForTag({ repo: input.repo, tag }),
+      token: input.token,
+      fetchImpl: input.fetchImpl,
+    });
+    return buildNixSources({
+      version,
+      hashes: hashesFromRelease({ assets, checksums }),
+    });
+  }
+}

--- a/scripts/update-nix-sources.sh
+++ b/scripts/update-nix-sources.sh
@@ -3,9 +3,70 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
-if ! command -v bun >/dev/null 2>&1; then
-  echo "error: bun is required" >&2
+if command -v bun >/dev/null 2>&1; then
+  exec bun scripts/update-nix-sources.ts "$@"
+fi
+
+repo="stablyai/agent-slack"
+latest_api="https://api.github.com/repos/${repo}/releases/latest"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: jq is required" >&2
   exit 1
 fi
 
-exec bun scripts/update-nix-sources.ts "$@"
+if ! command -v nix >/dev/null 2>&1; then
+  echo "error: nix is required" >&2
+  exit 1
+fi
+
+curl_opts=(-fsSL)
+if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+  curl_opts+=(-H "Authorization: token $GITHUB_TOKEN")
+fi
+
+tag="$(curl "${curl_opts[@]}" "$latest_api" | jq -r '.tag_name')"
+if [[ -z "$tag" || "$tag" == "null" ]]; then
+  echo "error: unable to resolve latest release tag" >&2
+  exit 1
+fi
+
+version="${tag#v}"
+checksums_url="https://github.com/${repo}/releases/download/${tag}/checksums-sha256.txt"
+checksums="$(curl "${curl_opts[@]}" "$checksums_url")"
+
+get_sri() {
+  local asset="$1"
+  local hex
+  hex="$(awk -v asset="$asset" '$2 == asset { print $1 }' <<<"$checksums")"
+
+  if [[ -z "$hex" ]]; then
+    echo "error: missing checksum for ${asset}" >&2
+    exit 1
+  fi
+
+  nix hash convert --hash-algo sha256 --to sri "$hex"
+}
+
+arm64_darwin="$(get_sri agent-slack-darwin-arm64)"
+x64_darwin="$(get_sri agent-slack-darwin-x64)"
+arm64_linux="$(get_sri agent-slack-linux-arm64)"
+x64_linux="$(get_sri agent-slack-linux-x64)"
+
+jq -n \
+  --arg version "$version" \
+  --arg aarch64_darwin "$arm64_darwin" \
+  --arg x86_64_darwin "$x64_darwin" \
+  --arg aarch64_linux "$arm64_linux" \
+  --arg x86_64_linux "$x64_linux" \
+  '{
+    version: $version,
+    hashes: {
+      "aarch64-darwin": $aarch64_darwin,
+      "x86_64-darwin": $x86_64_darwin,
+      "aarch64-linux": $aarch64_linux,
+      "x86_64-linux": $x86_64_linux
+    }
+  }' > nix/sources.json
+
+echo "Updated nix/sources.json to ${version}"

--- a/scripts/update-nix-sources.sh
+++ b/scripts/update-nix-sources.sh
@@ -1,66 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-repo="stablyai/agent-slack"
-latest_api="https://api.github.com/repos/${repo}/releases/latest"
+cd "$(dirname "$0")/.."
 
-if ! command -v jq >/dev/null 2>&1; then
-  echo "error: jq is required" >&2
+if ! command -v bun >/dev/null 2>&1; then
+  echo "error: bun is required" >&2
   exit 1
 fi
 
-if ! command -v nix >/dev/null 2>&1; then
-  echo "error: nix is required" >&2
-  exit 1
-fi
-
-curl_opts=(-fsSL)
-if [[ -n "${GITHUB_TOKEN:-}" ]]; then
-  curl_opts+=(-H "Authorization: token $GITHUB_TOKEN")
-fi
-
-tag="$(curl "${curl_opts[@]}" "$latest_api" | jq -r '.tag_name')"
-if [[ -z "$tag" || "$tag" == "null" ]]; then
-  echo "error: unable to resolve latest release tag" >&2
-  exit 1
-fi
-
-version="${tag#v}"
-checksums_url="https://github.com/${repo}/releases/download/${tag}/checksums-sha256.txt"
-checksums="$(curl "${curl_opts[@]}" "$checksums_url")"
-
-get_sri() {
-  local asset="$1"
-  local hex
-  hex="$(awk -v asset="$asset" '$2 == asset { print $1 }' <<<"$checksums")"
-
-  if [[ -z "$hex" ]]; then
-    echo "error: missing checksum for ${asset}" >&2
-    exit 1
-  fi
-
-  nix hash convert --hash-algo sha256 --to sri "$hex"
-}
-
-arm64_darwin="$(get_sri agent-slack-darwin-arm64)"
-x64_darwin="$(get_sri agent-slack-darwin-x64)"
-arm64_linux="$(get_sri agent-slack-linux-arm64)"
-x64_linux="$(get_sri agent-slack-linux-x64)"
-
-jq -n \
-  --arg version "$version" \
-  --arg aarch64_darwin "$arm64_darwin" \
-  --arg x86_64_darwin "$x64_darwin" \
-  --arg aarch64_linux "$arm64_linux" \
-  --arg x86_64_linux "$x64_linux" \
-  '{
-    version: $version,
-    hashes: {
-      "aarch64-darwin": $aarch64_darwin,
-      "x86_64-darwin": $x86_64_darwin,
-      "aarch64-linux": $aarch64_linux,
-      "x86_64-linux": $x86_64_linux
-    }
-  }' > nix/sources.json
-
-echo "Updated nix/sources.json to ${version}"
+exec bun scripts/update-nix-sources.ts "$@"

--- a/scripts/update-nix-sources.ts
+++ b/scripts/update-nix-sources.ts
@@ -1,0 +1,17 @@
+import { writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { formatSourcesJson, resolveNixSources } from "./nix-sources.ts";
+
+const DEFAULT_REPO = "stablyai/agent-slack";
+
+const rootDir = join(dirname(fileURLToPath(import.meta.url)), "..");
+const sourcesPath = join(rootDir, "nix", "sources.json");
+
+const sources = await resolveNixSources({
+  repo: process.env.AGENT_SLACK_GITHUB_REPO?.trim() || DEFAULT_REPO,
+  token: process.env.GITHUB_TOKEN?.trim() || undefined,
+});
+
+writeFileSync(sourcesPath, formatSourcesJson(sources));
+console.log(`Updated nix/sources.json to ${sources.version}`);

--- a/test/nix-sources.test.ts
+++ b/test/nix-sources.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  NIX_SYSTEM_ASSETS,
+  buildNixSources,
+  checksumsUrlForTag,
+  formatSourcesJson,
+  hashesFromRelease,
+  hexToSri,
+  parseChecksums,
+  resolveNixSources,
+  versionFromTag,
+  type FetchLike,
+  type GithubRelease,
+} from "../scripts/nix-sources.ts";
+
+const V0_5_2_DARWIN_ARM64_HEX = "fda9b131a2f033199fc87a94667f1b29debf6e3af1fe09424b32d26c5b3e90a9";
+const V0_5_2_DARWIN_ARM64_SRI = "sha256-/amxMaLwMxmfyHqUZn8bKd6/bjrx/glCSzLSbFs+kKk=";
+
+const V0_10_2_HEX = {
+  "agent-slack-darwin-arm64": "ff900d5c764033b737662113b4e8c5a953dfe2645b8708536f41867add54fe3b",
+  "agent-slack-darwin-x64": "791fea721447e15a6b43784797ec8a19c5c079d6a2b3ce3bbd2a416e54bef87f",
+  "agent-slack-linux-arm64": "02e71a69816aa679b2eb5756fee9349195fd728da99e6582dc6ac1a76f63f1ee",
+  "agent-slack-linux-x64": "ad4d65d4ee2c83ec7eba593951568e8b7c9722b72971a09e8cae6e090057d483",
+} as const;
+
+describe("hexToSri", () => {
+  test("should convert a known v0.5.2 release digest to the committed SRI hash", () => {
+    expect(hexToSri(V0_5_2_DARWIN_ARM64_HEX)).toBe(V0_5_2_DARWIN_ARM64_SRI);
+  });
+
+  test("should accept a sha256: prefix", () => {
+    expect(hexToSri(`sha256:${V0_5_2_DARWIN_ARM64_HEX}`)).toBe(V0_5_2_DARWIN_ARM64_SRI);
+  });
+
+  test("should reject truncated or non-hex input", () => {
+    expect(() => hexToSri("abcd")).toThrow("invalid sha256 hex");
+    expect(() => hexToSri("g".repeat(64))).toThrow("invalid sha256 hex");
+  });
+});
+
+describe("parseChecksums", () => {
+  test("should parse GNU text-mode and binary-mode checksum lines", () => {
+    const parsed = parseChecksums(
+      [
+        `${V0_10_2_HEX["agent-slack-darwin-arm64"]}  agent-slack-darwin-arm64`,
+        `${V0_10_2_HEX["agent-slack-darwin-x64"]} *agent-slack-darwin-x64`,
+        "not-a-checksum-line",
+        "",
+      ].join("\n"),
+    );
+
+    expect(parsed.get("agent-slack-darwin-arm64")).toBe(V0_10_2_HEX["agent-slack-darwin-arm64"]);
+    expect(parsed.get("agent-slack-darwin-x64")).toBe(V0_10_2_HEX["agent-slack-darwin-x64"]);
+    expect(parsed.size).toBe(2);
+  });
+});
+
+describe("versionFromTag", () => {
+  test("should strip a leading v from GitHub release tags", () => {
+    expect(versionFromTag("v0.10.2")).toBe("0.10.2");
+  });
+
+  test("should reject missing tags", () => {
+    expect(() => versionFromTag(undefined)).toThrow("unable to resolve latest release tag");
+    expect(() => versionFromTag("null")).toThrow("unable to resolve latest release tag");
+    expect(() => versionFromTag("  ")).toThrow("unable to resolve latest release tag");
+  });
+});
+
+describe("hashesFromRelease", () => {
+  test("should prefer GitHub asset digest fields when present", () => {
+    const hashes = hashesFromRelease({
+      assets: NIX_SYSTEM_ASSETS.map(({ asset }) => ({
+        name: asset,
+        digest: `sha256:${V0_10_2_HEX[asset]}`,
+      })),
+    });
+
+    expect(hashes["aarch64-darwin"]).toBe(hexToSri(V0_10_2_HEX["agent-slack-darwin-arm64"]));
+    expect(hashes["x86_64-darwin"]).toBe(hexToSri(V0_10_2_HEX["agent-slack-darwin-x64"]));
+    expect(hashes["aarch64-linux"]).toBe(hexToSri(V0_10_2_HEX["agent-slack-linux-arm64"]));
+    expect(hashes["x86_64-linux"]).toBe(hexToSri(V0_10_2_HEX["agent-slack-linux-x64"]));
+  });
+
+  test("should fall back to checksums-sha256.txt when digest is missing", () => {
+    const hashes = hashesFromRelease({
+      assets: [{ name: "agent-slack-darwin-arm64" }, { name: "agent-slack-darwin-x64" }],
+      checksums: NIX_SYSTEM_ASSETS.map(({ asset }) => `${V0_10_2_HEX[asset]}  ${asset}`).join("\n"),
+    });
+
+    expect(hashes["aarch64-linux"]).toBe(hexToSri(V0_10_2_HEX["agent-slack-linux-arm64"]));
+  });
+
+  test("should throw when an asset has neither digest nor checksum", () => {
+    expect(() =>
+      hashesFromRelease({
+        assets: [
+          {
+            name: "agent-slack-darwin-arm64",
+            digest: `sha256:${V0_10_2_HEX["agent-slack-darwin-arm64"]}`,
+          },
+        ],
+      }),
+    ).toThrow("missing checksum for agent-slack-darwin-x64");
+  });
+});
+
+describe("resolveNixSources", () => {
+  test("should fetch checksums when the latest release omits asset digests", async () => {
+    const release: GithubRelease = {
+      tag_name: "v0.10.2",
+      assets: NIX_SYSTEM_ASSETS.map(({ asset }) => ({ name: asset })),
+    };
+    const checksums = NIX_SYSTEM_ASSETS.map(({ asset }) => `${V0_10_2_HEX[asset]}  ${asset}`).join(
+      "\n",
+    );
+    const checksumsUrl = checksumsUrlForTag({ repo: "stablyai/agent-slack", tag: "v0.10.2" });
+    const fetchImpl: FetchLike = async (url) => {
+      if (String(url) !== checksumsUrl) {
+        throw new Error(`unexpected fetch: ${String(url)}`);
+      }
+      return new Response(checksums, { status: 200 });
+    };
+
+    const sources = await resolveNixSources({
+      repo: "stablyai/agent-slack",
+      release,
+      fetchImpl,
+    });
+
+    expect(sources.version).toBe("0.10.2");
+    expect(sources.hashes["x86_64-linux"]).toBe(hexToSri(V0_10_2_HEX["agent-slack-linux-x64"]));
+  });
+});
+
+describe("formatSourcesJson", () => {
+  test("should serialize a trailing newline so the file stays oxfmt-stable", () => {
+    const sources = buildNixSources({
+      version: "0.10.2",
+      hashes: hashesFromRelease({
+        assets: NIX_SYSTEM_ASSETS.map(({ asset }) => ({
+          name: asset,
+          digest: `sha256:${V0_10_2_HEX[asset]}`,
+        })),
+      }),
+    });
+
+    expect(formatSourcesJson(sources)).toBe(`${JSON.stringify(sources, null, 2)}\n`);
+  });
+});
+
+describe("nix/sources.json", () => {
+  test("should list an SRI hash for every flake system", () => {
+    const path = join(dirname(fileURLToPath(import.meta.url)), "..", "nix", "sources.json");
+    const sources = JSON.parse(readFileSync(path, "utf8")) as {
+      version?: unknown;
+      hashes?: Record<string, unknown>;
+    };
+
+    expect(typeof sources.version).toBe("string");
+    expect(String(sources.version)).toMatch(/^\d+\.\d+\.\d+/);
+
+    for (const { system } of NIX_SYSTEM_ASSETS) {
+      expect(sources.hashes?.[system]).toMatch(/^sha256-[A-Za-z0-9+/=]+$/);
+    }
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,5 @@
     "noEmit": true,
     "types": ["bun-types"]
   },
-  "include": ["src", "test"]
+  "include": ["src", "test", "scripts/**/*.ts"]
 }


### PR DESCRIPTION
## Summary

`nix run github:stablyai/agent-slack` currently reports **v0.5.2** while the latest GitHub release is **v0.10.2**. `nix/sources.json` was never updated after the flake shipped.

Fixes #140.

## Root cause

The weekly **Update Nix Sources** workflow has been failing every Monday since at least 2026-04-27. The updater itself works — run 34106123089 on 2026-09-07 printed `Updated nix/sources.json to 0.10.2` and force-pushed `chore/update-nix-sources`. Creating the PR then failed:

> GitHub Actions is not permitted to create or approve pull requests.

So the generated hashes never reached `main`.

## Fix

- Point `nix/sources.json` at v0.10.2 using the GitHub release `digest` values (SRI conversion matches the existing v0.5.2 darwin-arm64 vector).
- Add a TypeScript updater (`scripts/nix-sources.ts` / `scripts/update-nix-sources.ts`) that prefers GitHub asset digests and falls back to `checksums-sha256.txt` (text-mode and binary-mode GNU lines). `scripts/update-nix-sources.sh` uses this path when `bun` is available.
- Document `bun scripts/update-nix-sources.ts` in CONTRIBUTING.

To stop this drifting again after the next release, enable **Allow GitHub Actions to create and approve pull requests** in the repo Actions settings (the existing workflow already has `pull-requests: write`). Until that is on, running the TypeScript updater after each GitHub Release keeps the flake current.

## Testing

- `bun test test/nix-sources.test.ts` — 12 pass (known v0.5.2 SRI vector, checksum parsing, digest vs checksums fallback, missing-asset error, `sources.json` shape).
- `bun scripts/update-nix-sources.ts` against the live GitHub API reproduced the same v0.10.2 hashes.
- `bun run typecheck` — clean.
- `bun test` — 409 pass; 2 pre-existing Windows failures in `test/search-files.test.ts` (`path.endsWith('/F2.txt')` vs `\`), unrelated to this change.

Made with [Cursor](https://cursor.com)