### PR TITLE
feat: schedule messages with browser auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,8 @@ agent-slack message draft create "#general" "Latest numbers" --attach ./q3.png -
 agent-slack message draft update "DR_ID" "Latest numbers" --attach ./appendix.pdf
 ```
 
+Native draft listings read at most 100 records. Their JSON includes `"has_more": true` when Slack reports additional drafts; the internal API does not expose a cursor for retrieving them.
+
 ### Safe mode (enforced human-in-the-loop)
 
 Skill instructions like "always use `draft`, never `send`" are guidance an agent can ignore. Safe mode enforces it at the tool level — useful when an AI agent has access to `agent-slack` and you want a guarantee that nothing posts without human review.
@@ -304,10 +306,10 @@ agent-slack message delete "#general" --workspace "myteam" --ts "1770165109.6283
 Send options for `message send`:
 
 - `--attach <path>` upload a local file (repeatable; `<text>` is optional when attaching files)
-- `--blocks <path>` send raw [Block Kit](https://docs.slack.dev/block-kit/) blocks from a JSON file (or `-` for stdin). Bypasses the automatic markdown-to-rich-text conversion, unlocking header/divider/section/table blocks and other structured layouts. Cannot be combined with `--attach`.
+- `--blocks <path>` send raw [Block Kit](https://docs.slack.dev/block-kit/) blocks from a JSON file (or `-` for stdin). Bypasses the automatic markdown-to-rich-text conversion, unlocking header/divider/section/table blocks and other structured layouts. Browser-auth scheduled sends accept only non-empty top-level `rich_text` blocks because Slack Desktop strips or tombstones other native-draft content. Cannot be combined with `--attach`.
 - `--reply-broadcast` when replying in a thread, also post the reply to the parent channel (Slack's "Also send to #channel" checkbox). For channel targets, pair with `--thread-ts`; for URL targets, the thread context is derived from the message. Not supported for DM targets; cannot be combined with `--attach`.
-- `--no-unfurl` suppress Slack link and media previews. Also available on `message compose`; cannot be combined with `--attach`.
-- `--schedule <time>` schedule delivery at an ISO 8601 timestamp with explicit timezone (for example `YYYY-MM-DDTHH:mm:ss-07:00`) or a Unix timestamp. The timestamp must be in the future and within Slack's 120-day scheduled-send limit. Works with `--blocks`, `--thread-ts`, `--reply-broadcast`, and `--no-unfurl`; cannot be combined with `--attach`.
+- `--no-unfurl` suppress Slack link and media previews. Also available on `message compose`; unavailable for browser-auth scheduled sends and cannot be combined with `--attach`.
+- `--schedule <time>` schedule delivery at an ISO 8601 timestamp with explicit timezone (for example `YYYY-MM-DDTHH:mm:ss-07:00`) or a Unix timestamp. The timestamp must be in the future and within Slack's 120-day scheduled-send limit. Works with `--blocks`, `--thread-ts`, and `--reply-broadcast`, subject to the browser-auth restrictions above; cannot be combined with `--attach`.
 - `--schedule-in <duration>` schedule delivery after a duration or simple future phrase (`30m`, `3h`, `2d`, `tomorrow 9am`, `monday 9am`; phrases use your local timezone). Mutually exclusive with `--schedule`; cannot be combined with `--attach`.
 
 Upload files through `message send`:
@@ -323,7 +325,7 @@ agent-slack message send "#general" "Decision: shipping v2 today" \
   --thread-ts "1770160000.000001" --reply-broadcast
 ```
 
-Scheduled sends use Slack's server-side scheduled message queue:
+Scheduled sends use Slack's own server-side scheduling. Standard tokens call the public `chat.scheduleMessage` API and return a `Q...` ID. Browser credentials use Slack's native `drafts.create` scheduling field and return a `Dr...` ID because the public method rejects browser-session tokens. On Enterprise Grid, agent-slack resolves channel names in the selected workspace, then verifies and routes the native-draft call through that workspace's organization credential.
 
 ```bash
 # Absolute time with explicit timezone; replace with a future value within 120 days
@@ -333,7 +335,7 @@ agent-slack message send "#general" "Reminder: deploy starts soon." \
 # Relative / natural future time
 agent-slack message send "#general" "Monday launch checklist" --schedule-in "monday 9am"
 
-# Scheduled thread reply with a Block Kit payload
+# Scheduled thread reply with a Block Kit payload (standard tokens; browser auth requires rich_text-only blocks)
 agent-slack message send "#general" "fallback text" \
   --thread-ts "1770160000.000001" --blocks /tmp/blocks.json --schedule-in "3h"
 ```
@@ -345,6 +347,8 @@ agent-slack message scheduled list
 agent-slack message scheduled list --channel "#general" --limit 25
 agent-slack message scheduled cancel "Q1234ABCD" --channel "C12345678"
 ```
+
+With browser auth, `message scheduled list` reads at most 100 native drafts because Slack's internal `drafts.list` response exposes `has_more` but no pagination cursor. The JSON output includes `"has_more": true` when the result may be incomplete. `--cursor` applies only to standard-token scheduling. Cancel browser-auth schedules with the returned `Dr...` ID and the same required channel argument.
 
 Example — post a message with a native Slack table block:
 
@@ -375,7 +379,7 @@ agent-slack message send "#alerts-staging" --blocks /tmp/blocks.json
 
 When `--blocks` is used, the positional `<text>` argument (if provided) is still sent as the message's `text` fallback (for notifications and unfurls).
 
-`message send` returns `channel_id` plus the posted `ts` and a `permalink` (for non-attachment sends). `thread_ts` appears only when replying in a thread. Scheduled sends return `scheduled_message_id` and `post_at` instead of `ts`/`permalink`.
+`message send` returns `channel_id` plus the posted `ts` and a `permalink` (for non-attachment sends). `thread_ts` appears only when replying in a thread. Scheduled sends return `scheduled_message_id` (`Q...` for standard tokens or `Dr...` for browser auth) and `post_at` instead of `ts`/`permalink`.
 
 ### List, create, and invite channels
 

--- a/llms.txt
+++ b/llms.txt
@@ -12,7 +12,7 @@
 
 - Read Slack messages, threads, and channel history from any URL or channel name
 - Search Slack messages and files with filters for channel, user, date, and content type
-- Send, schedule, edit, delete Slack messages, upload local files with `message send --attach` (also on `message draft create/update`), and add/remove emoji reactions programmatically
+- Send, schedule, edit, delete Slack messages, upload local files with `message send --attach` (also on `message draft create/update`), and add/remove emoji reactions programmatically; scheduling supports standard tokens and browser-session credentials
 - Auto-download Slack file attachments (snippets, images, files) to local paths for AI agent consumption
 - Token-efficient compact JSON output so LLMs can consume Slack data cheaply
 - Zero-config auth: auto-detects Slack Desktop credentials on macOS, Windows, and Linux — with Chrome, Brave, and Firefox fallbacks

--- a/skills/agent-slack/SKILL.md
+++ b/skills/agent-slack/SKILL.md
@@ -31,7 +31,7 @@ If a capability named here is absent from installed help, report version skew in
 4. Use output limits such as `--limit`, `--max-body-chars`, and `--max-content-chars` to avoid unnecessary context.
 5. For a requested write, execute only the requested mutation and verify the resulting JSON metadata.
 
-For scheduled writes, prefer `--schedule` with an ISO 8601 timestamp and explicit offset when timezone matters. Named `--schedule-in` phrases use the executing environment's local timezone; confirm that it matches the user's intent.
+For scheduled writes, prefer `--schedule` with an ISO 8601 timestamp and explicit offset when timezone matters. Named `--schedule-in` phrases use the executing environment's local timezone; confirm that it matches the user's intent. Standard tokens use `chat.scheduleMessage`; browser auth uses a Slack-native scheduled draft and returns a `Dr...` ID. Browser-auth schedules accept only non-empty `rich_text` blocks and do not support `--no-unfurl`.
 
 Named `later remind --in` values such as `tomorrow` or `monday` also use the executing environment's local timezone at 9:00. Confirm that timezone or pass an explicit Unix timestamp.
 
@@ -39,7 +39,7 @@ Use `--no-unfurl` with `message send` or `message compose` when the user wants S
 
 Ordinary `message send` and `message edit` calls auto-convert lists. `message send --blocks` and `message edit --blocks` use supplied Block Kit blocks, while `message send --attach` sends its initial comment without automatic list conversion. Inside auto-converted lists, use Slack's `<URL|label>` syntax because CommonMark `[label](URL)` links are not converted into labeled link elements.
 
-Slack-native drafts (`message draft list|create|update|delete`) manage drafts that appear in the user's Slack client; `create` posts nothing. `create` and `update` accept repeatable `--attach <path>`; on `update` the files are added to the draft's existing attachments rather than replacing them. They use undocumented session endpoints and require browser-style auth (xoxc/xoxd).
+Slack-native drafts (`message draft list|create|update|delete`) manage drafts that appear in the user's Slack client; `create` posts nothing. `create` and `update` accept repeatable `--attach <path>`; on `update` the files are added to the draft's existing attachments rather than replacing them. They use undocumented session endpoints and require browser-style auth (xoxc/xoxd). Listings may include `has_more: true`; Slack exposes no cursor for the remaining native drafts.
 
 `canvas edit` uses Slack's public `canvases.edit` API and applies exactly one operation per call. The
 default `replace` operation replaces the whole canvas; section-targeted inserts/replacements and

--- a/skills/agent-slack/references/output.md
+++ b/skills/agent-slack/references/output.md
@@ -7,7 +7,7 @@ Slack data commands print JSON to stdout. Help, update, and some authentication 
 
 `message get` returns one message and an optional thread summary. `message list` returns chronological messages; in thread mode this includes the root and all replies.
 
-Immediate non-attachment sends return `ts` and usually a `permalink`. Attachment sends return neither; scheduled sends return `scheduled_message_id` and `post_at` instead.
+Immediate non-attachment sends return `ts` and usually a `permalink`. Attachment sends return neither; scheduled sends return `scheduled_message_id` (`Q...` with standard tokens or `Dr...` with browser auth) and `post_at` instead. Native draft and browser-auth scheduled listings may return `has_more: true`; Slack's native drafts API does not expose a cursor for the remaining results.
 
 `canvas create` returns `canvas: { id, title?, channel_id? }`. `canvas get` returns `canvas: { id, title?, markdown }`.
 `canvas edit` returns `ok: true` and `canvas: { id, operation }` after Slack accepts the change.

--- a/src/cli/context-client-resolver.ts
+++ b/src/cli/context-client-resolver.ts
@@ -12,6 +12,10 @@ import {
 import { resolveWorkspaceSelector } from "./workspace-selector.ts";
 import { SlackApiClient, type SlackAuth } from "../slack/client.ts";
 
+export type ClientResolutionOptions = {
+  excludeAuth?: SlackAuth;
+};
+
 export function normalizeUrl(u: string): string {
   const url = new URL(u);
   return `${url.protocol}//${url.host}`;
@@ -40,7 +44,10 @@ function pickAuthFromEnv(): SlackAuth | null {
   return { auth_type: "standard", token };
 }
 
-export async function getClientForWorkspace(workspaceUrl?: string): Promise<{
+export async function getClientForWorkspace(
+  workspaceUrl?: string,
+  options: ClientResolutionOptions = {},
+): Promise<{
   client: SlackApiClient;
   auth: SlackAuth;
   workspace_url?: string;
@@ -53,9 +60,9 @@ export async function getClientForWorkspace(workspaceUrl?: string): Promise<{
     const creds = await loadCredentials();
     const resolved = resolveWorkspaceSelector(creds.workspaces, selector);
     if (resolved.ambiguous.length > 0) {
-      const options = resolved.ambiguous.map((w) => w.workspace_url).join(", ");
+      const matches = resolved.ambiguous.map((w) => w.workspace_url).join(", ");
       throw new Error(
-        `Workspace selector "${selector}" is ambiguous. Matches: ${options}. Pass a more specific selector or full workspace URL.`,
+        `Workspace selector "${selector}" is ambiguous. Matches: ${matches}. Pass a more specific selector or full workspace URL.`,
       );
     }
     if (resolved.match) {
@@ -66,8 +73,12 @@ export async function getClientForWorkspace(workspaceUrl?: string): Promise<{
   }
 
   const env = pickAuthFromEnv();
-  if (env) {
-    const envWorkspaceUrl = process.env.SLACK_WORKSPACE_URL?.trim();
+  const envWorkspaceUrl = process.env.SLACK_WORKSPACE_URL?.trim();
+  if (
+    env &&
+    !sameAuth(env, options.excludeAuth) &&
+    environmentAuthMatchesSelector({ env, envWorkspaceUrl, selector, resolvedWorkspaceUrl })
+  ) {
     const urlForBrowser = resolvedWorkspaceUrl || envWorkspaceUrl;
     return {
       client: new SlackApiClient(env, { workspaceUrl: urlForBrowser }),
@@ -179,6 +190,36 @@ export async function getClientForWorkspace(workspaceUrl?: string): Promise<{
 
   throw new Error(
     'No Slack credentials available. Try "agent-slack auth import-desktop", "agent-slack auth import-chrome", "agent-slack auth import-brave", "agent-slack auth import-firefox", or set SLACK_TOKEN / SLACK_COOKIE_D.',
+  );
+}
+
+function sameAuth(left: SlackAuth, right: SlackAuth | undefined): boolean {
+  if (!right) {
+    return false;
+  }
+  if (left.auth_type === "standard") {
+    return right.auth_type === "standard" && left.token === right.token;
+  }
+  return right.auth_type === "browser" && left.xoxc_token === right.xoxc_token;
+}
+
+function environmentAuthMatchesSelector(input: {
+  env: SlackAuth;
+  envWorkspaceUrl?: string;
+  selector?: string;
+  resolvedWorkspaceUrl?: string;
+}): boolean {
+  if (!input.selector || !input.envWorkspaceUrl) {
+    return true;
+  }
+  const normalizedEnvUrl = tryNormalizeUrl(input.envWorkspaceUrl);
+  if (!normalizedEnvUrl) {
+    return false;
+  }
+  const selector = input.resolvedWorkspaceUrl ?? input.selector;
+  return Boolean(
+    resolveWorkspaceSelector([{ workspace_url: normalizedEnvUrl, auth: input.env }], selector)
+      .match,
   );
 }
 

--- a/src/cli/context.ts
+++ b/src/cli/context.ts
@@ -7,7 +7,11 @@ import { loadCredentials, upsertWorkspaces } from "../auth/store.ts";
 import { normalizeChannelInput } from "../slack/channels.ts";
 import type { SlackApiClient } from "../slack/client.ts";
 import { type SlackAuth } from "../slack/client.ts";
-import { getClientForWorkspace, normalizeUrl } from "./context-client-resolver.ts";
+import {
+  getClientForWorkspace,
+  normalizeUrl,
+  type ClientResolutionOptions,
+} from "./context-client-resolver.ts";
 
 export type CliContext = {
   effectiveWorkspaceUrl: (flag?: string) => string | undefined;
@@ -19,7 +23,10 @@ export type CliContext = {
     workspaceUrl: string | undefined;
     work: () => Promise<T>;
   }) => Promise<T>;
-  getClientForWorkspace: (workspaceUrl?: string) => Promise<{
+  getClientForWorkspace: (
+    workspaceUrl?: string,
+    options?: ClientResolutionOptions,
+  ) => Promise<{
     client: SlackApiClient;
     auth: SlackAuth;
     workspace_url?: string;

--- a/src/cli/message-actions.ts
+++ b/src/cli/message-actions.ts
@@ -7,12 +7,16 @@ import { normalizeSlackReactionName } from "../slack/emoji.ts";
 import { warnOnTruncatedSlackUrl } from "./message-url-warning.ts";
 import { textToRichTextBlocks } from "../slack/rich-text.ts";
 import { formatOutboundSlackText } from "../slack/format-outbound.ts";
-import type { SlackApiClient } from "../slack/client.ts";
+import type { SlackApiClient, SlackAuth } from "../slack/client.ts";
 import { uploadLocalFileToSlack } from "../slack/upload.ts";
 import { buildSlackMessageUrl } from "../slack/url.ts";
 import { normalizeAttachPaths } from "./options.ts";
-import { resolveSchedulePostAt } from "../slack/scheduled-messages.ts";
+import {
+  resolveSchedulePostAt,
+  scheduleMessage as scheduleMessageApi,
+} from "../slack/scheduled-messages.ts";
 import { buildUnfurlApiParams } from "./unfurl-options.ts";
+import { resolveSlackNativeDraftEndpoint } from "./slack-native-draft-endpoint.ts";
 
 function loadBlocksFromPath(path: string): unknown[] {
   const raw = path === "-" ? readFileSync(0, "utf8") : readFileSync(path, "utf8");
@@ -148,7 +152,9 @@ export async function sendMessage(input: {
     return await input.ctx.withAutoRefresh({
       workspaceUrl: ref.workspace_url,
       work: async () => {
-        const { client, workspace_url } = await input.ctx.getClientForWorkspace(ref.workspace_url);
+        const { client, auth, workspace_url } = await input.ctx.getClientForWorkspace(
+          ref.workspace_url,
+        );
         const msg = await fetchMessage(client, { ref });
         const threadTs = msg.thread_ts ?? msg.ts;
         return await sendMessageToChannel({
@@ -156,12 +162,15 @@ export async function sendMessage(input: {
           workspaceUrl: workspace_url ?? ref.workspace_url,
           channelId: ref.channel_id,
           text: formattedText,
+          draftText: input.text,
           blocks,
           threadTs,
           replyBroadcast: input.options.replyBroadcast,
           attachPaths,
           postAt,
           unfurl: input.options.unfurl,
+          auth,
+          ctx: input.ctx,
         });
       },
     });
@@ -175,17 +184,20 @@ export async function sendMessage(input: {
     return await input.ctx.withAutoRefresh({
       workspaceUrl,
       work: async () => {
-        const { client, workspace_url } = await input.ctx.getClientForWorkspace(workspaceUrl);
+        const { client, auth, workspace_url } = await input.ctx.getClientForWorkspace(workspaceUrl);
         const dmChannelId = await openDmChannel(client, target.userId);
         return await sendMessageToChannel({
           client,
           workspaceUrl: workspace_url ?? workspaceUrl,
           channelId: dmChannelId,
           text: formattedText,
+          draftText: input.text,
           blocks,
           attachPaths,
           postAt,
           unfurl: input.options.unfurl,
+          auth,
+          ctx: input.ctx,
         });
       },
     });
@@ -202,19 +214,22 @@ export async function sendMessage(input: {
   return await input.ctx.withAutoRefresh({
     workspaceUrl,
     work: async () => {
-      const { client, workspace_url } = await input.ctx.getClientForWorkspace(workspaceUrl);
+      const { client, auth, workspace_url } = await input.ctx.getClientForWorkspace(workspaceUrl);
       const channelId = await resolveChannelId(client, String(target.channel));
       return await sendMessageToChannel({
         client,
         workspaceUrl: workspace_url ?? workspaceUrl,
         channelId,
         text: formattedText,
+        draftText: input.text,
         blocks,
         threadTs: input.options.threadTs ? String(input.options.threadTs) : undefined,
         replyBroadcast: input.options.replyBroadcast,
         attachPaths,
         postAt,
         unfurl: input.options.unfurl,
+        auth,
+        ctx: input.ctx,
       });
     },
   });
@@ -225,22 +240,33 @@ async function sendMessageToChannel(input: {
   workspaceUrl?: string;
   channelId: string;
   text: string;
+  draftText: string;
   blocks?: unknown[] | null;
   threadTs?: string;
   replyBroadcast?: boolean;
   attachPaths: string[];
   postAt?: number;
   unfurl?: boolean;
+  auth: SlackAuth;
+  ctx: CliContext;
 }): Promise<Record<string, unknown>> {
   if (input.postAt !== undefined) {
-    const resp = await input.client.api("chat.scheduleMessage", {
-      channel: input.channelId,
+    const endpoint = await resolveSlackNativeDraftEndpoint({
+      ctx: input.ctx,
+      client: input.client,
+      auth: input.auth,
+      workspaceUrl: input.workspaceUrl,
+    });
+    const resp = await scheduleMessageApi(endpoint.client, {
+      authType: endpoint.auth.auth_type,
+      channelId: input.channelId,
       text: input.text,
-      post_at: input.postAt,
-      thread_ts: input.threadTs,
-      ...(input.blocks ? { blocks: input.blocks } : {}),
-      ...(input.replyBroadcast && input.threadTs ? { reply_broadcast: true } : {}),
-      ...buildUnfurlApiParams(input.unfurl),
+      draftText: input.draftText,
+      postAt: input.postAt,
+      threadTs: input.threadTs,
+      replyBroadcast: input.replyBroadcast,
+      blocks: input.blocks,
+      unfurl: input.unfurl,
     });
     const channelId = typeof resp.channel === "string" ? resp.channel : input.channelId;
     const scheduledMessageId =

--- a/src/cli/message-command.ts
+++ b/src/cli/message-command.ts
@@ -190,17 +190,20 @@ export function registerMessageCommand(input: { program: Command; ctx: CliContex
     )
     .option(
       "--blocks <path>",
-      "Path to a JSON file containing a Block Kit blocks array. Bypasses automatic markdown-to-rich-text conversion. Use '-' to read from stdin. Cannot be combined with --attach.",
+      "Path to a JSON file containing a Block Kit blocks array. Bypasses automatic markdown-to-rich-text conversion. Browser-auth scheduled sends accept only non-empty rich_text blocks. Use '-' to read from stdin. Cannot be combined with --attach.",
     )
     .option(
       "--schedule <time>",
-      "Schedule delivery at an ISO 8601 timestamp with explicit timezone (or Unix timestamp), within 120 days. Cannot be combined with --attach.",
+      "Schedule delivery at an ISO 8601 timestamp with explicit timezone (or Unix timestamp), within 120 days. Browser auth uses a Slack-native scheduled draft; --no-unfurl is unavailable. Cannot be combined with --attach.",
     )
     .option(
       "--schedule-in <duration>",
-      "Schedule delivery within 120 days after a duration or future phrase, e.g. 3h or monday 9am. Named phrases use this process's local timezone. Cannot be combined with --attach.",
+      "Schedule delivery within 120 days after a duration or future phrase, e.g. 3h or monday 9am. Named phrases use this process's local timezone. Browser auth has the same constraints as --schedule. Cannot be combined with --attach.",
     )
-    .option("--no-unfurl", "Suppress link and media previews. Cannot be combined with --attach.")
+    .option(
+      "--no-unfurl",
+      "Suppress link and media previews. Not supported for browser-auth scheduled sends; cannot be combined with --attach.",
+    )
     .action(async (...args) => {
       const [targetInput, text, options] = args as [
         string,

--- a/src/cli/message-draft-actions.ts
+++ b/src/cli/message-draft-actions.ts
@@ -26,12 +26,13 @@ export async function listDraftsAction(input: {
     workspaceUrl,
     work: async () => {
       const { client } = await input.ctx.getClientForWorkspace(workspaceUrl);
-      const { drafts } = await listDrafts(client, {
-        limit: normalizeScheduleLimit(input.options.limit),
+      const { drafts, has_more: hasMore } = await listDrafts(client, {
+        limit: normalizeScheduleLimit(input.options.limit) ?? 100,
         activeOnly: !input.options.all,
       });
       const hydrated = await hydrateChannelNames(client, drafts);
-      return { ok: true, drafts: hydrated, count: hydrated.length };
+      const pagination = hasMore ? { has_more: true } : {};
+      return { ok: true, drafts: hydrated, count: hydrated.length, ...pagination };
     },
   });
 }

--- a/src/cli/message-scheduled-actions.ts
+++ b/src/cli/message-scheduled-actions.ts
@@ -7,6 +7,7 @@ import {
   listScheduledMessages as listScheduledMessagesApi,
   normalizeScheduleLimit,
 } from "../slack/scheduled-messages.ts";
+import { resolveSlackNativeDraftEndpoint } from "./slack-native-draft-endpoint.ts";
 
 export async function listScheduledMessages(input: {
   ctx: CliContext;
@@ -36,16 +37,23 @@ export async function listScheduledMessages(input: {
   return await input.ctx.withAutoRefresh({
     workspaceUrl,
     work: async () => {
-      const { client } = await input.ctx.getClientForWorkspace(workspaceUrl);
+      const { client, auth, workspace_url } = await input.ctx.getClientForWorkspace(workspaceUrl);
       const channelId = channelTarget
         ? await resolveScheduledChannelTarget(client, channelTarget)
         : undefined;
-      return await listScheduledMessagesApi(client, {
+      const endpoint = await resolveSlackNativeDraftEndpoint({
+        ctx: input.ctx,
+        client,
+        auth,
+        workspaceUrl: workspace_url ?? workspaceUrl,
+      });
+      return await listScheduledMessagesApi(endpoint.client, {
         channelId,
         cursor: input.options.cursor,
         oldest: input.options.oldest,
         latest: input.options.latest,
         limit: normalizeScheduleLimit(input.options.limit),
+        authType: endpoint.auth.auth_type,
       });
     },
   });
@@ -71,11 +79,18 @@ export async function cancelScheduledMessage(input: {
   return await input.ctx.withAutoRefresh({
     workspaceUrl,
     work: async () => {
-      const { client } = await input.ctx.getClientForWorkspace(workspaceUrl);
+      const { client, auth, workspace_url } = await input.ctx.getClientForWorkspace(workspaceUrl);
       const channelId = await resolveScheduledChannelTarget(client, channelTarget);
-      await cancelScheduledMessageApi(client, {
+      const endpoint = await resolveSlackNativeDraftEndpoint({
+        ctx: input.ctx,
+        client,
+        auth,
+        workspaceUrl: workspace_url ?? workspaceUrl,
+      });
+      await cancelScheduledMessageApi(endpoint.client, {
         channelId,
         scheduledMessageId: input.scheduledMessageId,
+        authType: endpoint.auth.auth_type,
       });
       return {
         ok: true,

--- a/src/cli/message-scheduled-command.ts
+++ b/src/cli/message-scheduled-command.ts
@@ -17,7 +17,10 @@ export function registerScheduledMessageCommand(input: {
     .option("--channel <channel>", "Limit to a channel/DM id or channel name")
     .option("--oldest <ts>", "Only messages scheduled after this Unix timestamp")
     .option("--latest <ts>", "Only messages scheduled before this Unix timestamp")
-    .option("--cursor <cursor>", "Fetch the next page from chat.scheduledMessages.list")
+    .option(
+      "--cursor <cursor>",
+      "Fetch the next page from chat.scheduledMessages.list (standard-token scheduling only)",
+    )
     .option("--limit <n>", "Max scheduled messages to return")
     .action(
       async (options: {
@@ -41,7 +44,10 @@ export function registerScheduledMessageCommand(input: {
   scheduledCmd
     .command("cancel")
     .description("Cancel a pending scheduled message")
-    .argument("<id>", "scheduled_message_id returned by message send --schedule")
+    .argument(
+      "<id>",
+      "scheduled_message_id returned by message send --schedule (Q... for standard tokens, Dr... for browser auth)",
+    )
     .requiredOption(
       "--channel <channel>",
       "Required channel/DM id or channel name for the scheduled message",

--- a/src/cli/slack-native-draft-endpoint.ts
+++ b/src/cli/slack-native-draft-endpoint.ts
@@ -72,9 +72,19 @@ export async function resolveSlackNativeDraftEndpoint(input: {
     throw new Error("Slack did not return a valid Enterprise Grid domain for native drafts.");
   }
   const enterpriseWorkspaceUrl = `https://${enterpriseDomain}.enterprise.slack.com`;
-  const enterprise = await input.ctx.getClientForWorkspace(enterpriseWorkspaceUrl);
-  if (enterprise.auth.auth_type !== "browser") {
-    throw new Error("Enterprise Grid native drafts require browser auth for the organization.");
+  let enterprise: Awaited<ReturnType<CliContext["getClientForWorkspace"]>>;
+  try {
+    enterprise = await input.ctx.getClientForWorkspace(enterpriseWorkspaceUrl, {
+      excludeAuth: input.auth,
+    });
+  } catch (error) {
+    throw missingOrganizationCredentialsError(enterpriseWorkspaceUrl, error);
+  }
+  if (
+    enterprise.auth.auth_type !== "browser" ||
+    enterprise.auth.xoxc_token === input.auth.xoxc_token
+  ) {
+    throw missingOrganizationCredentialsError(enterpriseWorkspaceUrl);
   }
   const enterpriseIdentity = await enterprise.client.api("auth.test", {});
   if (getString(enterpriseIdentity.team_id)?.trim() !== enterpriseId) {
@@ -92,6 +102,13 @@ export async function resolveSlackNativeDraftEndpoint(input: {
     auth: enterprise.auth,
     workspaceUrl: enterprise.workspace_url ?? enterpriseWorkspaceUrl,
   };
+}
+
+function missingOrganizationCredentialsError(workspaceUrl: string, cause?: unknown): Error {
+  return new Error(
+    `Enterprise Grid native drafts require separate organization browser credentials for ${workspaceUrl}. Import or configure that organization workspace before scheduling, listing, or cancelling native schedules.`,
+    { cause },
+  );
 }
 
 function isEnterpriseWorkspaceUrl(workspaceUrl: string | undefined): boolean {

--- a/src/cli/slack-native-draft-endpoint.ts
+++ b/src/cli/slack-native-draft-endpoint.ts
@@ -1,0 +1,119 @@
+import { getString, isRecord } from "../lib/object-type-guards.ts";
+import type { SlackApiClient, SlackAuth } from "../slack/client.ts";
+import { isUserId } from "../slack/user-id.ts";
+import type { CliContext } from "./context.ts";
+
+const TEAM_ID_PATTERN = /^T[A-Z0-9]{8,19}$/;
+const ENTERPRISE_ID_PATTERN = /^E[A-Z0-9]{8,19}$/;
+
+export type SlackNativeDraftEndpoint = {
+  client: SlackApiClient;
+  auth: SlackAuth;
+  workspaceUrl?: string;
+};
+
+/**
+ * Slack routes drafts.* calls through the organization on Enterprise Grid.
+ * Bind that organization credential to the same enterprise and user before
+ * using it for a workspace-targeted scheduled message.
+ */
+export async function resolveSlackNativeDraftEndpoint(input: {
+  ctx: CliContext;
+  client: SlackApiClient;
+  auth: SlackAuth;
+  workspaceUrl?: string;
+}): Promise<SlackNativeDraftEndpoint> {
+  if (input.auth.auth_type !== "browser" || isEnterpriseWorkspaceUrl(input.workspaceUrl)) {
+    return {
+      client: input.client,
+      auth: input.auth,
+      workspaceUrl: input.workspaceUrl,
+    };
+  }
+
+  const identity = await input.client.api("auth.test", {});
+  const workspaceUserId = getString(identity.user_id);
+  const workspaceTeamId = getString(identity.team_id);
+  if (!workspaceUserId || !isUserId(workspaceUserId)) {
+    throw new Error("Slack auth.test did not return a canonical user ID for native drafts.");
+  }
+  if (!workspaceTeamId || !TEAM_ID_PATTERN.test(workspaceTeamId)) {
+    throw new Error(
+      "Slack auth.test did not return a canonical workspace team ID for native drafts.",
+    );
+  }
+  if (input.workspaceUrl && getHttpsOrigin(identity.url) !== getHttpsOrigin(input.workspaceUrl)) {
+    throw new Error(
+      "Slack auth.test workspace origin does not match the selected workspace for native drafts.",
+    );
+  }
+
+  const response = await input.client.api("team.info", {});
+  const team = isRecord(response.team) ? response.team : null;
+  if (!team || getString(team.id) !== workspaceTeamId) {
+    throw new Error(
+      "Slack team.info does not match the workspace verified by auth.test for native drafts.",
+    );
+  }
+  const enterpriseId = getString(team.enterprise_id)?.trim();
+  if (!enterpriseId) {
+    return {
+      client: input.client,
+      auth: input.auth,
+      workspaceUrl: input.workspaceUrl,
+    };
+  }
+  if (!ENTERPRISE_ID_PATTERN.test(enterpriseId)) {
+    throw new Error("Slack team.info returned an invalid Enterprise Grid ID for native drafts.");
+  }
+
+  const enterpriseDomain = getString(team.enterprise_domain)?.trim().toLowerCase();
+  if (!enterpriseDomain || !/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(enterpriseDomain)) {
+    throw new Error("Slack did not return a valid Enterprise Grid domain for native drafts.");
+  }
+  const enterpriseWorkspaceUrl = `https://${enterpriseDomain}.enterprise.slack.com`;
+  const enterprise = await input.ctx.getClientForWorkspace(enterpriseWorkspaceUrl);
+  if (enterprise.auth.auth_type !== "browser") {
+    throw new Error("Enterprise Grid native drafts require browser auth for the organization.");
+  }
+  const enterpriseIdentity = await enterprise.client.api("auth.test", {});
+  if (getString(enterpriseIdentity.team_id)?.trim() !== enterpriseId) {
+    throw new Error(
+      "The resolved Enterprise Grid credentials do not match the target workspace's organization.",
+    );
+  }
+  if (getString(enterpriseIdentity.user_id) !== workspaceUserId) {
+    throw new Error(
+      "The workspace and Enterprise Grid credentials do not belong to the same Slack user.",
+    );
+  }
+  return {
+    client: enterprise.client,
+    auth: enterprise.auth,
+    workspaceUrl: enterprise.workspace_url ?? enterpriseWorkspaceUrl,
+  };
+}
+
+function isEnterpriseWorkspaceUrl(workspaceUrl: string | undefined): boolean {
+  if (!workspaceUrl) {
+    return false;
+  }
+  try {
+    return new URL(workspaceUrl).hostname.endsWith(".enterprise.slack.com");
+  } catch {
+    return false;
+  }
+}
+
+function getHttpsOrigin(value: unknown): string | undefined {
+  const raw = getString(value);
+  if (!raw) {
+    return undefined;
+  }
+  try {
+    const url = new URL(raw);
+    return url.protocol === "https:" && !url.username && !url.password ? url.origin : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/slack/drafts.ts
+++ b/src/slack/drafts.ts
@@ -109,7 +109,7 @@ export function parseDraftRecord(raw: unknown): SlackDraft | null {
 export async function listDrafts(
   client: SlackApiClient,
   options?: { limit?: number; activeOnly?: boolean },
-): Promise<{ drafts: SlackDraft[] }> {
+): Promise<{ drafts: SlackDraft[]; has_more: boolean }> {
   const resp = await client.api("drafts.list", {
     is_active: options?.activeOnly === false ? undefined : true,
     limit: options?.limit,
@@ -117,17 +117,25 @@ export async function listDrafts(
   const drafts = asArray(resp.drafts)
     .map(parseDraftRecord)
     .filter((draft): draft is SlackDraft => draft !== null);
-  return { drafts };
+  return { drafts, has_more: resp.has_more === true };
 }
 
 export async function findDraft(client: SlackApiClient, draftId: string): Promise<SlackDraft> {
-  const { drafts } = await listDrafts(client, { activeOnly: false });
+  const { drafts, has_more: hasMore } = await listDrafts(client, {
+    activeOnly: false,
+    limit: 100,
+  });
   const matches = drafts.filter((d) => d.id === draftId);
   // update/delete need last_updated_ts for conflict detection, so prefer a
   // usable record if the response happens to include a malformed duplicate
   // (e.g. a first entry missing last_updated_ts).
   const draft = matches.find((d) => d.last_updated_ts) ?? matches[0];
   if (!draft) {
+    if (hasMore) {
+      throw new Error(
+        `Draft ${draftId} was not found in the first 100 results, and Slack drafts.list does not expose a pagination cursor.`,
+      );
+    }
     throw new Error(`Draft not found: ${draftId}. Run "message draft list" to see draft ids.`);
   }
   return draft;
@@ -142,6 +150,7 @@ export async function findDraft(client: SlackApiClient, draftId: string): Promis
 function buildDraftBody(input: {
   channelId: string;
   text: string;
+  blocks?: unknown[];
   threadTs?: string;
   broadcast?: boolean;
   fileIds?: string[];
@@ -151,12 +160,29 @@ function buildDraftBody(input: {
     destination.thread_ts = input.threadTs;
     destination.broadcast = input.broadcast === true;
   }
+  const blocks = input.blocks ?? draftTextToBlocks(input.text);
+  assertNativeDraftBlocks(blocks);
   return {
-    blocks: draftTextToBlocks(input.text),
+    blocks,
     destinations: [destination],
     client_msg_id: crypto.randomUUID(),
     file_ids: input.fileIds ?? [],
   };
+}
+
+/**
+ * Slack Desktop only preserves top-level rich_text blocks in native drafts,
+ * and tombstones drafts that have no renderable rich_text content.
+ */
+function assertNativeDraftBlocks(blocks: unknown[]): void {
+  const allRichText =
+    blocks.length > 0 && blocks.every((block) => isRecord(block) && block.type === "rich_text");
+  const hasContent = blocks.some((block) => extractMrkdwnFromRichTextBlock(block).trim());
+  if (!allRichText || !hasContent) {
+    throw new Error(
+      "Slack-native drafts require non-empty rich_text blocks; other top-level Block Kit blocks can be stripped or tombstoned by Slack Desktop.",
+    );
+  }
 }
 
 /**
@@ -181,15 +207,18 @@ export async function createDraft(
   input: {
     channelId: string;
     text: string;
+    blocks?: unknown[];
     threadTs?: string;
     broadcast?: boolean;
     fileIds?: string[];
+    dateScheduled?: number;
   },
 ): Promise<SlackDraft | null> {
   const resp = await client.api("drafts.create", {
     ...buildDraftBody(input),
     // Sent on create only, matching the official client's behavior.
     is_from_composer: true,
+    ...(input.dateScheduled !== undefined ? { date_scheduled: input.dateScheduled } : {}),
   });
   ensureDraftOk("drafts.create", resp);
   return parseDraftRecord(resp.draft);

--- a/src/slack/drafts.ts
+++ b/src/slack/drafts.ts
@@ -177,12 +177,80 @@ function buildDraftBody(input: {
 function assertNativeDraftBlocks(blocks: unknown[]): void {
   const allRichText =
     blocks.length > 0 && blocks.every((block) => isRecord(block) && block.type === "rich_text");
-  const hasContent = blocks.some((block) => extractMrkdwnFromRichTextBlock(block).trim());
+  const hasContent = blocks.some(hasRichTextContent);
   if (!allRichText || !hasContent) {
     throw new Error(
       "Slack-native drafts require non-empty rich_text blocks; other top-level Block Kit blocks can be stripped or tombstoned by Slack Desktop.",
     );
   }
+  for (const block of blocks) {
+    assertRichTextAdjacency(block);
+  }
+}
+
+function hasRichTextContent(value: unknown): boolean {
+  if (!isRecord(value)) {
+    return false;
+  }
+  if (value.type === "text") {
+    return Boolean(getString(value.text)?.trim());
+  }
+  const children = asArray(value.elements);
+  if (children.some(hasRichTextContent)) {
+    return true;
+  }
+  return (
+    typeof value.type === "string" && value.type.length > 0 && !isRichTextContainer(value.type)
+  );
+}
+
+function assertRichTextAdjacency(block: unknown): void {
+  if (!isRecord(block)) {
+    return;
+  }
+  const elements = asArray(block.elements);
+  for (let index = 0; index < elements.length - 1; index++) {
+    const current = elements[index];
+    const next = elements[index + 1];
+    if (
+      isRecord(current) &&
+      current.type === "rich_text_section" &&
+      isRecord(next) &&
+      isRichTextAdjacentContainer(next.type) &&
+      !sectionEndsWithNewline(current)
+    ) {
+      throw new Error(
+        `A rich_text_section immediately before ${next.type} must end its final text content with a newline.`,
+      );
+    }
+  }
+}
+
+function isRichTextContainer(type: unknown): boolean {
+  return (
+    type === "rich_text" ||
+    type === "rich_text_section" ||
+    type === "rich_text_list" ||
+    type === "rich_text_quote" ||
+    type === "rich_text_preformatted"
+  );
+}
+
+function isRichTextAdjacentContainer(type: unknown): boolean {
+  return (
+    type === "rich_text_list" || type === "rich_text_quote" || type === "rich_text_preformatted"
+  );
+}
+
+function sectionEndsWithNewline(section: Record<string, unknown>): boolean {
+  const elements = asArray(section.elements);
+  for (let index = elements.length - 1; index >= 0; index--) {
+    const element = elements[index];
+    if (isRecord(element) && typeof element.text === "string") {
+      return element.text.endsWith("\n");
+    }
+  }
+  return false;
 }
 
 /**

--- a/src/slack/native-scheduled-messages.ts
+++ b/src/slack/native-scheduled-messages.ts
@@ -27,13 +27,22 @@ export async function scheduleNativeMessage(
     broadcast: input.replyBroadcast,
     dateScheduled: input.postAt,
   });
-  if (!draft) {
-    throw new Error("Slack did not return the native scheduled draft it created.");
+  const destination = draft?.destinations[0];
+  if (
+    !draft ||
+    draft.date_scheduled !== input.postAt ||
+    draft.destinations.length !== 1 ||
+    !destination ||
+    destination.channel_id !== input.channelId ||
+    destination.thread_ts !== input.threadTs ||
+    Boolean(destination.broadcast) !== Boolean(input.threadTs && input.replyBroadcast)
+  ) {
+    throw new Error("Slack did not confirm a matching native scheduled draft.");
   }
   return {
-    channel: draft.destinations[0]?.channel_id ?? input.channelId,
+    channel: destination.channel_id,
     scheduled_message_id: draft.id,
-    post_at: draft.date_scheduled ?? input.postAt,
+    post_at: draft.date_scheduled,
   };
 }
 

--- a/src/slack/native-scheduled-messages.ts
+++ b/src/slack/native-scheduled-messages.ts
@@ -1,0 +1,128 @@
+import type { SlackApiClient } from "./client.ts";
+import { getNumber } from "../lib/object-type-guards.ts";
+import { createDraft, deleteDraft, findDraft, listDrafts, type SlackDraft } from "./drafts.ts";
+
+export async function scheduleNativeMessage(
+  client: SlackApiClient,
+  input: {
+    channelId: string;
+    text: string;
+    postAt: number;
+    threadTs?: string;
+    replyBroadcast?: boolean;
+    blocks?: unknown[] | null;
+    unfurl?: boolean;
+  },
+): Promise<Record<string, unknown>> {
+  if (input.unfurl === false) {
+    throw new Error(
+      "--no-unfurl is not supported with browser-auth scheduled messages because Slack-native scheduled drafts do not preserve that option.",
+    );
+  }
+  const draft = await createDraft(client, {
+    channelId: input.channelId,
+    text: input.text,
+    ...(input.blocks ? { blocks: input.blocks } : {}),
+    threadTs: input.threadTs,
+    broadcast: input.replyBroadcast,
+    dateScheduled: input.postAt,
+  });
+  if (!draft) {
+    throw new Error("Slack did not return the native scheduled draft it created.");
+  }
+  return {
+    channel: draft.destinations[0]?.channel_id ?? input.channelId,
+    scheduled_message_id: draft.id,
+    post_at: draft.date_scheduled ?? input.postAt,
+  };
+}
+
+export async function listNativeScheduledMessages(
+  client: SlackApiClient,
+  options: {
+    channelId?: string;
+    cursor?: string;
+    oldest?: string;
+    latest?: string;
+    limit?: number;
+  },
+): Promise<{
+  ok: true;
+  scheduled_messages: Record<string, unknown>[];
+  has_more?: boolean;
+}> {
+  if (options.cursor?.trim()) {
+    throw new Error("--cursor is not supported for Slack-native scheduled drafts.");
+  }
+  const oldest = parseOptionalScheduleBound(options.oldest, "--oldest");
+  const latest = parseOptionalScheduleBound(options.latest, "--latest");
+  const { drafts, has_more: hasMore } = await listDrafts(client, { limit: 100 });
+  const matching = drafts
+    .flatMap((draft) => nativeScheduledMessage(draft, options.channelId))
+    .filter((message) => {
+      const postAt = getNumber(message.post_at)!;
+      return (
+        (oldest === undefined || postAt >= oldest) && (latest === undefined || postAt <= latest)
+      );
+    });
+  const scheduledMessages =
+    options.limit === undefined ? matching : matching.slice(0, options.limit);
+  return {
+    ok: true,
+    scheduled_messages: scheduledMessages,
+    ...(hasMore ? { has_more: true } : {}),
+  };
+}
+
+export async function cancelNativeScheduledMessage(
+  client: SlackApiClient,
+  input: { channelId: string; scheduledMessageId: string },
+): Promise<void> {
+  const draft = await findDraft(client, input.scheduledMessageId);
+  if (!draft.date_scheduled) {
+    throw new Error(`Draft ${input.scheduledMessageId} is not a pending scheduled message.`);
+  }
+  if (!draft.destinations.some((destination) => destination.channel_id === input.channelId)) {
+    throw new Error(
+      `Scheduled draft ${input.scheduledMessageId} does not target channel ${input.channelId}.`,
+    );
+  }
+  await deleteDraft(client, {
+    draftId: draft.id,
+    clientLastUpdatedTs: draft.last_updated_ts,
+  });
+}
+
+function nativeScheduledMessage(draft: SlackDraft, channelId?: string): Record<string, unknown>[] {
+  const postAt = draft.date_scheduled;
+  if (!postAt || !Number.isSafeInteger(postAt)) {
+    return [];
+  }
+  const destination = channelId
+    ? draft.destinations.find((candidate) => candidate.channel_id === channelId)
+    : draft.destinations[0];
+  if (!destination) {
+    return [];
+  }
+  return [
+    {
+      id: draft.id,
+      channel_id: destination.channel_id,
+      post_at: postAt,
+      ...(draft.text !== undefined ? { text: draft.text } : {}),
+      ...(destination.thread_ts ? { thread_ts: destination.thread_ts } : {}),
+      ...(destination.broadcast ? { reply_broadcast: true } : {}),
+    },
+  ];
+}
+
+function parseOptionalScheduleBound(raw: string | undefined, flag: string): number | undefined {
+  if (raw === undefined) {
+    return undefined;
+  }
+  const value = Number(raw);
+  if (!Number.isFinite(value) || value < 0) {
+    throw new Error(`Invalid ${flag} value ${JSON.stringify(raw)}: must be a Unix timestamp`);
+  }
+  return value;
+}

--- a/src/slack/scheduled-messages.ts
+++ b/src/slack/scheduled-messages.ts
@@ -1,5 +1,10 @@
-import type { SlackApiClient } from "./client.ts";
+import type { SlackApiClient, SlackAuth } from "./client.ts";
 import { asArray, getNumber, getString, isRecord } from "../lib/object-type-guards.ts";
+import {
+  cancelNativeScheduledMessage,
+  listNativeScheduledMessages,
+  scheduleNativeMessage,
+} from "./native-scheduled-messages.ts";
 
 const MAX_SCHEDULE_SECONDS = 120 * 24 * 60 * 60;
 const DEFAULT_NAMED_TIME = { hour: 9, minute: 0 };
@@ -10,6 +15,45 @@ type Clock = {
 
 export type ScheduledMessage = Record<string, unknown>;
 
+type SlackAuthType = SlackAuth["auth_type"];
+
+export async function scheduleMessage(
+  client: SlackApiClient,
+  input: {
+    authType: SlackAuthType;
+    channelId: string;
+    text: string;
+    draftText?: string;
+    postAt: number;
+    threadTs?: string;
+    replyBroadcast?: boolean;
+    blocks?: unknown[] | null;
+    unfurl?: boolean;
+  },
+): Promise<Record<string, unknown>> {
+  if (input.authType === "browser") {
+    return await scheduleNativeMessage(client, {
+      channelId: input.channelId,
+      text: input.draftText ?? input.text,
+      postAt: input.postAt,
+      threadTs: input.threadTs,
+      replyBroadcast: input.replyBroadcast,
+      blocks: input.blocks,
+      unfurl: input.unfurl,
+    });
+  }
+
+  return await client.api("chat.scheduleMessage", {
+    channel: input.channelId,
+    text: input.text,
+    post_at: input.postAt,
+    thread_ts: input.threadTs,
+    ...(input.blocks ? { blocks: input.blocks } : {}),
+    ...(input.replyBroadcast && input.threadTs ? { reply_broadcast: true } : {}),
+    ...(input.unfurl === false ? { unfurl_links: false, unfurl_media: false } : {}),
+  });
+}
+
 export async function listScheduledMessages(
   client: SlackApiClient,
   options?: {
@@ -18,12 +62,18 @@ export async function listScheduledMessages(
     oldest?: string;
     latest?: string;
     limit?: number;
+    authType?: SlackAuthType;
   },
 ): Promise<{
   ok: true;
   scheduled_messages: ScheduledMessage[];
   next_cursor?: string;
+  has_more?: boolean;
 }> {
+  if (options?.authType === "browser") {
+    return await listNativeScheduledMessages(client, options);
+  }
+
   const resp = await client.api("chat.scheduledMessages.list", {
     channel: options?.channelId,
     cursor: options?.cursor,
@@ -42,8 +92,12 @@ export async function listScheduledMessages(
 
 export async function cancelScheduledMessage(
   client: SlackApiClient,
-  input: { channelId: string; scheduledMessageId: string },
+  input: { channelId: string; scheduledMessageId: string; authType?: SlackAuthType },
 ): Promise<void> {
+  if (input.authType === "browser") {
+    return await cancelNativeScheduledMessage(client, input);
+  }
+
   await client.api("chat.deleteScheduledMessage", {
     channel: input.channelId,
     scheduled_message_id: input.scheduledMessageId,

--- a/test/draft-block-validation.test.ts
+++ b/test/draft-block-validation.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from "bun:test";
+import { createDraft } from "../src/slack/drafts.ts";
+import type { SlackApiClient } from "../src/slack/client.ts";
+
+function createClient() {
+  const calls: { method: string; params: Record<string, unknown> }[] = [];
+  const client = {
+    api: async (method: string, params: Record<string, unknown> = {}) => {
+      calls.push({ method, params });
+      return { ok: true };
+    },
+  } as unknown as SlackApiClient;
+  return { client, calls };
+}
+
+describe("native draft block validation", () => {
+  test.each(["rich_text_list", "rich_text_quote", "rich_text_preformatted"])(
+    "requires a section newline before %s",
+    async (type) => {
+      const { client, calls } = createClient();
+
+      await expect(
+        createDraft(client, {
+          channelId: "C123",
+          text: "fallback",
+          blocks: [
+            {
+              type: "rich_text",
+              elements: [
+                {
+                  type: "rich_text_section",
+                  elements: [{ type: "text", text: "Introduction" }],
+                },
+                {
+                  type,
+                  elements:
+                    type === "rich_text_list"
+                      ? [
+                          {
+                            type: "rich_text_section",
+                            elements: [{ type: "text", text: "Item" }],
+                          },
+                        ]
+                      : [{ type: "text", text: "Item" }],
+                },
+              ],
+            },
+          ],
+        }),
+      ).rejects.toThrow(`immediately before ${type}`);
+      expect(calls).toHaveLength(0);
+    },
+  );
+
+  test("accepts a newline-terminated section before a list", async () => {
+    const { client, calls } = createClient();
+
+    await createDraft(client, {
+      channelId: "C123",
+      text: "fallback",
+      blocks: [
+        {
+          type: "rich_text",
+          elements: [
+            {
+              type: "rich_text_section",
+              elements: [{ type: "text", text: "Introduction\n" }],
+            },
+            {
+              type: "rich_text_list",
+              style: "bullet",
+              elements: [
+                {
+                  type: "rich_text_section",
+                  elements: [{ type: "text", text: "Item" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(calls).toHaveLength(1);
+  });
+
+  test("preserves other section adjacency without requiring a newline", async () => {
+    const { client, calls } = createClient();
+
+    await createDraft(client, {
+      channelId: "C123",
+      text: "fallback",
+      blocks: [
+        {
+          type: "rich_text",
+          elements: [
+            {
+              type: "rich_text_section",
+              elements: [{ type: "text", text: "First" }],
+            },
+            {
+              type: "rich_text_section",
+              elements: [{ type: "text", text: "Second" }],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(calls).toHaveLength(1);
+  });
+
+  test("accepts valid non-text rich-text content that Markdown rendering omits", async () => {
+    const { client, calls } = createClient();
+
+    await createDraft(client, {
+      channelId: "C123",
+      text: "fallback",
+      blocks: [
+        {
+          type: "rich_text",
+          elements: [
+            {
+              type: "rich_text_section",
+              elements: [{ type: "date", timestamp: 1770168709, format: "{date_long}" }],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(calls).toHaveLength(1);
+  });
+});

--- a/test/drafts.test.ts
+++ b/test/drafts.test.ts
@@ -95,7 +95,7 @@ describe("parseDraftRecord", () => {
 describe("listDrafts", () => {
   test("requests active drafts and parses the result", async () => {
     const { client, calls } = createClient({
-      "drafts.list": { ok: true, drafts: [rawDraft, { not: "a draft" }] },
+      "drafts.list": { ok: true, drafts: [rawDraft, { not: "a draft" }], has_more: true },
     });
 
     const result = await listDrafts(client, { limit: 10 });
@@ -105,6 +105,7 @@ describe("listDrafts", () => {
     expect(calls[0]?.params).toEqual({ is_active: true, limit: 10 });
     expect(result.drafts).toHaveLength(1);
     expect(result.drafts[0]?.id).toBe("Dr123");
+    expect(result.has_more).toBe(true);
   });
 
   test("omits is_active when activeOnly is false", async () => {
@@ -167,6 +168,46 @@ describe("createDraft", () => {
     });
 
     expect(calls[0]?.params.file_ids).toEqual(["F9"]);
+  });
+
+  test("creates a scheduled draft with caller-supplied rich_text blocks", async () => {
+    const { client, calls } = createClient({
+      "drafts.create": { ok: true, draft: { ...rawDraft, date_scheduled: 1770168709 } },
+    });
+    const blocks = [
+      {
+        type: "rich_text",
+        elements: [{ type: "rich_text_section", elements: [{ type: "text", text: "scheduled" }] }],
+      },
+    ];
+
+    const draft = await createDraft(client, {
+      channelId: "C123",
+      text: "fallback",
+      blocks,
+      dateScheduled: 1770168709,
+    });
+
+    expect(calls[0]?.params.blocks).toEqual(blocks);
+    expect(calls[0]?.params.date_scheduled).toBe(1770168709);
+    expect(draft?.date_scheduled).toBe(1770168709);
+  });
+
+  test("rejects draft blocks Slack Desktop would strip or tombstone", async () => {
+    const { client, calls } = createClient({ "drafts.create": { ok: true } });
+
+    await expect(
+      createDraft(client, {
+        channelId: "C123",
+        text: "fallback",
+        blocks: [{ type: "section", text: { type: "mrkdwn", text: "unsafe" } }],
+      }),
+    ).rejects.toThrow(/non-empty rich_text blocks/);
+    await expect(createDraft(client, { channelId: "C123", text: "   " })).rejects.toThrow(
+      /non-empty rich_text blocks/,
+    );
+
+    expect(calls).toHaveLength(0);
   });
 });
 

--- a/test/help-contracts.test.ts
+++ b/test/help-contracts.test.ts
@@ -44,6 +44,7 @@ describe("agent-facing help contracts", () => {
 
     expect(optionDescription(send, "--attach")).toContain("without automatic list conversion");
     expect(optionDescription(send, "--schedule")).toContain("within 120 days");
+    expect(optionDescription(send, "--schedule")).toContain("Browser auth");
     expect(optionDescription(send, "--schedule-in")).toContain("local timezone");
     expect(optionDescription(send, "--thread-ts")).toContain("channel targets");
     expect(optionDescription(send, "--reply-broadcast")).toContain("DM targets");
@@ -68,8 +69,11 @@ describe("agent-facing help contracts", () => {
   });
 
   test("scheduled cancellation identifies its required channel", () => {
+    const list = findCommand(buildProgram(), "message", "scheduled", "list");
     const cancel = findCommand(buildProgram(), "message", "scheduled", "cancel");
 
+    expect(optionDescription(list, "--cursor")).toContain("standard-token");
+    expect(cancel.registeredArguments[0]?.description).toContain("Dr...");
     expect(optionDescription(cancel, "--channel")).toContain("Required");
   });
 

--- a/test/message-draft-actions.test.ts
+++ b/test/message-draft-actions.test.ts
@@ -23,6 +23,7 @@ function createContext(
   calls: Call[],
   fixtures: {
     draftsList?: Record<string, unknown>[];
+    draftsHasMore?: boolean;
     channelInfo?: Record<string, Record<string, unknown>>;
     /** First call to this method returns ok:false invalid_auth (for retry tests). */
     failOnce?: "drafts.create" | "drafts.update";
@@ -38,7 +39,11 @@ function createContext(
       calls.push({ method, params });
       switch (method) {
         case "drafts.list":
-          return { ok: true, drafts: fixtures.draftsList ?? [] };
+          return {
+            ok: true,
+            drafts: fixtures.draftsList ?? [],
+            has_more: fixtures.draftsHasMore === true,
+          };
         case "drafts.create":
         case "drafts.update": {
           // Simulate a transient auth failure on the first call to this method,
@@ -652,17 +657,25 @@ describe("listDraftsAction", () => {
           last_updated_ts: "1700000000.1",
         },
       ],
+      draftsHasMore: true,
       channelInfo: { C11111111: { id: "C11111111", name: "general" } },
     });
 
     const result = (await listDraftsAction({
       ctx,
       options: { workspace: "https://workspace.slack.com" },
-    })) as { ok: boolean; count: number; drafts: { destinations: { channel_name?: string }[] }[] };
+    })) as {
+      ok: boolean;
+      count: number;
+      drafts: { destinations: { channel_name?: string }[] }[];
+      has_more?: boolean;
+    };
 
     expect(result.ok).toBe(true);
     expect(result.count).toBe(1);
+    expect(result.has_more).toBe(true);
     expect(result.drafts[0]?.destinations[0]?.channel_name).toBe("general");
+    expect(calls.find((call) => call.method === "drafts.list")?.params.limit).toBe(100);
   });
 });
 

--- a/test/message-send.test.ts
+++ b/test/message-send.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { CliContext } from "../src/cli/context.ts";
+import type { SlackAuth } from "../src/slack/client.ts";
 import { composeMessage } from "../src/cli/compose-actions.ts";
 import { editMessage, sendMessage } from "../src/cli/message-actions.ts";
 import {
@@ -18,8 +19,13 @@ import { withEnvironment } from "./helpers/environment.ts";
 
 function createContext(
   calls: { method: string; params: Record<string, unknown> }[],
-  fixtures: { historyMessages?: Record<string, unknown>[] } = {},
+  fixtures: {
+    historyMessages?: Record<string, unknown>[];
+    auth?: SlackAuth;
+    draftsHasMore?: boolean;
+  } = {},
 ) {
+  const auth = fixtures.auth ?? ({ auth_type: "standard", token: "x" } as const);
   const client = {
     api: async (method: string, params: Record<string, unknown>) => {
       calls.push({ method, params });
@@ -54,6 +60,57 @@ function createContext(
       if (method === "chat.deleteScheduledMessage") {
         return { ok: true };
       }
+      if (method === "auth.test") {
+        return {
+          ok: true,
+          url: "https://workspace.slack.com/",
+          team_id: "T12345678",
+          user_id: "U12345678",
+        };
+      }
+      if (method === "team.info") {
+        return { ok: true, team: { id: "T12345678" } };
+      }
+      if (method === "drafts.create") {
+        return {
+          ok: true,
+          draft: {
+            id: "Dr1234ABCD",
+            destinations: params.destinations,
+            blocks: params.blocks,
+            last_updated_ts: "1770165109.123456",
+            date_scheduled: params.date_scheduled,
+          },
+        };
+      }
+      if (method === "drafts.list") {
+        return {
+          ok: true,
+          drafts: [
+            {
+              id: "Dr1234ABCD",
+              destinations: [{ channel_id: "C12345678" }],
+              blocks: [
+                {
+                  type: "rich_text",
+                  elements: [
+                    {
+                      type: "rich_text_section",
+                      elements: [{ type: "text", text: "scheduled" }],
+                    },
+                  ],
+                },
+              ],
+              last_updated_ts: "1770165109.123456",
+              date_scheduled: 1770168709,
+            },
+          ],
+          has_more: fixtures.draftsHasMore === true,
+        };
+      }
+      if (method === "drafts.delete") {
+        return { ok: true };
+      }
       if (method === "search.messages") {
         return {
           ok: true,
@@ -79,7 +136,7 @@ function createContext(
     }) => input.work(),
     getClientForWorkspace: async () => ({
       client: client as never,
-      auth: { auth_type: "standard", token: "x" as const },
+      auth,
       workspace_url: "https://workspace.slack.com",
     }),
     normalizeUrl: (u: string) => u,
@@ -725,6 +782,83 @@ describe("sendMessage", () => {
     });
   });
 
+  test("browser auth schedules through a Slack-native draft", async () => {
+    const calls: { method: string; params: Record<string, unknown> }[] = [];
+    const ctx = createContext(calls, {
+      auth: { auth_type: "browser", xoxc_token: "xoxc-test", xoxd_cookie: "xoxd-test" },
+    });
+    const when = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    const postAt = Math.floor(Date.parse(when) / 1000);
+
+    const result = await sendMessage({
+      ctx,
+      targetInput: "C12345678",
+      text: "later",
+      options: { schedule: when },
+    });
+
+    const create = calls.find((call) => call.method === "drafts.create");
+    expect(create?.params).toMatchObject({
+      destinations: [{ channel_id: "C12345678" }],
+      date_scheduled: postAt,
+      is_from_composer: true,
+    });
+    expect(calls.some((call) => call.method === "chat.scheduleMessage")).toBe(false);
+    expect(result).toEqual({
+      ok: true,
+      channel_id: "C12345678",
+      scheduled_message_id: "Dr1234ABCD",
+      post_at: postAt,
+      thread_ts: undefined,
+    });
+  });
+
+  test("browser auth refuses Block Kit that Slack Desktop would strip", async () => {
+    const calls: { method: string; params: Record<string, unknown> }[] = [];
+    const ctx = createContext(calls, {
+      auth: { auth_type: "browser", xoxc_token: "xoxc-test", xoxd_cookie: "xoxd-test" },
+    });
+    const dir = await mkdtemp(join(tmpdir(), "agent-slack-send-test-"));
+    const blocksPath = join(dir, "blocks.json");
+    await writeFile(
+      blocksPath,
+      JSON.stringify([{ type: "section", text: { type: "mrkdwn", text: "unsafe" } }]),
+    );
+
+    try {
+      await expect(
+        sendMessage({
+          ctx,
+          targetInput: "C12345678",
+          text: "fallback",
+          options: { blocks: blocksPath, scheduleIn: "30m" },
+        }),
+      ).rejects.toThrow(/non-empty rich_text blocks/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+
+    expect(calls.some((call) => call.method === "drafts.create")).toBe(false);
+  });
+
+  test("browser auth refuses --no-unfurl because native scheduled drafts cannot preserve it", async () => {
+    const calls: { method: string; params: Record<string, unknown> }[] = [];
+    const ctx = createContext(calls, {
+      auth: { auth_type: "browser", xoxc_token: "xoxc-test", xoxd_cookie: "xoxd-test" },
+    });
+
+    await expect(
+      sendMessage({
+        ctx,
+        targetInput: "C12345678",
+        text: "https://example.com",
+        options: { scheduleIn: "30m", unfurl: false },
+      }),
+    ).rejects.toThrow(/--no-unfurl is not supported with browser-auth scheduled messages/);
+
+    expect(calls.some((call) => call.method === "drafts.create")).toBe(false);
+  });
+
   test("--schedule cannot be combined with file attachments", async () => {
     const calls: { method: string; params: Record<string, unknown> }[] = [];
     const ctx = createContext(calls);
@@ -877,6 +1011,61 @@ describe("scheduled message management", () => {
       ok: true,
       channel_id: "C12345678",
       scheduled_message_id: "Q1234ABCD",
+    });
+  });
+
+  test("browser auth lists native scheduled drafts and reports a truncated response", async () => {
+    const calls: { method: string; params: Record<string, unknown> }[] = [];
+    const ctx = createContext(calls, {
+      auth: { auth_type: "browser", xoxc_token: "xoxc-test", xoxd_cookie: "xoxd-test" },
+      draftsHasMore: true,
+    });
+
+    const result = await listScheduledMessages({
+      ctx,
+      options: { channel: "C12345678", limit: "25" },
+    });
+
+    const list = calls.find((call) => call.method === "drafts.list");
+    expect(list?.params).toEqual({ is_active: true, limit: 100 });
+    expect(result).toEqual({
+      ok: true,
+      scheduled_messages: [
+        {
+          id: "Dr1234ABCD",
+          channel_id: "C12345678",
+          post_at: 1770168709,
+          text: "scheduled",
+        },
+      ],
+      has_more: true,
+    });
+  });
+
+  test("browser auth cancels a native scheduled draft", async () => {
+    const calls: { method: string; params: Record<string, unknown> }[] = [];
+    const ctx = createContext(calls, {
+      auth: { auth_type: "browser", xoxc_token: "xoxc-test", xoxd_cookie: "xoxd-test" },
+    });
+
+    const result = await cancelScheduledMessage({
+      ctx,
+      scheduledMessageId: "Dr1234ABCD",
+      options: { channel: "C12345678" },
+    });
+
+    const list = calls.find((call) => call.method === "drafts.list");
+    const deletion = calls.find((call) => call.method === "drafts.delete");
+    expect(list?.params).toEqual({ is_active: undefined, limit: 100 });
+    expect(deletion?.params).toEqual({
+      draft_id: "Dr1234ABCD",
+      client_last_updated_ts: "1770165109.1234560",
+    });
+    expect(calls.some((call) => call.method === "chat.deleteScheduledMessage")).toBe(false);
+    expect(result).toEqual({
+      ok: true,
+      channel_id: "C12345678",
+      scheduled_message_id: "Dr1234ABCD",
     });
   });
 });

--- a/test/native-scheduled-messages.test.ts
+++ b/test/native-scheduled-messages.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+import { scheduleNativeMessage } from "../src/slack/native-scheduled-messages.ts";
+import type { SlackApiClient } from "../src/slack/client.ts";
+
+const postAt = 1770168709;
+
+function clientReturning(draft: Record<string, unknown>): SlackApiClient {
+  return {
+    api: async () => ({ ok: true, draft }),
+  } as unknown as SlackApiClient;
+}
+
+describe("scheduleNativeMessage", () => {
+  test("returns only metadata confirmed by the matching scheduled draft", async () => {
+    const result = await scheduleNativeMessage(
+      clientReturning({
+        id: "Dr1234ABCD",
+        destinations: [
+          { channel_id: "C12345678", thread_ts: "1770160000.000001", broadcast: true },
+        ],
+        blocks: [
+          {
+            type: "rich_text",
+            elements: [
+              { type: "rich_text_section", elements: [{ type: "text", text: "scheduled" }] },
+            ],
+          },
+        ],
+        date_scheduled: postAt,
+      }),
+      {
+        channelId: "C12345678",
+        text: "scheduled",
+        postAt,
+        threadTs: "1770160000.000001",
+        replyBroadcast: true,
+      },
+    );
+
+    expect(result).toEqual({
+      channel: "C12345678",
+      scheduled_message_id: "Dr1234ABCD",
+      post_at: postAt,
+    });
+  });
+
+  test.each([
+    {
+      caseName: "missing schedule time",
+      dateScheduled: undefined,
+      destinations: [{ channel_id: "C12345678" }],
+    },
+    {
+      caseName: "different schedule time",
+      dateScheduled: postAt + 1,
+      destinations: [{ channel_id: "C12345678" }],
+    },
+    {
+      caseName: "different destination",
+      dateScheduled: postAt,
+      destinations: [{ channel_id: "C99999999" }],
+    },
+    {
+      caseName: "an additional destination",
+      dateScheduled: postAt,
+      destinations: [{ channel_id: "C12345678" }, { channel_id: "C99999999" }],
+    },
+  ])("rejects a drafts.create response with $caseName", async ({ dateScheduled, destinations }) => {
+    await expect(
+      scheduleNativeMessage(
+        clientReturning({
+          id: "Dr1234ABCD",
+          destinations,
+          blocks: [
+            {
+              type: "rich_text",
+              elements: [
+                { type: "rich_text_section", elements: [{ type: "text", text: "scheduled" }] },
+              ],
+            },
+          ],
+          date_scheduled: dateScheduled,
+        }),
+        { channelId: "C12345678", text: "scheduled", postAt },
+      ),
+    ).rejects.toThrow("did not confirm a matching native scheduled draft");
+  });
+});

--- a/test/slack-native-draft-endpoint.test.ts
+++ b/test/slack-native-draft-endpoint.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, test } from "bun:test";
+import type { CliContext } from "../src/cli/context.ts";
+import { resolveSlackNativeDraftEndpoint } from "../src/cli/slack-native-draft-endpoint.ts";
+import type { SlackApiClient, SlackAuth } from "../src/slack/client.ts";
+
+const workspaceUrl = "https://workspace.slack.com";
+const enterpriseUrl = "https://grid.enterprise.slack.com";
+const browserAuth: SlackAuth = {
+  auth_type: "browser",
+  xoxc_token: "xoxc-test",
+  xoxd_cookie: "xoxd-test",
+};
+
+function createGridFixture(input?: {
+  enterpriseUserId?: string;
+  enterpriseTeamId?: string;
+  identityUrl?: string;
+}) {
+  const calls: { client: "workspace" | "enterprise"; method: string }[] = [];
+  const api =
+    (client: "workspace" | "enterprise") =>
+    async (method: string): Promise<Record<string, unknown>> => {
+      calls.push({ client, method });
+      if (method === "auth.test") {
+        return client === "workspace"
+          ? {
+              ok: true,
+              url: input?.identityUrl ?? `${workspaceUrl}/`,
+              team_id: "T12345678",
+              user_id: "U12345678",
+            }
+          : {
+              ok: true,
+              team_id: input?.enterpriseTeamId ?? "E12345678",
+              user_id: input?.enterpriseUserId ?? "U12345678",
+            };
+      }
+      if (method === "team.info") {
+        return {
+          ok: true,
+          team: {
+            id: "T12345678",
+            enterprise_id: "E12345678",
+            enterprise_domain: "grid",
+          },
+        };
+      }
+      throw new Error(`Unexpected method: ${method}`);
+    };
+  const workspaceClient = { api: api("workspace") } as SlackApiClient;
+  const enterpriseClient = { api: api("enterprise") } as SlackApiClient;
+  const ctx = {
+    getClientForWorkspace: async (selector?: string) => {
+      expect(selector).toBe(enterpriseUrl);
+      return { client: enterpriseClient, auth: browserAuth, workspace_url: enterpriseUrl };
+    },
+  } as CliContext;
+  return { calls, ctx, workspaceClient, enterpriseClient };
+}
+
+describe("resolveSlackNativeDraftEndpoint", () => {
+  test("routes a child workspace through its verified Enterprise Grid organization", async () => {
+    const fixture = createGridFixture();
+
+    const endpoint = await resolveSlackNativeDraftEndpoint({
+      ctx: fixture.ctx,
+      client: fixture.workspaceClient,
+      auth: browserAuth,
+      workspaceUrl,
+    });
+
+    expect(endpoint.client).toBe(fixture.enterpriseClient);
+    expect(endpoint.workspaceUrl).toBe(enterpriseUrl);
+    expect(fixture.calls).toEqual([
+      { client: "workspace", method: "auth.test" },
+      { client: "workspace", method: "team.info" },
+      { client: "enterprise", method: "auth.test" },
+    ]);
+  });
+
+  test("rejects organization credentials for a different enterprise or user", async () => {
+    const wrongEnterprise = createGridFixture({ enterpriseTeamId: "E99999999" });
+    await expect(
+      resolveSlackNativeDraftEndpoint({
+        ctx: wrongEnterprise.ctx,
+        client: wrongEnterprise.workspaceClient,
+        auth: browserAuth,
+        workspaceUrl,
+      }),
+    ).rejects.toThrow("do not match the target workspace's organization");
+
+    const wrongUser = createGridFixture({ enterpriseUserId: "U99999999" });
+    await expect(
+      resolveSlackNativeDraftEndpoint({
+        ctx: wrongUser.ctx,
+        client: wrongUser.workspaceClient,
+        auth: browserAuth,
+        workspaceUrl,
+      }),
+    ).rejects.toThrow("do not belong to the same Slack user");
+  });
+
+  test("rejects credentials authenticated to a different workspace", async () => {
+    const fixture = createGridFixture({ identityUrl: "https://other.slack.com/" });
+
+    await expect(
+      resolveSlackNativeDraftEndpoint({
+        ctx: fixture.ctx,
+        client: fixture.workspaceClient,
+        auth: browserAuth,
+        workspaceUrl,
+      }),
+    ).rejects.toThrow("workspace origin does not match");
+    expect(fixture.calls).toEqual([{ client: "workspace", method: "auth.test" }]);
+  });
+
+  test("keeps standard auth and organization URLs on their selected endpoint", async () => {
+    const fixture = createGridFixture();
+    const standardAuth = { auth_type: "standard" as const, token: "xoxb-test" };
+
+    const standard = await resolveSlackNativeDraftEndpoint({
+      ctx: fixture.ctx,
+      client: fixture.workspaceClient,
+      auth: standardAuth,
+      workspaceUrl,
+    });
+    const organization = await resolveSlackNativeDraftEndpoint({
+      ctx: fixture.ctx,
+      client: fixture.enterpriseClient,
+      auth: browserAuth,
+      workspaceUrl: enterpriseUrl,
+    });
+
+    expect(standard.client).toBe(fixture.workspaceClient);
+    expect(organization.client).toBe(fixture.enterpriseClient);
+    expect(fixture.calls).toHaveLength(0);
+  });
+});

--- a/test/slack-native-draft-endpoint.test.ts
+++ b/test/slack-native-draft-endpoint.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { CliContext } from "../src/cli/context.ts";
 import { resolveSlackNativeDraftEndpoint } from "../src/cli/slack-native-draft-endpoint.ts";
 import type { SlackApiClient, SlackAuth } from "../src/slack/client.ts";
@@ -10,11 +13,17 @@ const browserAuth: SlackAuth = {
   xoxc_token: "xoxc-test",
   xoxd_cookie: "xoxd-test",
 };
+const enterpriseBrowserAuth: SlackAuth = {
+  auth_type: "browser",
+  xoxc_token: "xoxc-enterprise-test",
+  xoxd_cookie: "xoxd-test",
+};
 
 function createGridFixture(input?: {
   enterpriseUserId?: string;
   enterpriseTeamId?: string;
   identityUrl?: string;
+  reuseWorkspaceAuth?: boolean;
 }) {
   const calls: { client: "workspace" | "enterprise"; method: string }[] = [];
   const api =
@@ -50,9 +59,14 @@ function createGridFixture(input?: {
   const workspaceClient = { api: api("workspace") } as SlackApiClient;
   const enterpriseClient = { api: api("enterprise") } as SlackApiClient;
   const ctx = {
-    getClientForWorkspace: async (selector?: string) => {
+    getClientForWorkspace: async (selector, options) => {
       expect(selector).toBe(enterpriseUrl);
-      return { client: enterpriseClient, auth: browserAuth, workspace_url: enterpriseUrl };
+      expect(options?.excludeAuth).toBe(browserAuth);
+      return {
+        client: enterpriseClient,
+        auth: input?.reuseWorkspaceAuth ? browserAuth : enterpriseBrowserAuth,
+        workspace_url: enterpriseUrl,
+      };
     },
   } as CliContext;
   return { calls, ctx, workspaceClient, enterpriseClient };
@@ -114,6 +128,23 @@ describe("resolveSlackNativeDraftEndpoint", () => {
     expect(fixture.calls).toEqual([{ client: "workspace", method: "auth.test" }]);
   });
 
+  test("rejects reuse of child workspace browser credentials as organization auth", async () => {
+    const fixture = createGridFixture({ reuseWorkspaceAuth: true });
+
+    await expect(
+      resolveSlackNativeDraftEndpoint({
+        ctx: fixture.ctx,
+        client: fixture.workspaceClient,
+        auth: browserAuth,
+        workspaceUrl,
+      }),
+    ).rejects.toThrow("require separate organization browser credentials");
+    expect(fixture.calls).toEqual([
+      { client: "workspace", method: "auth.test" },
+      { client: "workspace", method: "team.info" },
+    ]);
+  });
+
   test("keeps standard auth and organization URLs on their selected endpoint", async () => {
     const fixture = createGridFixture();
     const standardAuth = { auth_type: "standard" as const, token: "xoxb-test" };
@@ -136,3 +167,115 @@ describe("resolveSlackNativeDraftEndpoint", () => {
     expect(fixture.calls).toHaveLength(0);
   });
 });
+
+describe("environment-backed Enterprise Grid resolution", () => {
+  const resolverUrl = new URL("../src/cli/context-client-resolver.ts", import.meta.url).href;
+  const endpointUrl = new URL("../src/cli/slack-native-draft-endpoint.ts", import.meta.url).href;
+
+  test("the real resolver uses separately configured organization auth", async () => {
+    const home = await mkdtemp(join(tmpdir(), "agent-slack-grid-resolver-"));
+    try {
+      const configDir = join(home, ".config", "agent-slack");
+      await mkdir(configDir, { recursive: true });
+      await writeFile(
+        join(configDir, "credentials.json"),
+        JSON.stringify({
+          version: 1,
+          workspaces: [
+            {
+              workspace_url: enterpriseUrl,
+              auth: enterpriseBrowserAuth,
+            },
+          ],
+        }),
+      );
+      const environmentBinding = await runResolverScript({
+        home,
+        script: `
+          const { getClientForWorkspace } = await import(${JSON.stringify(resolverUrl)});
+          const endpoint = await getClientForWorkspace(${JSON.stringify(enterpriseUrl)});
+          console.log(JSON.stringify({ auth: endpoint.auth, workspaceUrl: endpoint.workspace_url }));
+        `,
+      });
+      const credentialExclusion = await runResolverScript({
+        home,
+        script: `
+          const { getClientForWorkspace } = await import(${JSON.stringify(resolverUrl)});
+          const childAuth = { auth_type: "browser", xoxc_token: "xoxc-child-test", xoxd_cookie: "xoxd-test" };
+          const endpoint = await getClientForWorkspace(${JSON.stringify(enterpriseUrl)}, { excludeAuth: childAuth });
+          console.log(JSON.stringify({ auth: endpoint.auth, workspaceUrl: endpoint.workspace_url }));
+        `,
+        omitEnvironmentWorkspaceUrl: true,
+      });
+
+      for (const result of [environmentBinding, credentialExclusion]) {
+        expect(result.exitCode).toBe(0);
+        expect(JSON.parse(result.stdout)).toEqual({
+          auth: enterpriseBrowserAuth,
+          workspaceUrl: enterpriseUrl,
+        });
+      }
+    } finally {
+      await rm(home, { recursive: true, force: true });
+    }
+  });
+
+  test("the real resolver fails explicitly when no separate organization auth exists", async () => {
+    const home = await mkdtemp(join(tmpdir(), "agent-slack-grid-resolver-"));
+    try {
+      const result = await runResolverScript({
+        home,
+        script: `
+          const { getClientForWorkspace } = await import(${JSON.stringify(resolverUrl)});
+          const { resolveSlackNativeDraftEndpoint } = await import(${JSON.stringify(endpointUrl)});
+          const childAuth = { auth_type: "browser", xoxc_token: "xoxc-child-test", xoxd_cookie: "xoxd-test" };
+          const workspaceClient = { api: async (method) => {
+            if (method === "auth.test") return { ok: true, url: ${JSON.stringify(`${workspaceUrl}/`)}, team_id: "T12345678", user_id: "U12345678" };
+            if (method === "team.info") return { ok: true, team: { id: "T12345678", enterprise_id: "E12345678", enterprise_domain: "grid" } };
+            throw new Error("Unexpected method: " + method);
+          } };
+          try {
+            await resolveSlackNativeDraftEndpoint({ ctx: { getClientForWorkspace }, client: workspaceClient, auth: childAuth, workspaceUrl: ${JSON.stringify(workspaceUrl)} });
+            throw new Error("resolver unexpectedly accepted child credentials");
+          } catch (error) {
+            console.log(error instanceof Error ? error.message : String(error));
+          }
+        `,
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain(
+        `Enterprise Grid native drafts require separate organization browser credentials for ${enterpriseUrl}`,
+      );
+    } finally {
+      await rm(home, { recursive: true, force: true });
+    }
+  });
+});
+
+async function runResolverScript(input: {
+  home: string;
+  script: string;
+  omitEnvironmentWorkspaceUrl?: boolean;
+}): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  const { XDG_CONFIG_HOME: _ignoredConfigHome, ...inheritedEnv } = process.env;
+  const env = {
+    ...inheritedEnv,
+    HOME: input.home,
+    SLACK_TOKEN: "xoxc-child-test",
+    SLACK_COOKIE_D: "xoxd-test",
+    ...(input.omitEnvironmentWorkspaceUrl ? {} : { SLACK_WORKSPACE_URL: workspaceUrl }),
+  };
+  const child = Bun.spawn([process.execPath, "--eval", input.script], {
+    cwd: process.cwd(),
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [exitCode, stdout, stderr] = await Promise.all([
+    child.exited,
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+  ]);
+  return { exitCode, stdout: stdout.trim(), stderr: stderr.trim() };
+}


### PR DESCRIPTION
## Summary

- keep standard tokens on the public `chat.scheduleMessage` API
- schedule browser sessions through Slack-native `drafts.create` with `date_scheduled`
- list and cancel native schedules through `drafts.list` and `drafts.delete`
- verify Enterprise Grid organization and user identity before routing native draft calls
- surface native-draft truncation and reject payloads Slack Desktop cannot preserve

## Context

agent-slack already has the two required pieces from #102 and #119, but browser-session tokens cannot use `chat.scheduleMessage`. This connects the auth-aware paths while preserving `Q...` IDs for standard tokens and returning `Dr...` IDs for browser auth.

The native-draft behavior follows prior art from:

- https://github.com/tammersaleh/slack-cli/blob/ab04c76de1bd4eb00509a9d3c156ec8906db7588/docs/draft-messages.md
- https://github.com/emacs-slack/emacs-slack/blob/a7c971ef6f92ec1b9dca164512cd276a95cdfaa5/slack-scheduled-messages-buffer.el

Browser traffic continues to use the shared Slack API client; #142 remains independent transport hardening.

Native scheduled drafts accept only non-empty top-level `rich_text` blocks, reject `--no-unfurl`, and report `has_more` when the non-pageable 100-draft response may be incomplete.

Validated with 410 tests, typecheck, format, lint, and the Node-targeted build.